### PR TITLE
feat: Add section title

### DIFF
--- a/src/Dfe.PlanTech.Application/Caching/Interfaces/IQuestionnaireCacher.cs
+++ b/src/Dfe.PlanTech.Application/Caching/Interfaces/IQuestionnaireCacher.cs
@@ -1,0 +1,10 @@
+using Dfe.PlanTech.Domain.Caching.Models;
+
+namespace Dfe.PlanTech.Application.Caching.Interfaces;
+
+public interface IQuestionnaireCacher
+{
+    public QuestionnaireCache? Cached { get; }
+
+    public void SaveCache(QuestionnaireCache cache);
+}

--- a/src/Dfe.PlanTech.Application/Caching/Models/QuestionnaireCacher.cs
+++ b/src/Dfe.PlanTech.Application/Caching/Models/QuestionnaireCacher.cs
@@ -3,11 +3,16 @@ using Dfe.PlanTech.Domain.Caching.Models;
 
 namespace Dfe.PlanTech.Application.Caching.Models;
 
-public class QuestionnaireCacher
+public class QuestionnaireCacher : IQuestionnaireCacher
 {
     private const string CACHE_KEY = "QuestionnaireCache";
 
     private readonly ICacher _cacher;
+
+    public QuestionnaireCacher(ICacher cacher)
+    {
+        _cacher = cacher;
+    }
 
     public QuestionnaireCache? Cached => _cacher.Get(CACHE_KEY, () => new QuestionnaireCache());
 

--- a/src/Dfe.PlanTech.Application/Caching/Models/QuestionnaireCacher.cs
+++ b/src/Dfe.PlanTech.Application/Caching/Models/QuestionnaireCacher.cs
@@ -1,0 +1,15 @@
+using Dfe.PlanTech.Application.Caching.Interfaces;
+using Dfe.PlanTech.Domain.Caching.Models;
+
+namespace Dfe.PlanTech.Application.Caching.Models;
+
+public class QuestionnaireCacher
+{
+    private const string CACHE_KEY = "QuestionnaireCache";
+
+    private readonly ICacher _cacher;
+
+    public QuestionnaireCache? Cached => _cacher.Get(CACHE_KEY, () => new QuestionnaireCache());
+
+    public void SaveCache(QuestionnaireCache cache) => _cacher.Set(CACHE_KEY, TimeSpan.FromHours(1), cache);
+}

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetPageQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetPageQuery.cs
@@ -1,3 +1,4 @@
+using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Core;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Application.Persistence.Models;
@@ -8,8 +9,11 @@ namespace Dfe.PlanTech.Application.Content.Queries;
 
 public class GetPageQuery : ContentRetriever
 {
-    public GetPageQuery(IContentRepository repository) : base(repository)
+    private readonly IQuestionnaireCacher _cacher;
+
+    public GetPageQuery(IQuestionnaireCacher cacher, IContentRepository repository) : base(repository)
     {
+        _cacher = cacher;
     }
 
     /// <summary>
@@ -24,6 +28,11 @@ public class GetPageQuery : ContentRetriever
 
         var page = pages.FirstOrDefault() ?? throw new Exception($"Could not find page with slug {slug}");
 
+        if(page.DisplaySectionTitle){
+            var cached = _cacher.Cached!;
+            page.SectionTitle = cached.CurrentSectionTitle;
+        }
+        
         return page;
     }
 }

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetPageQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetPageQuery.cs
@@ -28,11 +28,11 @@ public class GetPageQuery : ContentRetriever
 
         var page = pages.FirstOrDefault() ?? throw new Exception($"Could not find page with slug {slug}");
 
-        if(page.DisplaySectionTitle){
+        if(page.DisplayTopicTitle){
             var cached = _cacher.Cached!;
             page.SectionTitle = cached.CurrentSectionTitle;
         }
-        
+
         return page;
     }
 }

