### PR TITLE
chore: SonarCloud workflow tweaks

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -10,7 +10,8 @@ on:
       - 'tests/**'
 
 jobs:
-  build:
+  sonar-cloud:
+    name: Run SonarCloud checks + coverage
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths: 
+      - 'src/**'
+      - 'tests/**'
 
 jobs:
   build:

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -16,10 +16,6 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 7.0.x
-    - name: Setup JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.11
     - name: Cache SonarCloud packages
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
- Rename job to be more descriptive
- Remove JDK step
- Add `path` restriction for PR