### PR TITLE
feat: Add Data Protection Storage

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -36,7 +36,7 @@ jobs:
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-        dotnet-sonarscanner begin /k:"DFE-Digital_plan-technology-for-your-school" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+        dotnet-sonarscanner begin /k:"DFE-Digital_plan-technology-for-your-school" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.exlusions=src/**/Program.cs
         dotnet build "plan-technology-for-your-school.sln" --no-restore
-        dotnet-coverage collect "dotnet test plan-technology-for-your-school.sln /p:ExcludeByFile=\"src/**/program.cs\"" -f xml -o "coverage.xml" -s "coverage.settings.xml"
+        dotnet-coverage collect "dotnet test plan-technology-for-your-school.sln" -f xml -o "coverage.xml" -s "coverage.settings.xml"
         dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -38,5 +38,5 @@ jobs:
       run: |
         dotnet-sonarscanner begin /k:"DFE-Digital_plan-technology-for-your-school" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
         dotnet build "plan-technology-for-your-school.sln" --no-restore
-        dotnet-coverage collect "dotnet test plan-technology-for-your-school.sln /p:ExcludeByFile='**/program.cs'" -f xml -o "coverage.xml" -s "coverage.settings.xml
+        dotnet-coverage collect "dotnet test plan-technology-for-your-school.sln /p:ExcludeByFile=\"**/program.cs\"" -f xml -o "coverage.xml" -s "coverage.settings.xml"
         dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -36,7 +36,7 @@ jobs:
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-        dotnet-sonarscanner begin /k:"DFE-Digital_plan-technology-for-your-school" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.exlusions=src/**/Program.cs
+        dotnet-sonarscanner begin /k:"DFE-Digital_plan-technology-for-your-school" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.coverage.exclusions=src/**/Program.cs
         dotnet build "plan-technology-for-your-school.sln" --no-restore
         dotnet-coverage collect "dotnet test plan-technology-for-your-school.sln" -f xml -o "coverage.xml" -s "coverage.settings.xml"
         dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -38,5 +38,5 @@ jobs:
       run: |
         dotnet-sonarscanner begin /k:"DFE-Digital_plan-technology-for-your-school" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
         dotnet build "plan-technology-for-your-school.sln" --no-restore
-        dotnet-coverage collect "dotnet test plan-technology-for-your-school.sln /p:ExcludeByFile=\"**/program.cs\"" -f xml -o "coverage.xml" -s "coverage.settings.xml"
+        dotnet-coverage collect "dotnet test plan-technology-for-your-school.sln /p:ExcludeByFile=\"src/**/program.cs\"" -f xml -o "coverage.xml" -s "coverage.settings.xml"
         dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -38,5 +38,5 @@ jobs:
       run: |
         dotnet-sonarscanner begin /k:"DFE-Digital_plan-technology-for-your-school" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
         dotnet build "plan-technology-for-your-school.sln" --no-restore
-        dotnet-coverage collect "dotnet test plan-technology-for-your-school.sln" -f xml -o "coverage.xml" -s "coverage.settings.xml"
+        dotnet-coverage collect "dotnet test plan-technology-for-your-school.sln /p:ExcludeByFile='**/program.cs'" -f xml -o "coverage.xml" -s "coverage.settings.xml
         dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/terraform-pr-check.yml
+++ b/.github/workflows/terraform-pr-check.yml
@@ -1,6 +1,8 @@
 name: Terraform PR Check
 
-on: 
+on:
+  push:
+    branches: [ "main" ]
   pull_request:
     paths: 
       - 'terraform/**'

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230724_1439_CreateDataProtectionTable.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230724_1439_CreateDataProtectionTable.sql
@@ -1,8 +1,8 @@
 BEGIN TRAN
 
---Establishment Table--
+--DataProtectionKeys Table--
 CREATE TABLE [dbo].[DataProtectionKeys](
-	[Id] [int] PK IDENTITY(1,1) NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL,
 	[FriendlyName] [nvarchar](MAX) NULL,
 	[Xml] [nvarchar](MAX) NOT NULL
 )

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230724_1439_CreateDataProtectionTable.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230724_1439_CreateDataProtectionTable.sql
@@ -1,0 +1,10 @@
+BEGIN TRAN
+
+--Establishment Table--
+CREATE TABLE [dbo].[DataProtectionKeys](
+	[Id] [int] PK IDENTITY(1,1) NOT NULL,
+	[FriendlyName] [nvarchar](MAX) NULL,
+	[Xml] [nvarchar](MAX) NOT NULL
+)
+
+COMMIT TRAN

--- a/src/Dfe.PlanTech.Infrastructure.Data/DataProtectionDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/DataProtectionDbContext.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Dfe.PlanTech.Infrastructure.Data;
+
+[ExcludeFromCodeCoverage]
+public class DataProtectionDbContext : DbContext, IDataProtectionKeyContext
+{
+    public DataProtectionDbContext(DbContextOptions<DataProtectionDbContext> options) : base(options)
+    {
+    }
+
+    protected DataProtectionDbContext()
+    {
+    }
+
+    public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+}

--- a/src/Dfe.PlanTech.Infrastructure.Data/Dfe.PlanTech.Infrastructure.Data.csproj
+++ b/src/Dfe.PlanTech.Infrastructure.Data/Dfe.PlanTech.Infrastructure.Data.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="7.0.8" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.8" />

--- a/src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj
+++ b/src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj
@@ -22,9 +22,12 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
+      <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.2" />
       <PackageReference Include="Azure.Identity" Version="1.9.0" />
       <PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.0.0" />
       <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+      <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="7.0.8" />
+      <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="7.0.8" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.8" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.5" />

