### PR TITLE
refactor: Move UrlHistory to /Caching/ folder

### DIFF
--- a/src/Dfe.PlanTech.Application/Caching/Interfaces/IUrlHistory.cs
+++ b/src/Dfe.PlanTech.Application/Caching/Interfaces/IUrlHistory.cs
@@ -1,4 +1,4 @@
-namespace Dfe.PlanTech.Application.Core;
+namespace Dfe.PlanTech.Application.Caching.Interfaces;
 
 /// <summary>
 /// For tracking user's URL history

--- a/src/Dfe.PlanTech.Application/Caching/Models/UrlHistory.cs
+++ b/src/Dfe.PlanTech.Application/Caching/Models/UrlHistory.cs
@@ -1,6 +1,6 @@
 using Dfe.PlanTech.Application.Caching.Interfaces;
 
-namespace Dfe.PlanTech.Application.Core;
+namespace Dfe.PlanTech.Application.Caching.Models;
 
 public class UrlHistory : IUrlHistory
 {

--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -1,4 +1,4 @@
-using Dfe.PlanTech.Application.Core;
+using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Questionnaire.Queries;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Web.Models;

--- a/src/Dfe.PlanTech.Web/ProgramExtensions.cs
+++ b/src/Dfe.PlanTech.Web/ProgramExtensions.cs
@@ -1,5 +1,5 @@
 using Dfe.PlanTech.Application.Caching.Interfaces;
-using Dfe.PlanTech.Application.Core;
+using Dfe.PlanTech.Application.Caching.Models;
 using Dfe.PlanTech.Domain.Caching.Interfaces;
 using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Content.Models.Options;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Core/UrlHistoryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Core/UrlHistoryTests.cs
@@ -1,5 +1,5 @@
 using Dfe.PlanTech.Application.Caching.Interfaces;
-using Dfe.PlanTech.Application.Core;
+using Dfe.PlanTech.Application.Caching.Models;
 using Moq;
 
 namespace Dfe.PlanTech.Application.UnitTests.Core;

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -1,5 +1,4 @@
 using Dfe.PlanTech.Application.Caching.Interfaces;
-using Dfe.PlanTech.Application.Core;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Application.Questionnaire.Queries;
 using Dfe.PlanTech.Domain.Caching.Models;

--- a/tests/Dfe.PlanTech.Web.UnitTests/Middleware/UrlHistoryMiddlewareTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Middleware/UrlHistoryMiddlewareTests.cs
@@ -1,4 +1,5 @@
 using Dfe.PlanTech.Application.Caching.Interfaces;
+using Dfe.PlanTech.Application.Caching.Models;
 using Dfe.PlanTech.Application.Core;
 using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Web.Helpers;
@@ -32,7 +33,7 @@ public class UrlHistoryMiddlewareTests
     }
 
     [Fact]
-    public void Should_PopHistory_When_Navigating_Backwards()
+    public async Task Should_PopHistory_When_Navigating_Backwards()
     {
         var requestMock = new Mock<HttpRequest>();
         requestMock.SetupGet(request => request.Host).Returns(new HostString("www.website.com"));
@@ -45,7 +46,7 @@ public class UrlHistoryMiddlewareTests
         var urlHistory = new UrlHistoryMiddleware(nextDelegateMock.Object);
 
         var history = new UrlHistory(_cacher);
-        urlHistory.InvokeAsync(contextMock.Object, history);
+        await urlHistory.InvokeAsync(contextMock.Object, history);
 
         var historyCache = history.History;
         Assert.Equal(2, historyCache.Count);
@@ -53,7 +54,7 @@ public class UrlHistoryMiddlewareTests
     }
 
     [Fact]
-    public void Should_AddToHistory_When_Navigating_ToNewPage()
+    public async Task Should_AddToHistory_When_Navigating_ToNewPage()
     {
         var requestMock = new Mock<HttpRequest>();
         requestMock.SetupGet(request => request.IsHttps).Returns(false);
@@ -70,7 +71,7 @@ public class UrlHistoryMiddlewareTests
         var urlHistory = new UrlHistoryMiddleware(nextDelegateMock.Object);
 
         var history = new UrlHistory(_cacher);
-        urlHistory.InvokeAsync(contextMock.Object, history);
+        await urlHistory.InvokeAsync(contextMock.Object, history);
 
         var historyCache = history.History;
 


### PR DESCRIPTION
- Moves UrlHistory class + interfaces to a different folder