### PR TITLE
fix: Add production check for keyvault

### DIFF
--- a/src/Dfe.PlanTech.Web/Program.cs
+++ b/src/Dfe.PlanTech.Web/Program.cs
@@ -14,9 +14,12 @@ builder.Services.AddApplicationInsightsTelemetry();
 builder.Services.AddControllersWithViews();
 builder.Services.AddGovUkFrontend();
 
-builder.Configuration.AddAzureKeyVault(
-new Uri($"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/"),
-new DefaultAzureCredential());
+if (builder.Environment.IsProduction())
+{
+    builder.Configuration.AddAzureKeyVault(
+    new Uri($"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/"),
+    new DefaultAzureCredential());
+}
 
 builder.Services.AddCaching();
 builder.Services.AddCQRSServices();


### PR DESCRIPTION
- Amends KeyVault configuration to only run in production mode

Using KeyVault locally leads to problems as it requires adding the Keyvault name in your configuration, as well as obviously logging into Azure.

This is not the main issue, as even if this is done, due to the URL re-writes used for DFE SignIn, it means that the callback URLs for signin lead to the _dev environment_. I.e. you will be re-directed back to https://dev-plantech.com/auth/cb instead of https://localhost:1234/auth/cb.

By making the KV run in production _only_, this will ensure minimise issues caused by the above.