### PR TITLE
feat: Missing component type for non-found entity

### DIFF
--- a/src/Dfe.PlanTech.Domain/Content/Models/MissingComponent.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/MissingComponent.cs
@@ -1,0 +1,5 @@
+namespace Dfe.PlanTech.Domain.Content.Models;
+
+public class MissingComponent : ContentComponent
+{
+}

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/ContentfulRepository.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/ContentfulRepository.cs
@@ -1,5 +1,7 @@
 using Contentful.Core;
+using Contentful.Core.Configuration;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.Persistence;
 
@@ -12,10 +14,10 @@ public class ContentfulRepository : IContentRepository
 {
     private readonly IContentfulClient _client;
 
-    public ContentfulRepository(IContentfulClient client)
+    public ContentfulRepository(ILoggerFactory loggerFactory, IContentfulClient client)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
-        _client.ContentTypeResolver = new EntityResolver();
+        _client.ContentTypeResolver = new EntityResolver(loggerFactory.CreateLogger<IContentTypeResolver>());
     }
 
     public async Task<IEnumerable<TEntity>> GetEntities<TEntity>(string entityTypeId, IEnumerable<IContentQuery>? queries = null, CancellationToken cancellationToken = default)

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/EntityResolver.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/EntityResolver.cs
@@ -1,13 +1,41 @@
 using Contentful.Core.Configuration;
 using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
+using Microsoft.Extensions.Logging;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful;
 
+/// <summary>
+/// For mapping fields/properties of type <see chref="IContentComponent"/> to their concrete type,
+/// when serialising the returned API response from Contentful
+/// </summary>
 public class EntityResolver : IContentTypeResolver
 {
+    private readonly ILogger<IContentTypeResolver> _logger;
+
     public Dictionary<string, Type> _types = typeof(IContentComponent).Assembly.GetTypes()
                                                                         .Where(type => type.IsAssignableTo(typeof(IContentComponent)))
                                                                         .ToDictionary(type => type.Name.ToLower());
 
-    public Type Resolve(string contentTypeId) => _types.TryGetValue(contentTypeId.ToLower(), out var type) ? type : throw new Exception($"Could not find type for {contentTypeId}");
+    public EntityResolver(ILogger<IContentTypeResolver> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns matching type for ID, or <see chref="MissingComponent"/> if none found.
+    /// </summary>
+    /// <param name="contentTypeId"></param>
+    /// <returns></returns>
+    public Type Resolve(string contentTypeId)
+    {
+        if (_types.TryGetValue(contentTypeId.ToLower(), out var type))
+        {
+            return type;
+        }
+
+        _logger.LogWarning("Could not find content type for ID {contentTypeId}", contentTypeId);
+
+        return typeof(MissingComponent);
+    }
 }

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/MissingComponent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/MissingComponent.cshtml
@@ -1,0 +1,1 @@
+<p>Class missing for content type</p>

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Persistence/ContentfulRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Persistence/ContentfulRepositoryTests.cs
@@ -1,9 +1,11 @@
 using Contentful.Core;
 using Contentful.Core.Models;
 using Contentful.Core.Search;
-using Moq;
-using Dfe.PlanTech.Infrastructure.Contentful.Persistence;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Infrastructure.Contentful.Persistence;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
 {
@@ -14,6 +16,8 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         private readonly List<TestClass> _mockData = new() {
             new TestClass(), new TestClass("testId"), new TestClass("anotherId"), new TestClass("abcd1234")
         };
+
+        private readonly ILoggerFactory _loggerFactory;
 
         public ContentfulRepositoryTests()
         {
@@ -27,9 +31,10 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
 
                 return collection;
             });
-            
+
             _clientMock.Setup(client => client.GetEntries<OtherTestClass>(It.IsAny<QueryBuilder<OtherTestClass>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((QueryBuilder<OtherTestClass> query, CancellationToken token) => {
+            .ReturnsAsync((QueryBuilder<OtherTestClass> query, CancellationToken token) =>
+            {
                 var collection = new ContentfulCollection<OtherTestClass>
                 {
                     Items = Enumerable.Empty<OtherTestClass>()
@@ -51,7 +56,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task Should_Call_Client_Method_When_Using_GetEntities()
         {
-            IContentRepository repository = new ContentfulRepository(_clientMock.Object);
+            IContentRepository repository = new ContentfulRepository(new NullLoggerFactory(), _clientMock.Object);
 
             var result = await repository.GetEntities<TestClass>();
 
@@ -61,29 +66,29 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task Should_CallClientMethod_When_Using_GetEntityById()
         {
-            IContentRepository repository = new ContentfulRepository(_clientMock.Object);
+            IContentRepository repository = new ContentfulRepository(new NullLoggerFactory(), _clientMock.Object);
 
             var result = await repository.GetEntityById<TestClass>("testId");
 
             Assert.NotNull(result);
         }
-        
+
         [Fact]
         public async Task GetEntities_Should_ReturnItems_When_ClassMatches()
         {
-            IContentRepository repository = new ContentfulRepository(_clientMock.Object);
+            IContentRepository repository = new ContentfulRepository(new NullLoggerFactory(), _clientMock.Object);
 
             var result = await repository.GetEntities<TestClass>();
 
             Assert.NotNull(result);
             Assert.Equal(result, _mockData);
         }
-        
-        
+
+
         [Fact]
         public async Task GetEntities_Should_ReturnEmptyIEnumerable_When_NoDataFound()
         {
-            IContentRepository repository = new ContentfulRepository(_clientMock.Object);
+            IContentRepository repository = new ContentfulRepository(new NullLoggerFactory(), _clientMock.Object);
 
             var result = await repository.GetEntities<OtherTestClass>();
 
@@ -95,26 +100,26 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         public async Task GetEntityById_Should_FindMatchingItem_When_IdMatches()
         {
             var testId = "testId";
-            IContentRepository repository = new ContentfulRepository(_clientMock.Object);
+            IContentRepository repository = new ContentfulRepository(new NullLoggerFactory(), _clientMock.Object);
 
             var result = await repository.GetEntityById<TestClass>(testId);
 
             Assert.NotNull(result);
             Assert.Equal(result.Id, testId);
         }
-        
+
         [Fact]
         public async Task GetEntityById_Should_ThrowException_When_IdIsNull()
         {
-            IContentRepository repository = new ContentfulRepository(_clientMock.Object);
+            IContentRepository repository = new ContentfulRepository(new NullLoggerFactory(), _clientMock.Object);
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => repository.GetEntityById<TestClass>(null));
         }
-        
+
         [Fact]
         public async Task GetEntityById_Should_ThrowException_When_IdIsEmpty()
         {
-            IContentRepository repository = new ContentfulRepository(_clientMock.Object);
+            IContentRepository repository = new ContentfulRepository(new NullLoggerFactory(), _clientMock.Object);
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => repository.GetEntityById<TestClass>(""));
         }
@@ -122,7 +127,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task Should_ReturnNull_When_IdNotFound()
         {
-            IContentRepository repository = new ContentfulRepository(_clientMock.Object);
+            IContentRepository repository = new ContentfulRepository(new NullLoggerFactory(), _clientMock.Object);
 
             var result = await repository.GetEntityById<TestClass>("not a real id");
 


### PR DESCRIPTION
**Feature**:

- When an entity is returned from the Contentful API, but is not found locally in code, do not throw an error but return a dummy component instead.
  - Logs warning message to logger as well, for debugging/tracking missing components.