### PR TITLE
feat: Add logging to Rich Text content renderers

### DIFF
--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextContentPartRenderer.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextContentPartRenderer.cs
@@ -19,13 +19,4 @@ public interface IRichTextContentPartRenderer
     /// <param name="stringBuilder"></param>
     /// <returns></returns>
     public StringBuilder AddHtml(IRichTextContent content, IRichTextContentPartRendererCollection rendererCollection, StringBuilder stringBuilder);
-
-    /// <summary>
-    /// Render child content
-    /// </summary>
-    /// <param name="content"></param>
-    /// <param name="renderers"></param>
-    /// <param name="stringBuilder"></param>
-    /// <returns></returns>
-    StringBuilder RenderChildren(IRichTextContent content, IRichTextContentPartRendererCollection renderers, StringBuilder stringBuilder);
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextContentPartRendererCollection.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextContentPartRendererCollection.cs
@@ -1,9 +1,12 @@
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
 public interface IRichTextContentPartRendererCollection
 {
+    public ILogger Logger { get; }
+    
     public IRichTextContentPartRenderer? GetRendererForContent(IRichTextContent content);
 
     /// <summary>
@@ -12,5 +15,4 @@ public interface IRichTextContentPartRendererCollection
     /// <param name="content"></param>
     /// <param name="stringBuilder"></param>
     public void RenderChildren(IRichTextContent content, StringBuilder stringBuilder);
-
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextContentPartRendererCollection.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextContentPartRendererCollection.cs
@@ -1,6 +1,16 @@
+using System.Text;
+
 namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
 public interface IRichTextContentPartRendererCollection
 {
     public IRichTextContentPartRenderer? GetRendererForContent(IRichTextContent content);
+
+    /// <summary>
+    /// Renders all children of the content
+    /// </summary>
+    /// <param name="content"></param>
+    /// <param name="stringBuilder"></param>
+    public void RenderChildren(IRichTextContent content, StringBuilder stringBuilder);
+
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextRenderer.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextRenderer.cs
@@ -1,6 +1,23 @@
+using System.Text;
+
 namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
+/// <summary>
+/// Renders Rich Text content
+/// </summary>
 public interface IRichTextRenderer
 {
+    /// <summary>
+    /// Renders all children of the content
+    /// </summary>
+    /// <param name="content"></param>
+    /// <param name="stringBuilder"></param>
+    public void RenderChildren(IRichTextContent content, StringBuilder stringBuilder);
+
+    /// <summary>
+    /// Converts content to HTML string
+    /// </summary>
+    /// <param name="content">Content to convert</param>
+    /// <returns>Content converted to HTML string (including tags, classes, etc.)</returns>
     public string ToHtml(IRichTextContent content);
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextRenderer.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextRenderer.cs
@@ -8,13 +8,6 @@ namespace Dfe.PlanTech.Domain.Content.Interfaces;
 public interface IRichTextRenderer
 {
     /// <summary>
-    /// Renders all children of the content
-    /// </summary>
-    /// <param name="content"></param>
-    /// <param name="stringBuilder"></param>
-    public void RenderChildren(IRichTextContent content, StringBuilder stringBuilder);
-
-    /// <summary>
     /// Converts content to HTML string
     /// </summary>
     /// <param name="content">Content to convert</param>

--- a/src/Dfe.PlanTech.Domain/Content/Models/Options/TextRendererOptions.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Options/TextRendererOptions.cs
@@ -1,11 +1,15 @@
+using Microsoft.Extensions.Logging;
+
 namespace Dfe.PlanTech.Domain.Content.Models.Options;
 
 public class TextRendererOptions
 {
+    private readonly ILogger<TextRendererOptions> _logger;
     private readonly List<MarkOption> _markOptions;
 
-    public TextRendererOptions(List<MarkOption> markOptions)
+    public TextRendererOptions(ILogger<TextRendererOptions> logger, List<MarkOption> markOptions)
     {
+        _logger = logger;
         _markOptions = markOptions;
     }
 
@@ -15,7 +19,7 @@ public class TextRendererOptions
 
         if (matchingOption == null)
         {
-            //TODO: LOG missing mark
+            _logger.LogWarning("Missing mark option for {mark}", mark);
         }
 
         return matchingOption;

--- a/src/Dfe.PlanTech.Domain/Dfe.PlanTech.Domain.csproj
+++ b/src/Dfe.PlanTech.Domain/Dfe.PlanTech.Domain.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/BaseRichTextContentPartRender.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/BaseRichTextContentPartRender.cs
@@ -16,22 +16,4 @@ public abstract class BaseRichTextContentPartRender : IRichTextContentPartRender
     public bool Accepts(IRichTextContent content) => content.MappedNodeType == _nodeType;
 
     public abstract StringBuilder AddHtml(IRichTextContent content, IRichTextContentPartRendererCollection richTextRendererCollection, StringBuilder stringBuilder);
-
-    public StringBuilder RenderChildren(IRichTextContent content, IRichTextContentPartRendererCollection renderers, StringBuilder stringBuilder)
-    {
-        foreach (var subContent in content.Content)
-        {
-            var renderer = renderers.GetRendererForContent(subContent);
-
-            if (renderer == null)
-            {
-                //TODO: Add logging for missing content type
-                continue;
-            }
-
-            renderer.AddHtml(subContent, renderers, stringBuilder);
-        }
-
-        return stringBuilder;
-    }
 }

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/HyperlinkRenderer.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/HyperlinkRenderer.cs
@@ -32,7 +32,7 @@ public class HyperlinkRenderer : BaseRichTextContentPartRender
 
         stringBuilder.Append("\">");
 
-        RenderChildren(content, renderers, stringBuilder);
+        renderers.RenderChildren(content, stringBuilder);
 
         stringBuilder.Append(content.Value);
 

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/HyperlinkRenderer.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/HyperlinkRenderer.cs
@@ -1,7 +1,8 @@
-using System.Text;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Content.Models.Options;
+using Microsoft.Extensions.Logging;
+using System.Text;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models.PartRenderers;
 
@@ -18,7 +19,7 @@ public class HyperlinkRenderer : BaseRichTextContentPartRender
     {
         if (string.IsNullOrEmpty(content.Data?.Uri))
         {
-            //TODO: Log missing data;
+            renderers.Logger.LogError("{this} has no Uri", this);
             return stringBuilder;
         }
 

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/ListItemRenderer.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/ListItemRenderer.cs
@@ -15,7 +15,7 @@ public class ListItemRenderer : BaseRichTextContentPartRender
     {
         stringBuilder.Append("<li>");
 
-        RenderChildren(content, renderers, stringBuilder);
+        renderers.RenderChildren(content, stringBuilder);
 
         stringBuilder.Append("</li>");
 

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/OrderedListRenderer.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/OrderedListRenderer.cs
@@ -15,7 +15,7 @@ public class OrderedListRenderer : BaseRichTextContentPartRender
     {
         stringBuilder.Append("<ol>");
 
-        RenderChildren(content, renderers, stringBuilder);
+        renderers.RenderChildren(content, stringBuilder);
 
         stringBuilder.Append("</ol>");
 

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/ParagraphRenderer.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/ParagraphRenderer.cs
@@ -26,7 +26,7 @@ public class ParagraphRenderer : BaseRichTextContentPartRender
             stringBuilder.Append("\">");
         }
 
-        RenderChildren(content, renderers, stringBuilder);
+        renderers.RenderChildren(content, stringBuilder);
 
         stringBuilder.Append("</p>");
         return stringBuilder;

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/UnorderedListRenderer.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/UnorderedListRenderer.cs
@@ -15,7 +15,7 @@ public class UnorderedListRenderer : BaseRichTextContentPartRender
     {
         stringBuilder.Append("<ul>");
 
-        RenderChildren(content, renderers, stringBuilder);
+        renderers.RenderChildren(content, stringBuilder);
 
         stringBuilder.Append("</ul>");
 

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/RichTextRenderer.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/RichTextRenderer.cs
@@ -12,6 +12,8 @@ public class RichTextRenderer : IRichTextRenderer, IRichTextContentPartRendererC
     private readonly ILogger<IRichTextRenderer> _logger;
     private readonly List<IRichTextContentPartRenderer> _renderers;
 
+    public ILogger Logger => _logger;
+    
     public RichTextRenderer(ILogger<IRichTextRenderer> logger, IEnumerable<IRichTextContentPartRenderer> renderers)
     {
         _logger = logger;

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Dfe.PlanTech.Infrastructure.Contentful.csproj
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Dfe.PlanTech.Infrastructure.Contentful.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/Dfe.PlanTech.Web/Program.cs
+++ b/src/Dfe.PlanTech.Web/Program.cs
@@ -19,13 +19,18 @@ builder.Services.AddGovUkFrontend();
 
 builder.Services.SetupContentfulClient(builder.Configuration, "Contentful", HttpClientPolicyExtensions.AddRetryPolicy);
 
-builder.Services.AddScoped((_) => new TextRendererOptions(new List<MarkOption>() {
-    new MarkOption(){
-        Mark = "bold",
-        HtmlTag = "span",
-        Classes = "govuk-body govuk-!-font-weight-bold",
-    }
-}));
+builder.Services.AddScoped((services) =>
+{
+    var logger = services.GetRequiredService<ILogger<TextRendererOptions>>();
+
+    return new TextRendererOptions(logger, new List<MarkOption>() {
+        new MarkOption(){
+            Mark = "bold",
+            HtmlTag = "span",
+            Classes = "govuk-body govuk-!-font-weight-bold",
+        }
+    });
+});
 
 builder.Services.AddScoped((_) => new ParagraphRendererOptions()
 {

--- a/src/Dfe.PlanTech.Web/TagHelpers/RichText/RichTextTagHelper.cs
+++ b/src/Dfe.PlanTech.Web/TagHelpers/RichText/RichTextTagHelper.cs
@@ -6,12 +6,14 @@ namespace Dfe.PlanTech.Web.TagHelpers.RichText;
 
 public class RichTextTagHelper : TagHelper
 {
+    private readonly ILogger<RichTextTagHelper> _logger;
     private readonly IRichTextRenderer _richTextRenderer;
 
     public RichTextContent? Content { get; set; }
 
-    public RichTextTagHelper(IRichTextRenderer richTextRenderer)
+    public RichTextTagHelper(ILogger<RichTextTagHelper> logger, IRichTextRenderer richTextRenderer)
     {
+        _logger = logger;
         _richTextRenderer = richTextRenderer;
     }
 
@@ -19,7 +21,7 @@ public class RichTextTagHelper : TagHelper
     {
         if (Content == null)
         {
-            //TODO: Log missing rich text;
+            _logger.LogWarning("Missing content");
             return;
         }
 

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/HyperlinkRendererTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/HyperlinkRendererTests.cs
@@ -3,6 +3,8 @@ using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models.PartRenderers;
 using Dfe.PlanTech.Domain.Content.Models.Options;
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Content.Renderers.Models.PartRenderers;
 
@@ -53,7 +55,7 @@ public class HyperlinkRendererTests
     public void Should_CreateLink_When_PassedValidData()
     {
         var renderer = new HyperlinkRenderer(new HyperlinkRendererOptions());
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string linkText = "Click Here";
         const string url = "https://www.test-url.com";
@@ -80,7 +82,7 @@ public class HyperlinkRendererTests
     public void Should_NotAddLink_When_MissingURI()
     {
         var renderer = new HyperlinkRenderer(new HyperlinkRendererOptions());
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string linkText = "Click Here";
 
@@ -103,7 +105,7 @@ public class HyperlinkRendererTests
         const string testClasses = "testing-classes";
 
         var renderer = new HyperlinkRenderer(new HyperlinkRendererOptions() { Classes = testClasses });
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string linkText = "Click Here";
         const string url = "https://www.test-url.com";

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/ListItemRendererTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/ListItemRendererTests.cs
@@ -1,7 +1,9 @@
 using System.Text;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models.PartRenderers;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Content.Renderers.Models.PartRenderers;
 
@@ -47,7 +49,7 @@ public class ListItemRendererTests
     public void Should_CreateListItem_When_PassedValidData()
     {
         var renderer = new ListItemRenderer();
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string listItemValue = "List item one";
 

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/OrderedListRendererTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/OrderedListRendererTests.cs
@@ -1,7 +1,9 @@
 using System.Text;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models.PartRenderers;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Content.Renderers.Models.PartRenderers;
 
@@ -47,7 +49,7 @@ public class OrderedListRendererTests
     public void Should_CreateOrderedList_When_PassedValidData()
     {
         var renderer = new OrderedListRenderer();
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string listItemValue = "List item one";
 

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/ParagraphRendererTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/ParagraphRendererTests.cs
@@ -3,6 +3,8 @@ using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models.PartRenderers;
 using Dfe.PlanTech.Domain.Content.Models.Options;
+using Microsoft.Extensions.Logging.Abstractions;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Content.Renderers.Models.PartRenderers;
 
@@ -48,7 +50,7 @@ public class ParagraphRendererTests
     public void Should_Create_Paragraph_When_PassedValidData()
     {
         var renderer = new ParagraphRenderer(new ParagraphRendererOptions());
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string value = "Paragraph text";
 
@@ -71,7 +73,7 @@ public class ParagraphRendererTests
     {
         const string classes = "testing-classes";
         var renderer = new ParagraphRenderer(new ParagraphRendererOptions() { Classes = classes });
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string value = "Paragraph text";
 

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/TextRendererTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/TextRendererTests.cs
@@ -3,6 +3,8 @@ using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models.PartRenderers;
 using Dfe.PlanTech.Domain.Content.Models.Options;
+using Microsoft.Extensions.Logging.Abstractions;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Content.Renderers.Models.PartRenderers;
 
@@ -57,7 +59,7 @@ public class TextRendererTests
         };
 
         var renderer = new TextRenderer(new TextRendererOptions(new List<MarkOption>() { boldMarkOption }));
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string value = "Paragraph text";
 
@@ -94,7 +96,7 @@ public class TextRendererTests
         };
 
         var renderer = new TextRenderer(new TextRendererOptions(new List<MarkOption>() { boldMarkOption }));
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string value = "Paragraph text";
 
@@ -132,7 +134,7 @@ public class TextRendererTests
         };
 
         var renderer = new TextRenderer(new TextRendererOptions(new List<MarkOption>() { boldMarkOption }));
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string value = "Paragraph text";
 

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/TextRendererTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/TextRendererTests.cs
@@ -23,7 +23,7 @@ public class TextRendererTests
             Value = value,
         };
 
-        var renderer = new TextRenderer(new TextRendererOptions(new List<MarkOption>() { }));
+        var renderer = new TextRenderer(new TextRendererOptions(new NullLogger<TextRendererOptions>(), new List<MarkOption>() { }));
 
         var accepted = renderer.Accepts(content);
 
@@ -39,7 +39,7 @@ public class TextRendererTests
             Value = "hyperlink"
         };
 
-        var renderer = new TextRenderer(new TextRendererOptions(new List<MarkOption>() { }));
+        var renderer = new TextRenderer(new TextRendererOptions(new NullLogger<TextRendererOptions>(), new List<MarkOption>() { }));
 
         var accepted = renderer.Accepts(content);
 
@@ -58,7 +58,7 @@ public class TextRendererTests
             HtmlTag = htmlTagForBold,
         };
 
-        var renderer = new TextRenderer(new TextRendererOptions(new List<MarkOption>() { boldMarkOption }));
+        var renderer = new TextRenderer(new TextRendererOptions(new NullLogger<TextRendererOptions>(), new List<MarkOption>() { boldMarkOption }));
         var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string value = "Paragraph text";
@@ -95,7 +95,7 @@ public class TextRendererTests
             Classes = testClasses
         };
 
-        var renderer = new TextRenderer(new TextRendererOptions(new List<MarkOption>() { boldMarkOption }));
+        var renderer = new TextRenderer(new TextRendererOptions(new NullLogger<TextRendererOptions>(), new List<MarkOption>() { boldMarkOption }));
         var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string value = "Paragraph text";
@@ -117,8 +117,8 @@ public class TextRendererTests
 
         Assert.Equal($"<{htmlTagForBold} class=\"{testClasses}\">{value}</{htmlTagForBold}>", html);
     }
-    
-    
+
+
     [Fact]
     public void Should_RenderText_When_HasNoMarks()
     {
@@ -133,7 +133,7 @@ public class TextRendererTests
             Classes = testClasses
         };
 
-        var renderer = new TextRenderer(new TextRendererOptions(new List<MarkOption>() { boldMarkOption }));
+        var renderer = new TextRenderer(new TextRendererOptions(new NullLogger<TextRendererOptions>(), new List<MarkOption>() { boldMarkOption }));
         var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string value = "Paragraph text";

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/UnorderedListRendererTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/UnorderedListRendererTests.cs
@@ -1,7 +1,9 @@
 using System.Text;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models.PartRenderers;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Content.Renderers.Models.PartRenderers;
 
@@ -47,7 +49,7 @@ public class UnorderedListRendererTests
     public void Should_CreateUnorderedList_When_PassedValidData()
     {
         var renderer = new UnorderedListRenderer();
-        var rendererCollection = new RichTextRenderer(new[] { renderer });
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
 
         const string value = "List item one";
 

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/RichTextRendererTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/RichTextRendererTests.cs
@@ -1,9 +1,10 @@
 using System.Text;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Content.Models.Options;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models.PartRenderers;
-using Dfe.PlanTech.Domain.Content.Models.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Content.Renderers.Models;
@@ -32,7 +33,7 @@ public class RichTextRendererTests
             new HyperlinkRenderer(new HyperlinkRendererOptions())
         };
 
-        _renderer = new RichTextRenderer(partRenderers);
+        _renderer = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), partRenderers);
     }
 
     [Fact]


### PR DESCRIPTION
- Refactors Rich Text renderers slighty; children renderering handled by `IRichTextContentPartRendererCollection` only
- Adds `ILogger` to RichTextRendererer
- Adds logging for various warnings/errors
  - Missing renderer for rich text
  - Missing mark for text body