### PR TITLE
fix: Revert Docker port

### DIFF
--- a/src/Dfe.PlanTech.Web/Dockerfile
+++ b/src/Dfe.PlanTech.Web/Dockerfile
@@ -1,9 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /
-EXPOSE 80
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends libcap2-bin
-RUN apt-get clean
+EXPOSE 8080 
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /
@@ -16,6 +13,5 @@ WORKDIR /src
 RUN useradd -m dotnet
 COPY --from=build /out/publish .
 RUN chown dotnet:dotnet /src .
-RUN setcap CAP_NET_BIND_SERVICE=+ep ./Dfe.PlanTech.Web.dll
 USER dotnet
 ENTRYPOINT ["dotnet", "Dfe.PlanTech.Web.dll"]

--- a/src/Dfe.PlanTech.Web/appsettings.json
+++ b/src/Dfe.PlanTech.Web/appsettings.json
@@ -23,5 +23,12 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://*:8080"
+      }
+    }
   }
 }

--- a/terraform/main-hosting.tf
+++ b/terraform/main-hosting.tf
@@ -14,6 +14,7 @@ module "main_hosting" {
   #################
   enable_container_registry = true
   image_name                = local.container_app_image_name
+  container_port            = 8080
   container_secret_environment_variables = {
     "AZURE_CLIENT_ID" = azurerm_user_assigned_identity.user_assigned_identity.client_id,
     "KeyVaultName"    = local.kv_name


### PR DESCRIPTION
- Reverts Docker port back to 8080, due to port 80 still not working
- Adds port into Terraform