--- a/src/Dfe.PlanTech.Application/Questionnaire/Queries/GetQuestionQuery.cs
+++ b/src/Dfe.PlanTech.Application/Questionnaire/Queries/GetQuestionQuery.cs
@@ -1,13 +1,18 @@
+using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Core;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 
 namespace Dfe.PlanTech.Application.Questionnaire.Queries;
 
 public class GetQuestionQuery : ContentRetriever
 {
-    public GetQuestionQuery(IContentRepository repository) : base(repository)
+    private readonly IQuestionnaireCacher _cacher;
+
+    public GetQuestionQuery(IQuestionnaireCacher cacher, IContentRepository repository) : base(repository)
     {
+        _cacher = cacher;
     }
 
     public async Task<Question?> GetQuestionById(string id, CancellationToken cancellationToken = default)
@@ -15,5 +20,23 @@ public class GetQuestionQuery : ContentRetriever
         var question = await repository.GetEntityById<Question>(id, 3, cancellationToken);
 
         return question;
+    }
+
+    public Task<Question?> GetQuestionById(string id, string? section, CancellationToken cancellationToken = default)
+    {
+        if (section != null)
+        {
+            UpdateSectionTitle(section);
+        }
+        
+        return GetQuestionById(id, cancellationToken);
+    }
+
+    private void UpdateSectionTitle(string section)
+    {
+        var cached = _cacher.Cached ?? new QuestionnaireCache();
+        cached = cached with { CurrentSectionTitle = section };
+
+        _cacher.SaveCache(cached);
     }
 }

--- a/src/Dfe.PlanTech.Domain/Caching/Interfaces/IQuestionnaireCache.cs
+++ b/src/Dfe.PlanTech.Domain/Caching/Interfaces/IQuestionnaireCache.cs
@@ -1,0 +1,6 @@
+namespace Dfe.PlanTech.Domain.Caching.Interfaces;
+
+public interface IQuestionnaireCache
+{
+   public string? CurrentSectionTitle { get; init; }
+}

--- a/src/Dfe.PlanTech.Domain/Caching/Models/QuestionnaireCache.cs
+++ b/src/Dfe.PlanTech.Domain/Caching/Models/QuestionnaireCache.cs
@@ -1,0 +1,8 @@
+using Dfe.PlanTech.Domain.Caching.Interfaces;
+
+namespace Dfe.PlanTech.Domain.Caching.Models;
+
+public record QuestionnaireCache : IQuestionnaireCache
+{
+    public string? CurrentSectionTitle { get; init; }
+}

--- a/src/Dfe.PlanTech.Domain/Content/Models/Page.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Page.cs
@@ -8,6 +8,10 @@ public class Page : ContentComponent
 
     public string Slug { get; init; } = null!;
 
+    public bool DisplaySectionTitle { get; init;}
+    
+    public string? SectionTitle { get; set; }
+
     public Title? Title { get; init; }
 
     public IContentComponent[] Content { get; init; } = Array.Empty<IContentComponent>();

--- a/src/Dfe.PlanTech.Domain/Content/Models/Page.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Page.cs
@@ -8,7 +8,7 @@ public class Page : ContentComponent
 
     public string Slug { get; init; } = null!;
 
-    public bool DisplaySectionTitle { get; init;}
+    public bool DisplayTopicTitle { get; init;}
     
     public string? SectionTitle { get; set; }
 

--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -18,14 +18,15 @@ public class QuestionsController : BaseController<QuestionsController>
     /// 
     /// </summary>
     /// <param name="id"></param>
+    /// <param name="section">Name of current section (if starting new)</param>
     /// <param name="query"></param>
     /// <exception cref="ArgumentNullException">Throws exception when Id is null or empty</exception>
     /// <returns></returns>
-    public async Task<IActionResult> GetQuestionById(string id, CancellationToken cancellationToken, [FromServices] GetQuestionQuery query)
+    public async Task<IActionResult> GetQuestionById(string id, string? section, CancellationToken cancellationToken, [FromServices] GetQuestionQuery query)
     {
         if (string.IsNullOrEmpty(id)) throw new ArgumentNullException(nameof(id));
 
-        var question = await query.GetQuestionById(id, cancellationToken) ?? throw new KeyNotFoundException($"Could not find question with id {id}");
+        var question = await query.GetQuestionById(id, section, cancellationToken) ?? throw new KeyNotFoundException($"Could not find question with id {id}");
         
         var viewModel = new QuestionViewModel()
         {

--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -42,14 +42,8 @@ public class QuestionsController : BaseController<QuestionsController>
     {
         if (submitAnswerDto == null) throw new ArgumentNullException(nameof(submitAnswerDto));
 
-        if (string.IsNullOrEmpty(submitAnswerDto.NextQuestionId)) return RedirectToAction("CheckYourAnswers");
+        if (string.IsNullOrEmpty(submitAnswerDto.NextQuestionId)) return RedirectToAction("GetByRoute", "Pages", new { route = "check-answers" });
 
         return RedirectToAction("GetQuestionById", new { id = submitAnswerDto.NextQuestionId });
-    }
-
-    [HttpGet("check-answers")]
-    public IActionResult CheckYourAnswers()
-    {
-        return View("CheckYourAnswers");
     }
 }

--- a/src/Dfe.PlanTech.Web/ProgramExtensions.cs
+++ b/src/Dfe.PlanTech.Web/ProgramExtensions.cs
@@ -1,4 +1,5 @@
 using Dfe.PlanTech.Application.Caching.Interfaces;
+using Dfe.PlanTech.Application.Caching.Models;
 using Dfe.PlanTech.Application.Core;
 using Dfe.PlanTech.Domain.Caching.Interfaces;
 using Dfe.PlanTech.Domain.Caching.Models;
@@ -54,7 +55,8 @@ public static class ProgramExtensions
         services.AddSingleton<ICacheOptions>((services) => new CacheOptions());
         services.AddTransient<ICacher, Cacher>();
         services.AddTransient<IUrlHistory, UrlHistory>();
-
+        services.AddTransient<IQuestionnaireCacher, QuestionnaireCacher>();
+        
         return services;
     }
 }

