### PR TITLE
fix: Enable SQL "public" access

### DIFF
--- a/terraform/main-hosting.tf
+++ b/terraform/main-hosting.tf
@@ -34,8 +34,8 @@ module "main_hosting" {
   #############
   # Azure SQL #
   #############
-  enable_mssql_database       = true
-  mssql_database_name         = "${local.resource_prefix}-sqldb"
-  mssql_server_admin_password = local.az_sql_admin_password
+  enable_mssql_database              = true
+  mssql_database_name                = "${local.resource_prefix}-sqldb"
+  mssql_server_admin_password        = local.az_sql_admin_password
   mssql_server_public_access_enabled = true
 }

--- a/terraform/main-hosting.tf
+++ b/terraform/main-hosting.tf
@@ -1,5 +1,5 @@
 module "main_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.17.5"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.18.2"
 
   ###########
   # General #

--- a/terraform/main-hosting.tf
+++ b/terraform/main-hosting.tf
@@ -37,4 +37,5 @@ module "main_hosting" {
   enable_mssql_database       = true
   mssql_database_name         = "${local.resource_prefix}-sqldb"
   mssql_server_admin_password = local.az_sql_admin_password
+  mssql_server_public_access_enabled = true
 }

--- a/terraform/terraform-configuration.md
+++ b/terraform/terraform-configuration.md
@@ -14,14 +14,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.67.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.68.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_main_hosting"></a> [main\_hosting](#module\_main\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.17.5 |
+| <a name="module_main_hosting"></a> [main\_hosting](#module\_main\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.18.2 |
 
 ## Resources
 


### PR DESCRIPTION
- Enables public access to SQL Server, otherwise the DB Upgrader is unable to run.


Note: Public access is whitelist restricted anyway, so even when enabled by default no one can access it.