--- a/src/Dfe.PlanTech.Web/Program.cs
+++ b/src/Dfe.PlanTech.Web/Program.cs
@@ -35,6 +35,8 @@ builder.Services.AddAuthentication();
 
 var app = builder.Build();
 
+app.UseForwardedHeaders();
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
@@ -46,7 +48,6 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 
-app.UseForwardedHeaders();
 
 app.UseRouting();
 

--- a/src/Dfe.PlanTech.Web/Program.cs
+++ b/src/Dfe.PlanTech.Web/Program.cs
@@ -1,10 +1,13 @@
 using Azure.Identity;
 using Dfe.PlanTech.Application.Helpers;
-using Dfe.PlanTech.Web;
+using Dfe.PlanTech.Infrastructure.Data;
 using Dfe.PlanTech.Infrastructure.SignIn;
+using Dfe.PlanTech.Web;
 using Dfe.PlanTech.Web.Helpers;
 using Dfe.PlanTech.Web.Middleware;
 using GovUk.Frontend.AspNetCore;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,9 +20,15 @@ builder.Services.AddGovUkFrontend();
 
 if (builder.Environment.IsProduction())
 {
-    builder.Configuration.AddAzureKeyVault(
-    new Uri($"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/"),
-    new DefaultAzureCredential());
+    var keyVaultUri = $"https://{builder.Configuration["KeyVaultName"]}.vault.azure.net/";
+    var azureCredentials = new DefaultAzureCredential();
+
+    builder.Configuration.AddAzureKeyVault(new Uri(keyVaultUri), azureCredentials);
+
+    builder.Services.AddDbContext<DataProtectionDbContext>(options => options.UseSqlServer(builder.Configuration.GetConnectionString("Database")));
+    builder.Services.AddDataProtection()
+                        .PersistKeysToDbContext<DataProtectionDbContext>()
+                        .ProtectKeysWithAzureKeyVault(new Uri(keyVaultUri + "keys/dataprotection"), azureCredentials);
 }
 
 builder.Services.AddCaching();
@@ -47,7 +56,6 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();
-
 
 app.UseRouting();
 

--- a/terraform/key-vault.tf
+++ b/terraform/key-vault.tf
@@ -99,4 +99,10 @@ resource "azurerm_key_vault_key" "key" {
   key_type = var.key_type
   key_size = var.key_size
   key_opts = var.key_ops
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
 }

--- a/terraform/key-vault.tf
+++ b/terraform/key-vault.tf
@@ -81,7 +81,7 @@ resource "azurerm_key_vault_secret" "vault_secret_contentful_environment" {
 
 resource "azurerm_key_vault_secret" "vault_secret_database_connectionstring" {
   key_vault_id = azurerm_key_vault.vault.id
-  name         = "connectionstring--database"
+  name         = "connectionstrings--database"
   value        = local.az_sql_connection_string
   depends_on   = [azurerm_key_vault_access_policy.vault_access_policy_tf, null_resource.keyvault-add-vnet-restriction]
 

--- a/terraform/key-vault.tf
+++ b/terraform/key-vault.tf
@@ -99,10 +99,4 @@ resource "azurerm_key_vault_key" "key" {
   key_type = var.key_type
   key_size = var.key_size
   key_opts = var.key_ops
-
-  lifecycle {
-    ignore_changes = [
-      value,
-    ]
-  }
 }

--- a/terraform/key-vault.tf
+++ b/terraform/key-vault.tf
@@ -81,7 +81,7 @@ resource "azurerm_key_vault_secret" "vault_secret_contentful_environment" {
 
 resource "azurerm_key_vault_secret" "vault_secret_database_connectionstring" {
   key_vault_id = azurerm_key_vault.vault.id
-  name         = "database--connectionstring"
+  name         = "connectionstring--database"
   value        = local.az_sql_connection_string
   depends_on   = [azurerm_key_vault_access_policy.vault_access_policy_tf, null_resource.keyvault-add-vnet-restriction]
 
@@ -90,4 +90,13 @@ resource "azurerm_key_vault_secret" "vault_secret_database_connectionstring" {
       value,
     ]
   }
+}
+
+resource "azurerm_key_vault_key" "key" {
+  name         = "dataprotection"
+  key_vault_id = azurerm_key_vault.vault.id
+
+  key_type = var.key_type
+  key_size = var.key_size
+  key_opts = var.key_ops
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,3 +55,28 @@ variable "az_sql_admin_userid_postfix" {
   description = "Azure SQL admin userid postfix, used with `project_name` and `environment` to build userid"
   type        = string
 }
+
+############
+# KeyVault #
+############
+variable "key_type" {
+  description = "The JsonWebKeyType of the key to be created."
+  default     = "RSA"
+  type        = string
+  validation {
+    condition     = contains(["EC", "EC-HSM", "RSA", "RSA-HSM"], var.key_type)
+    error_message = "The key_type must be one of the following: EC, EC-HSM, RSA, RSA-HSM."
+  }
+}
+
+variable "key_ops" {
+  type        = list(string)
+  description = "The permitted JSON web key operations of the key to be created."
+  default     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+}
+
+variable "key_size" {
+  type        = number
+  description = "The size in bits of the key to be created."
+  default     = 2048
+}


### PR DESCRIPTION
Fixes 405 error - ticket [170087](https://dev.azure.com/dfe-ssp/s190-schools-technology-services/_sprints/taskboard/Plan%20Tech/s190-schools-technology-services/Plan%20Tech/Plan%20Tech%20sprint%207?workitem=170087)

- Adds storage of Data Protection keys in database
- Adds key for above in Azure Keyvault
- Updates Terraform to generate KV Key for above
- Adds `Program.cs` to coverage exclusions for SonarCloud