### PR TITLE
feat: Use front-door URL for redirect URI

### DIFF
--- a/src/Dfe.PlanTech.Domain/SignIn/Interfaces/IDfeSignInConfiguration.cs
+++ b/src/Dfe.PlanTech.Domain/SignIn/Interfaces/IDfeSignInConfiguration.cs
@@ -2,20 +2,21 @@ namespace Dfe.PlanTech.Domain.SignIn.Models;
 
 public interface IDfeSignInConfiguration
 {
-    string Authority { get; set; }
-    string MetaDataUrl { get; set; }
-    string APIServiceProxyUrl { get; set; }
-    string CallbackUrl { get; set; }
-    string ClientId { get; set; }
-    string ClientSecret { get; set; }
-    string CookieName { get; set; }
-    int CookieExpireTimeSpanInMinutes { get; set; }
-    bool SlidingExpiration { get; set; }
-    string AccessDeniedPath { get; set; }
-    bool GetClaimsFromUserInfoEndpoint { get; set; }
-    bool SaveTokens { get; set; }
-    IList<string> Scopes { get; set; }
-    string SignoutCallbackUrl { get; set; }
-    string SignoutRedirectUrl { get; set; }
-    bool DiscoverRolesWithPublicApi { get; set; }
+    public string Authority { get; set; }
+    public string MetaDataUrl { get; set; }
+    public string APIServiceProxyUrl { get; set; }
+    public string CallbackUrl { get; set; }
+    public string ClientId { get; set; }
+    public string ClientSecret { get; set; }
+    public string CookieName { get; set; }
+    public int CookieExpireTimeSpanInMinutes { get; set; }
+    public bool SlidingExpiration { get; set; }
+    public string AccessDeniedPath { get; set; }
+    public bool GetClaimsFromUserInfoEndpoint { get; set; }
+    public bool SaveTokens { get; set; }
+    public IList<string> Scopes { get; set; }
+    public string SignoutCallbackUrl { get; set; }
+    public string SignoutRedirectUrl { get; set; }
+    public bool DiscoverRolesWithPublicApi { get; set; }
+    public string FrontDoorUrl { get; init; }
 }

--- a/src/Dfe.PlanTech.Domain/SignIn/Models/DfeSignInConfiguration.cs
+++ b/src/Dfe.PlanTech.Domain/SignIn/Models/DfeSignInConfiguration.cs
@@ -49,4 +49,6 @@ public sealed class DfeSignInConfiguration : IDfeSignInConfiguration
 
     /// <inheritdoc/>
     public bool DiscoverRolesWithPublicApi { get; set; } = false;
+
+    public string FrontDoorUrl { get; init; } = null!;
 }

--- a/src/Dfe.PlanTech.Infrastructure.SignIn/DfeOpenIdConnectEvents.cs
+++ b/src/Dfe.PlanTech.Infrastructure.SignIn/DfeOpenIdConnectEvents.cs
@@ -25,11 +25,13 @@ public static class DfeOpenIdConnectEvents
         }
     }
 
-    public static async Task OnRedirectToIdentityProvider(RedirectContext context)
+    public static Task OnRedirectToIdentityProvider(RedirectContext context)
     {
         var config = context.HttpContext.RequestServices.GetRequiredService<IDfeSignInConfiguration>();
 
         context.ProtocolMessage.RedirectUri = $"{config.FrontDoorUrl}{config.CallbackUrl}";
+
+        return Task.FromResult(0);
     }
 
     private static async Task AddRoleClaimsFromDfePublicApi(TokenValidatedContext context)

--- a/src/Dfe.PlanTech.Infrastructure.SignIn/DfeOpenIdConnectEvents.cs
+++ b/src/Dfe.PlanTech.Infrastructure.SignIn/DfeOpenIdConnectEvents.cs
@@ -25,6 +25,13 @@ public static class DfeOpenIdConnectEvents
         }
     }
 
+    public static async Task OnRedirectToIdentityProvider(RedirectContext context)
+    {
+        var config = context.HttpContext.RequestServices.GetRequiredService<IDfeSignInConfiguration>();
+
+        context.ProtocolMessage.RedirectUri = $"{config.FrontDoorUrl}{config.CallbackUrl}";
+    }
+
     private static async Task AddRoleClaimsFromDfePublicApi(TokenValidatedContext context)
     {
         var dfePublicApi = context.HttpContext.RequestServices.GetRequiredService<IDfePublicApi>();

--- a/src/Dfe.PlanTech.Infrastructure.SignIn/DfeSignInSetup.cs
+++ b/src/Dfe.PlanTech.Infrastructure.SignIn/DfeSignInSetup.cs
@@ -64,7 +64,8 @@ public static class DfeSignInSetup
 
         options.Events = new OpenIdConnectEvents()
         {
-            OnTokenValidated = DfeOpenIdConnectEvents.OnTokenValidated
+            OnTokenValidated = DfeOpenIdConnectEvents.OnTokenValidated,
+            OnRedirectToIdentityProvider = DfeOpenIdConnectEvents.OnRedirectToIdentityProvider
         };
     }
 

--- a/src/Dfe.PlanTech.Infrastructure.SignIn/README.md
+++ b/src/Dfe.PlanTech.Infrastructure.SignIn/README.md
@@ -14,12 +14,13 @@ Project containing code for integrating with DFE Sign-in
 
 You will need to set the following variables to match the ones set in the DFE Sign-in environment:
 
-```
-DfeSignIn:Authority
-DfeSignIn:MetadataUrl
-DfeSignIn:ClientId
-DfeSignIn:ClientSecret
-```
+| Env variable           | Description                                  | Example                   |
+| ---------------------- | -------------------------------------------- | ------------------------- |
+| DfeSignIn:Authority    |                                              |                           |
+| DfeSignIn:MetadataUrl  |                                              |                           |
+| DfeSignIn:ClientId     |                                              |                           |
+| DfeSignIn:ClientSecret |                                              |                           |
+| DfeSignIn:FrontDoorUrl | The resulting path for the app on front-door | https://dev.plan-tech.com |
 
 These should be set in the `Azure KeyVault` for deployed instances, or `dotnet user-secrets` for local testing.
 

--- a/src/Dfe.PlanTech.Web/appsettings.json
+++ b/src/Dfe.PlanTech.Web/appsettings.json
@@ -21,6 +21,7 @@
     "SaveTokens": true,
     "SlidingExpiration": true,
     "AccessDeniedPath": "/restricted",
-    "DiscoverRolesWithPublicApi": false
+    "DiscoverRolesWithPublicApi": false,
+    "FrontDoorUrl": "http://localhost:16251"
   }
 }


### PR DESCRIPTION
- Adds an environment variable option for the `front-door URL`
- Then writes a custom re-direct URI when re-directing the user to the OIDC provider

Fixes _164328_