### PR TITLE
minor: Make methods non-async

### DIFF
--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -37,7 +37,7 @@ public class QuestionsController : BaseController<QuestionsController>
     }
 
     [HttpPost("SubmitAnswer")]
-    public async Task<IActionResult> SubmitAnswer(SubmitAnswerDto submitAnswerDto)
+    public IActionResult SubmitAnswer(SubmitAnswerDto submitAnswerDto)
     {
         if (submitAnswerDto == null) throw new ArgumentNullException(nameof(submitAnswerDto));
 
@@ -47,7 +47,7 @@ public class QuestionsController : BaseController<QuestionsController>
     }
 
     [HttpGet("check-answers")]
-    public async Task<IActionResult> CheckYourAnswers()
+    public IActionResult CheckYourAnswers()
     {
         return View("CheckYourAnswers");
     }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -138,7 +138,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         }
 
         [Fact]
-        public async Task SubmitAnswer_Should_ThrowException_When_NullArgument()
+        public void SubmitAnswer_Should_ThrowException_When_NullArgument()
         {
             Assert.ThrowsAny<ArgumentNullException>(() => _controller.SubmitAnswer(null!));
         }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -140,18 +140,18 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         [Fact]
         public async Task SubmitAnswer_Should_ThrowException_When_NullArgument()
         {
-            await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _controller.SubmitAnswer(null!));
+            Assert.ThrowsAny<ArgumentNullException>(() => _controller.SubmitAnswer(null!));
         }
 
         [Fact]
-        public async Task SubmitAnswer_Should_RedirectToNextQuestion_When_NextQuestionId_Exists()
+        public void SubmitAnswer_Should_RedirectToNextQuestion_When_NextQuestionId_Exists()
         {
             var submitAnswerDto = new SubmitAnswerDto()
             {
                 NextQuestionId = "Question2"
             };
 
-            var result = await _controller.SubmitAnswer(submitAnswerDto);
+            var result = _controller.SubmitAnswer(submitAnswerDto);
 
             Assert.IsType<RedirectToActionResult>(result);
 
@@ -165,11 +165,11 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         }
 
         [Fact]
-        public async Task SubmitAnswer_Should_RedirectTo_CheckYourAnswers_When_NextQuestionId_IsNull()
+        public void SubmitAnswer_Should_RedirectTo_CheckYourAnswers_When_NextQuestionId_IsNull()
         {
             var submitAnswerDto = new SubmitAnswerDto();
 
-            var result = await _controller.SubmitAnswer(submitAnswerDto);
+            var result = _controller.SubmitAnswer(submitAnswerDto);
 
             Assert.IsType<RedirectToActionResult>(result);
 


### PR DESCRIPTION
- Makes certain actions non-async as modifier was not performing anything currently, but was throwing up warnings as a result.