--- a/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
@@ -4,7 +4,7 @@
     <div class="govuk-grid-column-two-thirds">
         @{
             if(Model.DisplayTopicTitle){
-                <h2>@Model.SectionTitle</h2>
+                <span class="govuk-caption-xl">@Model.SectionTitle</span>
             }
 
             if(Model.Title != null){

--- a/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
@@ -3,12 +3,14 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         @{
+            if(Model.DisplaySectionTitle){
+                <h2>@Model.SectionTitle</h2>
+            }
+            
             if(Model.Title != null){
                 await Html.RenderPartialAsync("Components/Title", Model.Title);
             }
-        }
-
-        @{
+ 
             foreach(var content in Model.Content){
                 await Html.RenderPartialAsync("Components/PageComponentFactory", content);
             }

--- a/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
@@ -3,10 +3,10 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         @{
-            if(Model.DisplaySectionTitle){
+            if(Model.DisplayTopicTitle){
                 <h2>@Model.SectionTitle</h2>
             }
-            
+
             if(Model.Title != null){
                 await Html.RenderPartialAsync("Components/Title", Model.Title);
             }

--- a/src/Dfe.PlanTech.Web/Views/Shared/Questionnaire/Category.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Questionnaire/Category.cshtml
@@ -19,7 +19,7 @@
 
         <task-list-item>
             <task-list-item-name>
-                <a asp-controller="Questions" asp-action="GetQuestionById" asp-route-id=@categorySection.FirstQuestionId class="govuk-link">
+                <a asp-controller="Questions" asp-action="GetQuestionById" asp-route-id=@categorySection.FirstQuestionId asp-route-section=@categorySection.Name class="govuk-link">
                     @categorySection.Name
                 </a>
             </task-list-item-name>

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
@@ -1,5 +1,7 @@
+using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Infrastructure.Application.Models;
 using Moq;
@@ -8,8 +10,11 @@ namespace Dfe.PlanTech.Application.UnitTests.Content.Queries;
 
 public class GetPageQueryTests
 {
+    private const string SECTION_SLUG = "SectionSlugTest";
+    private const string SECTION_TITLE = "SectionTitleTest";
     private const string LANDING_PAGE_SLUG = "LandingPage";
     private readonly Mock<IContentRepository> _repoMock = new();
+    private readonly Mock<IQuestionnaireCacher> _questionnaireCacherMock = new Mock<IQuestionnaireCacher>();
 
     private readonly List<Page> _mockData = new() {
         new Page(){
@@ -20,10 +25,20 @@ public class GetPageQueryTests
         },
         new Page(){
             Slug = "AuditStart"
+        },
+        new Page(){
+            Slug = SECTION_SLUG,
+            DisplayTopicTitle = true,
         }
     };
 
     public GetPageQueryTests()
+    {
+        SetupRepository();
+        SetupQuestionnaireCacher();
+    }
+
+    private void SetupRepository()
     {
         _repoMock.Setup(client => client.GetEntities<Page>(It.IsAny<IGetEntitiesOptions>(), It.IsAny<CancellationToken>()))
         .ReturnsAsync((IGetEntitiesOptions options, CancellationToken token) =>
@@ -43,10 +58,21 @@ public class GetPageQueryTests
         }).Verifiable();
     }
 
+    private void SetupQuestionnaireCacher()
+    {
+        _questionnaireCacherMock.Setup(questionnaire => questionnaire.Cached).Returns(new QuestionnaireCache()
+        {
+            CurrentSectionTitle = SECTION_TITLE
+        });
+
+        _questionnaireCacherMock.Setup(questionnaire => questionnaire.SaveCache(It.IsAny<QuestionnaireCache>()));
+    }
+
+
     [Fact]
     public async Task Should_Retrieve_Page_By_Slug()
     {
-        var query = new GetPageQuery(_repoMock.Object);
+        var query = new GetPageQuery(_questionnaireCacherMock.Object, _repoMock.Object);
 
         var result = await query.GetPageBySlug(LANDING_PAGE_SLUG);
 
@@ -60,8 +86,19 @@ public class GetPageQueryTests
     [Fact]
     public async Task Should_ThrowException_When_SlugNotFound()
     {
-        var query = new GetPageQuery(_repoMock.Object);
+        var query = new GetPageQuery(_questionnaireCacherMock.Object, _repoMock.Object);
 
         await Assert.ThrowsAsync<Exception>(async () => await query.GetPageBySlug("NOT A REAL SLUG"));
+    }
+
+    [Fact]
+    public async Task Should_SetSectionTitle_When_DisplayTitle_IsTrue()
+    {
+        var query = new GetPageQuery(_questionnaireCacherMock.Object, _repoMock.Object);
+        var result = await query.GetPageBySlug(SECTION_SLUG);
+
+
+        Assert.Equal(SECTION_TITLE, result.SectionTitle);
+        _questionnaireCacherMock.Verify(mock => mock.Cached, Times.Once);
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/PagesControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/PagesControllerTests.cs
@@ -1,6 +1,5 @@
 using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Content.Queries;
-using Dfe.PlanTech.Application.Core;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
@@ -43,15 +42,27 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
                     Text = INDEX_TITLE,
                 },
                 Content = Array.Empty<IContentComponent>()
-            }
-        };
+                }
+            };
 
         private readonly PagesController _controller;
         private readonly GetPageQuery _query;
+        private readonly Mock<IQuestionnaireCacher> _questionnaireCacherMock = new Mock<IQuestionnaireCacher>();
 
         public PagesControllerTests()
         {
+            Mock<IContentRepository> repositoryMock = SetupRepositoryMock();
 
+            var mockLogger = new Mock<ILogger<PagesController>>();
+            var historyMock = new Mock<IUrlHistory>();
+
+            _controller = new PagesController(mockLogger.Object, historyMock.Object);
+
+            _query = new GetPageQuery(_questionnaireCacherMock.Object, repositoryMock.Object);
+        }
+
+        private Mock<IContentRepository> SetupRepositoryMock()
+        {
             var repositoryMock = new Mock<IContentRepository>();
             repositoryMock.Setup(repo => repo.GetEntities<Page>(It.IsAny<IGetEntitiesOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync((IGetEntitiesOptions options, CancellationToken _) =>
             {
@@ -68,13 +79,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
 
                 return Array.Empty<Page>();
             });
-
-            var mockLogger = new Mock<ILogger<PagesController>>();
-            var historyMock = new Mock<IUrlHistory>();
-
-            _controller = new PagesController(mockLogger.Object, historyMock.Object);
-
-            _query = new GetPageQuery(repositoryMock.Object);
+            return repositoryMock;
         }
 
         [Fact]

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -68,10 +68,34 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
 
         private readonly QuestionsController _controller;
         private readonly GetQuestionQuery _query;
+        private readonly Mock<IQuestionnaireCacher> _questionnaireCacherMock;
 
         private readonly ICacher _cacher;
 
         public QuestionsControllerTests()
+        {
+            Mock<IContentRepository> repositoryMock = MockRepository();
+            _questionnaireCacherMock = MockQuestionnaireCacher();
+
+            var mockLogger = new Mock<ILogger<QuestionsController>>();
+
+            var historyMock = new Mock<IUrlHistory>();
+            _controller = new QuestionsController(mockLogger.Object, historyMock.Object);
+            _query = new GetQuestionQuery(_questionnaireCacherMock.Object, repositoryMock.Object);
+
+            _cacher = new Cacher(new CacheOptions(), new MemoryCache(new MemoryCacheOptions()));
+        }
+
+        private Mock<IQuestionnaireCacher> MockQuestionnaireCacher()
+        {
+            var mock = new Mock<IQuestionnaireCacher>();
+            mock.Setup(questionnaireCache => questionnaireCache.Cached).Returns(new QuestionnaireCache()).Verifiable();
+            mock.Setup(questionnaireCache => questionnaireCache.SaveCache(It.IsAny<QuestionnaireCache>())).Verifiable();
+
+            return mock;
+        }
+
+        private Mock<IContentRepository> MockRepository()
         {
             var repositoryMock = new Mock<IContentRepository>();
             repositoryMock.Setup(repo => repo.GetEntities<Question>(It.IsAny<IGetEntitiesOptions>(), It.IsAny<CancellationToken>())).ReturnsAsync((IGetEntitiesOptions options, CancellationToken _) =>
@@ -92,24 +116,15 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
 
             repositoryMock.Setup(repo => repo.GetEntityById<Question>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
                           .ReturnsAsync((string id, int include, CancellationToken _) => _questions.FirstOrDefault(question => question.Sys.Id == id));
-
-            var mockLogger = new Mock<ILogger<QuestionsController>>();
-
-            var historyMock = new Mock<IUrlHistory>();
-
-            _controller = new QuestionsController(mockLogger.Object, historyMock.Object);
-            _query = new GetQuestionQuery(repositoryMock.Object);
-
-            _cacher = new Cacher(new CacheOptions(), new MemoryCache(new MemoryCacheOptions()));
+            return repositoryMock;
         }
-
 
         [Fact]
         public async Task GetQuestionById_Should_ReturnQuestionPage_When_FetchingQuestionWithValidId()
         {
             var id = "Question1";
 
-            var result = await _controller.GetQuestionById(id, CancellationToken.None, _query);
+            var result = await _controller.GetQuestionById(id, null, CancellationToken.None, _query);
             Assert.IsType<ViewResult>(result);
 
             var viewResult = result as ViewResult;
@@ -127,13 +142,34 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         [Fact]
         public async Task GetQuestionById_Should_ThrowException_When_IdIsNull()
         {
-            await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _controller.GetQuestionById(null!, CancellationToken.None, _query));
+            await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _controller.GetQuestionById(null!, null, CancellationToken.None, _query));
         }
 
         [Fact]
         public async Task GetQuestionById_Should_ThrowException_When_IdIsNotFound()
         {
-            await Assert.ThrowsAnyAsync<KeyNotFoundException>(() => _controller.GetQuestionById("not a real question id", CancellationToken.None,  _query));
+            await Assert.ThrowsAnyAsync<KeyNotFoundException>(() => _controller.GetQuestionById("not a real question id", null, CancellationToken.None, _query));
+        }
+
+        [Fact]
+        public async Task GetQuestionById_Should_SaveSectionTitle_When_NotNull()
+        {
+            var id = "Question1";
+            var sectionTitle = "Section title";
+
+            await _controller.GetQuestionById(id, sectionTitle, CancellationToken.None, _query);
+
+            _questionnaireCacherMock.Verify();
+        }
+
+        [Fact]
+        public async Task GetQuestionById_Should_NotSaveSectionTitle_When_Null()
+        {
+            var id = "Question1";
+            var result = await _controller.GetQuestionById(id, null, CancellationToken.None, _query);
+            
+            _questionnaireCacherMock.Verify(cache => cache.Cached, Times.Never);
+            _questionnaireCacherMock.Verify(cache => cache.SaveCache(It.IsAny<QuestionnaireCache>()), Times.Never);
         }
 
         [Fact]

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -211,7 +211,10 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
             var redirectToActionResult = result as RedirectToActionResult;
 
             Assert.NotNull(redirectToActionResult);
-            Assert.Equal("CheckYourAnswers", redirectToActionResult.ActionName);
+            Assert.Equal("Pages", redirectToActionResult.ControllerName);
+            Assert.Equal("GetByRoute", redirectToActionResult.ActionName);
+            Assert.NotNull(redirectToActionResult.RouteValues);
+            Assert.Equal("check-answers", redirectToActionResult.RouteValues["route"]);
         }
     }
 }


### PR DESCRIPTION
- Adds caching for questionnaire data
  - Currently just `Current Section Title`
- Uses caching to display the current section title on the `Check your answers` page
- Routes to proper check your answers page
  - Note: This will need improving. Needs content model changes. To be dealt with on another ticket.