### PR TITLE
Fix/162541 ps terraform docs

### DIFF
--- a/.github/workflows/terraform-pr-check.yml
+++ b/.github/workflows/terraform-pr-check.yml
@@ -168,9 +168,10 @@ jobs:
           config-file: .terraform-docs.yml
           output-file: terraform-configuration.md
           output-method: inject
-          fail-on-diff: false
+          fail-on-diff: true
       
       - name: Upload terraform-configuration.md artifact
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: terraform-configuration

--- a/.github/workflows/terraform-pr-check.yml
+++ b/.github/workflows/terraform-pr-check.yml
@@ -98,7 +98,7 @@ jobs:
         id: fmt
         run: terraform fmt -check -diff
 
-      - name: Generate Terraform docs
+      - name: Validate Terraform docs
         uses: terraform-docs/gh-actions@v1.0.0
         with:
           working-dir: terraform
@@ -160,29 +160,3 @@ jobs:
         uses: aquasecurity/tfsec-pr-commenter-action@v1.2.0
         with:
           github_token: ${{ github.token }}
-
-  # terraform-docs-validation:
-  #   name: Terraform Docs validation
-  #   runs-on: ubuntu-latest
-  #   needs: [validate-terraform]
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.ref }}
-
-  #     - name: Generate Terraform docs
-  #       uses: terraform-docs/gh-actions@v1.0.0
-  #       with:
-  #         working-dir: terraform
-  #         config-file: .terraform-docs.yml
-  #         output-file: terraform-configuration.md
-  #         output-method: inject
-  #         fail-on-diff: true
-      
-  #     - name: Upload terraform-configuration.md artifact
-  #       if: always()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: terraform-configuration
-  #         path: terraform/terraform-configuration.md

--- a/.github/workflows/terraform-pr-check.yml
+++ b/.github/workflows/terraform-pr-check.yml
@@ -98,6 +98,15 @@ jobs:
         id: fmt
         run: terraform fmt -check -diff
 
+      - name: Generate Terraform docs
+        uses: terraform-docs/gh-actions@v1.0.0
+        with:
+          working-dir: terraform
+          config-file: .terraform-docs.yml
+          output-file: terraform-configuration.md
+          output-method: inject
+          fail-on-diff: true
+
       - name: Update PR with Terraform results  
         uses: ./.github/actions/post-terraform-results
         if: github.event_name == 'pull_request'
@@ -152,27 +161,28 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-  terraform-docs-validation:
-    name: Terraform Docs validation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
+  # terraform-docs-validation:
+  #   name: Terraform Docs validation
+  #   runs-on: ubuntu-latest
+  #   needs: [validate-terraform]
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Generate Terraform docs
-        uses: terraform-docs/gh-actions@v1.0.0
-        with:
-          working-dir: terraform
-          config-file: .terraform-docs.yml
-          output-file: terraform-configuration.md
-          output-method: inject
-          fail-on-diff: true
+  #     - name: Generate Terraform docs
+  #       uses: terraform-docs/gh-actions@v1.0.0
+  #       with:
+  #         working-dir: terraform
+  #         config-file: .terraform-docs.yml
+  #         output-file: terraform-configuration.md
+  #         output-method: inject
+  #         fail-on-diff: true
       
-      - name: Upload terraform-configuration.md artifact
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: terraform-configuration
-          path: terraform/terraform-configuration.md
+  #     - name: Upload terraform-configuration.md artifact
+  #       if: always()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: terraform-configuration
+  #         path: terraform/terraform-configuration.md

--- a/.github/workflows/terraform-pr-check.yml
+++ b/.github/workflows/terraform-pr-check.yml
@@ -169,3 +169,9 @@ jobs:
           output-file: terraform-configuration.md
           output-method: inject
           fail-on-diff: false
+      
+      - name: Upload terraform-configuration.md artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: terraform-configuration
+          path: terraform/terraform-configuration.md

--- a/terraform/terraform-configuration.md
+++ b/terraform/terraform-configuration.md
@@ -13,8 +13,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.52.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.62.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
 
 ## Modules
 
@@ -35,7 +35,7 @@
 | [azurerm_key_vault_secret.vault_secret_contentful_spaceid](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.vault_secret_database_connectionstring](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_user_assigned_identity.user_assigned_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [null_resource.avnet-add-kv-service-endpoint](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.keyvault-add-vnet-restriction](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.keyvault-assign-identity](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 

--- a/terraform/terraform-configuration.md
+++ b/terraform/terraform-configuration.md
@@ -6,7 +6,8 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.5 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.52.0 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.6.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.56.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
 ## Providers

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.52.0"
+      version = ">= 3.56.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 1.6.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
DevOps: [AB#162541](https://dfe-ssp.visualstudio.com/3b5b3e9f-31ab-4776-8acf-15724e34e45b/_workitems/edit/162541)

Fixed issue relating to validating terraform docs.  It was because the `terraform-docs markdown .` command did not have access to the versions of the downloaded providers so fell back to the versions within the versions.tf file.

in future the following can be used to upload the terraform config artifact so its possible to see whats been generated.
```
     - name: Upload terraform-configuration.md artifact
         if: always()
         uses: actions/upload-artifact@v2
         with:
            name: terraform-configuration
            path: terraform/terraform-configuration.md
```