### PR TITLE
fix: Remove Kestrel from Appsettings.json

### DIFF
--- a/src/Dfe.PlanTech.Web/appsettings.json
+++ b/src/Dfe.PlanTech.Web/appsettings.json
@@ -28,12 +28,5 @@
     "AccessDeniedPath": "/restricted",
     "DiscoverRolesWithPublicApi": false,
     "FrontDoorUrl": "https://localhost:16251"
-  },
-  "Kestrel": {
-    "Endpoints": {
-      "Https": {
-        "Url": "https://localhost:16251"
-      }
-    }
   }
 }


### PR DESCRIPTION
Local settings for `Kestrel` were accidentally added in a previous PR. This is breaking deployed instances, as they're trying to use a `localhost` address.

This PR removes those settings.