### PR TITLE
fix: Move error route to prevent duplicate routes

### DIFF
--- a/src/Dfe.PlanTech.Web/Controllers/BaseController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/BaseController.cs
@@ -12,11 +12,4 @@ public class BaseController<TConcreteController> : Controller
     {
         this.logger = logger;
     }
-
-    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-    [Route("/Error")]
-    public IActionResult Error()
-    {
-        return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
-    }
 }

--- a/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
@@ -1,4 +1,5 @@
-﻿using Dfe.PlanTech.Application.Content.Queries;
+﻿using System.Diagnostics;
+using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Web.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -38,6 +39,14 @@ public class PagesController : BaseController<PagesController>
         var viewModel = CreatePageModel(page, param);
 
         return View("Page", viewModel);
+    }
+
+
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    [Route("/error")]
+    public IActionResult Error()
+    {
+        return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
     }
 
     private PageViewModel CreatePageModel(Page page, string param = null!)

--- a/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
@@ -1,9 +1,9 @@
-﻿using System.Diagnostics;
-using Dfe.PlanTech.Application.Content.Queries;
+﻿using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics;
 
 namespace Dfe.PlanTech.Web.Controllers;
 

--- a/src/Dfe.PlanTech.Web/Views/Shared/Error.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Error.cshtml
@@ -12,14 +12,3 @@
         <strong>Request ID:</strong> <code>@Model?.RequestId</code>
     </p>
 }
-
-<h3>Development Mode</h3>
-<p>
-    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
-</p>
-<p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
-</p>

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/PagesControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/PagesControllerTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Persistence.Interfaces;

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/PagesControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/PagesControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
@@ -7,6 +8,7 @@ using Dfe.PlanTech.Infrastructure.Application.Models;
 using Dfe.PlanTech.Web.Controllers;
 using Dfe.PlanTech.Web.Helpers;
 using Dfe.PlanTech.Web.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -141,7 +143,29 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         [Fact]
         public async Task Should_ThrowError_When_NoRouteFound()
         {
-            await Assert.ThrowsAnyAsync<Exception>(() => _controller.GetByRoute("NOT A VALID ROUTE",_query, CancellationToken.None, It.IsAny<string>()));
+            await Assert.ThrowsAnyAsync<Exception>(() => _controller.GetByRoute("NOT A VALID ROUTE", _query, CancellationToken.None, It.IsAny<string>()));
         }
+
+        [Fact]
+        public void Should_Retrieve_ErrorPage()
+        {
+            var httpContextMock = new Mock<HttpContext>();
+
+            var controllerContext = new ControllerContext
+            {
+                HttpContext = httpContextMock.Object
+            };
+            
+            _controller.ControllerContext = controllerContext;
+
+            var result = _controller.Error();
+
+            var viewResult = result as ViewResult;
+
+            var model = viewResult!.Model;
+
+            Assert.IsType<ErrorViewModel>(model);
+        }
+
     }
 }


### PR DESCRIPTION
- Moves error page handling route from `BaseController` to `PagesController`
- Fixes issue where multiple routes of `/Error` were being registered as a result