### PR TITLE
feat: Fix E2E tests

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -165,3 +165,20 @@ jobs:
               --image ${{ secrets.AZ_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.release }} \
               --output none
             
+  run-tests:
+    name: Run E2E Tests
+    needs: [ set-env, deploy-image ]
+    runs-on: ubuntu-22.04
+    if: ${{ needs.set-env.outputs.environment }} == 'dev'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Cypress tests
+        uses: ./.github/actions/run-e2e-tests
+        with:
+          url: ${{ secrets.AZ_FRONTDOOR_URL }}
+          dsi_url: ${{ secrets.DSI_URL }}
+          dsi_username: ${{ secrets.DSI_USERNAME }}
+          dsi_password: ${{ secrets.DSI_PASSWORD }}

--- a/src/Dfe.PlanTech.DatabaseUpgrader/StoredProcs/20230810_110900_DeleteDataForEstablishmentSproc.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/StoredProcs/20230810_110900_DeleteDataForEstablishmentSproc.sql
@@ -1,0 +1,30 @@
+CREATE PROCEDURE [dbo].[deleteDataForEstablishment] @establishmentRef nvarchar(50)
+AS
+    BEGIN TRY
+        BEGIN TRAN
+
+            DECLARE @establishmentUID int
+            DECLARE @rowsDeletedCount int
+
+            SELECT @establishmentUID = id FROM [dbo].[establishment] WHERE establishmentRef = @establishmentRef
+
+            SELECT id, establishmentId
+                INTO #submissionIds
+                    FROM [dbo].[submission]
+                    WHERE [submission].establishmentId = @establishmentUID
+
+            DELETE FROM[dbo].[response]
+            WHERE EXISTS (SELECT *
+                            FROM #submissionIds
+                            where [response].submissionId = #submissionIds.id)
+
+            DELETE FROM [dbo].[submission] WHERE [submission].establishmentId = @establishmentUID
+
+        COMMIT TRAN
+
+        RETURN @@ROWCOUNT
+    END TRY
+    BEGIN CATCH
+	    ROLLBACK TRAN
+        RETURN 0
+    END CATCH

--- a/tests/Dfe.PlanTech.Web.E2ETests/.gitignore
+++ b/tests/Dfe.PlanTech.Web.E2ETests/.gitignore
@@ -1,1 +1,3 @@
 cypress.env.json
+screenshots/
+videos/

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress.config.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress.config.js
@@ -1,7 +1,11 @@
-module.exports = {
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  chromeWebSecurity: false,
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },
   },
-};
+})
+

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress.config.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress.config.js
@@ -2,6 +2,6 @@ module.exports = {
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here
-    }
+    },
   },
 };

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/login.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/login.js
@@ -1,20 +1,30 @@
-const SELF_ASSESSMENT_URL = Cypress.env("URL") + "/self-assessment";
-
-Cypress.Commands.add("login", (email, password, url) => {
-    cy.visit(Cypress.env("URL"));
-
+Cypress.Commands.add("login", ({ email, password, url }) => {
     cy.visit(url);
+    cy.get("input#username").type(email);
+    cy.get("input#password").type(password);
+    cy.get("div.govuk-button-group button.govuk-button").first().click();
 
-    cy.session([email, password, url], () => {
-        cy.origin(Cypress.env("DSiUrl"), { args: { email, password } },({ email, password }) => {
-            cy.get("input#username").type(email);
-            cy.get("input#password").type(password);
-            cy.get("div.govuk-button-group button.govuk-button").click();
-        });
-
-    }, {
-        cacheAcrossSpecs: true
+    cy.origin(Cypress.env("URL"), { args: { url } }, ({ url }) => {
+        cy.url().should("contain", url);
     });
 });
 
-Cypress.Commands.add("loginWithEnv", (url) => cy.login(Cypress.env("Username"), Cypress.env("Password"), url));
+Cypress.Commands.add("loginWithEnv", (url) => {
+    const args = {
+        email: Cypress.env("Username"),
+        password: Cypress.env("Password"),
+        url
+    };
+
+    cy.session(
+        args.email,
+        () => {
+            cy.login(args);
+        },
+        {
+            cacheAcrossSpecs: true,
+        }
+    )
+
+    cy.visit(url);
+});

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/login.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/login.js
@@ -11,8 +11,8 @@ Cypress.Commands.add("login", ({ email, password, url }) => {
 
 Cypress.Commands.add("loginWithEnv", (url) => {
     const args = {
-        email: Cypress.env("Username"),
-        password: Cypress.env("Password"),
+        email: Cypress.env("DSi_Email"),
+        password: Cypress.env("DSi_Password"),
         url
     };
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/login.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/login.js
@@ -1,8 +1,20 @@
+const SELF_ASSESSMENT_URL = Cypress.env("URL") + "/self-assessment";
+
 Cypress.Commands.add("login", (email, password, url) => {
+    cy.visit(Cypress.env("URL"));
+
     cy.visit(url);
-    cy.get("input#username").type(email);
-    cy.get("input#password").type(password);
-    cy.get("div.govuk-button-group button.govuk-button").first().click();
+
+    cy.session([email, password, url], () => {
+        cy.origin(Cypress.env("DSiUrl"), { args: { email, password } },({ email, password }) => {
+            cy.get("input#username").type(email);
+            cy.get("input#password").type(password);
+            cy.get("div.govuk-button-group button.govuk-button").click();
+        });
+
+    }, {
+        cacheAcrossSpecs: true
+    });
 });
 
 Cypress.Commands.add("loginWithEnv", (url) => cy.login(Cypress.env("Username"), Cypress.env("Password"), url));

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/self-assessment-page.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/self-assessment-page.js
@@ -1,0 +1,11 @@
+/**
+ * Click first section link on self-assessment page
+ */
+const clickFirstSection = () => {
+    cy.get("ul.app-task-list__items > li a")
+        .first()
+        .click();
+}
+
+Cypress.Commands.add("clickFirstSection", () => clickFirstSection());
+

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/self-assessment-page.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/self-assessment-page.js
@@ -1,7 +1,7 @@
 /**
  * Click first section link on self-assessment page
  */
-const clickFirstSection = () => {
+export const clickFirstSection = () => {
     cy.get("ul.app-task-list__items > li a")
         .first()
         .click();

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/components/beta-header.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/components/beta-header.cy.js
@@ -1,12 +1,10 @@
 describe("beta header", () => {
-  const url = Cypress.env("/");
-
   const expectedFeedbackLink = "https://feedback";
 
   const phaseBannerSelector = "div.govuk-phase-banner";
 
   beforeEach(() => {
-    cy.visit(url);
+    cy.visit("/");
   });
 
   it("displays phase banner", () => {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/components/beta-header.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/components/beta-header.cy.js
@@ -1,5 +1,5 @@
 describe("beta header", () => {
-  const url = Cypress.env("URL");
+  const url = Cypress.env("/");
 
   const expectedFeedbackLink = "https://feedback";
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/components/dropdown.cy.old.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/components/dropdown.cy.old.js
@@ -1,7 +1,7 @@
 const PARENT_SELECTOR = "details.govuk-details";
 
 describe("dropdown", () => {
-  const url = Cypress.env("URL");
+  const url = Cypress.env("/");
 
   beforeEach(() => {
     cy.visit(url);

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
@@ -1,8 +1,9 @@
 describe("landing page", () => {
-    const url = "/broadband-connection";
+    const url = "/self-assessment";
 
     beforeEach(() => {
         cy.loginWithEnv(url);
+        cy.clickFirstSection();
     });
 
     it("should have content", () => {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
@@ -1,6 +1,5 @@
 describe("landing page", () => {
-    const url = Cypress.env("URL") + "/broadband-connection";
-    const selfassessmentUrl = Cypress.env("URL") + "/self-assessment";
+    const url = "/broadband-connection";
 
     beforeEach(() => {
         cy.loginWithEnv(url);

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
@@ -1,10 +1,12 @@
-describe("landing page", () => {
-    const url = "/self-assessment";
+
+describe("Interstitial page", () => {
+    const url = "/broadband-connection";
 
     beforeEach(() => {
-        cy.loginWithEnv(url);
-        cy.clickFirstSection();
-    });
+        cy.loginWithEnv("/self-assessment");
+        cy.get("ul.app-task-list__items > li a").first().click();
+        cy.url().should("contain", url);
+      });
 
     it("should have content", () => {
         cy.get("rich-text").should("exist");

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
@@ -15,8 +15,6 @@ describe("landing page", () => {
     });
 
     it("should link back to self-assessment", () => {
-        cy.get("ul.app-task-list__items  a").first().click();
-
         cy.get("a.govuk-back-link").should("exist");
         cy.get("a.govuk-back-link").should("have.attr", "href").and("include", "self-assessment");
     });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
@@ -2,32 +2,23 @@ describe("landing page", () => {
     const url = Cypress.env("URL") + "/broadband-connection";
     const selfassessmentUrl = Cypress.env("URL") + "/self-assessment";
 
-    it("should have content", () => {
+    beforeEach(() => {
         cy.loginWithEnv(url);
+    });
 
-        cy.origin(Cypress.env("URL"), () => {
-            cy.get("rich-text").should("exist");
-        });
+    it("should have content", () => {
+        cy.get("rich-text").should("exist");
     });
 
     it("should have button which links to a question", () => {
-        cy.loginWithEnv(url);
-
-        cy.origin(Cypress.env("URL"), () => {
-            cy.get("a.govuk-button.govuk-link").should("exist");
-            cy.get("a.govuk-button.govuk-link").should("have.attr", "href").and("include", "question");
-        });
+        cy.get("a.govuk-button.govuk-link").should("exist");
+        cy.get("a.govuk-button.govuk-link").should("have.attr", "href").and("include", "question");
     });
 
     it("should link back to self-assessment", () => {
-        cy.loginWithEnv(selfassessmentUrl);
+        cy.get("ul.app-task-list__items  a").first().click();
 
-        cy.origin(Cypress.env("URL"), () => {
-
-            cy.get("ul.app-task-list__items  a").first().click();
-
-            cy.get("a.govuk-back-link").should("exist");
-            cy.get("a.govuk-back-link").should("have.attr", "href").and("include", "self-assessment");
-        });
+        cy.get("a.govuk-back-link").should("exist");
+        cy.get("a.govuk-back-link").should("have.attr", "href").and("include", "self-assessment");
     });
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
@@ -33,12 +33,13 @@ describe("landing page", () => {
 
   it("should re-direct to login page", () => {
     cy.get("a.govuk-button--start.govuk-button").click();
-
-    cy.location("href").should("be.null");
-
-    const expectedUrl = Cypress.env("DSiUrl");
+    const dsiUrl = Cypress.env("DSiUrl");
     
-    cy.origin(expectedUrl, { args: { expectedUrl } }, ({ expectedUrl }) => {
+    cy.origin(dsiUrl, {
+      args: {
+        expectedUrl: dsiUrl
+      }
+    }, ({expectedUrl}) => {
       cy.location("href").should("include", expectedUrl);
     });
   });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
@@ -1,8 +1,6 @@
 describe("landing page", () => {
-  const url = "/";
-
   beforeEach(() => {
-    cy.visit(url);
+    cy.visit("/");
   });
 
   it("should contain title", () => {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
@@ -29,16 +29,9 @@ describe("landing page", () => {
     cy.get("a.govuk-button--start.govuk-button").should("exist");
   });
 
-  it("should re-direct to login page", () => {
-    cy.get("a.govuk-button--start.govuk-button").click();
-    const dsiUrl = Cypress.env("DSiUrl");
-    
-    cy.origin(dsiUrl, {
-      args: {
-        expectedUrl: dsiUrl
-      }
-    }, ({expectedUrl}) => {
-      cy.location("href").should("include", expectedUrl);
-    });
+  it("should direct to self-assessment page", () => {
+    cy.get("a.govuk-button--start.govuk-button")
+      .and("have.attr", "href")
+      .and("equal", "/self-assessment");
   });
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
@@ -1,5 +1,5 @@
 describe("landing page", () => {
-  const url = Cypress.env("URL");
+  const url = "/";
 
   beforeEach(() => {
     cy.visit(url);

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
@@ -3,7 +3,7 @@ describe("landing page", () => {
 
   beforeEach(() => {
     cy.loginWithEnv(url);
-    cy.get("ul.app-task-list__items > li a").first().click();
+    cy.clickFirstSection();
     cy.get('a.govuk-button').contains('Continue').click();
   });
 
@@ -37,45 +37,49 @@ describe("landing page", () => {
   });
 
   it("should navigate to next page on submit", () => {
-    const path = cy.location("pathname");
+    cy.url().then(firstUrl => {
+      
+      cy.get("form div.govuk-radios div.govuk-radios__item input")
+        .first()
+        .click();
 
-    cy.get("form div.govuk-radios div.govuk-radios__item input")
-      .first()
-      .click();
+      cy.get("form button.govuk-button")
+        .contains("Save and continue")
+        .click();
 
-    cy.get("form button.govuk-button")
-      .contains("Save and continue")
-      .click();
-
-    cy.location("pathname", { timeout: 60000 })
-      .should("not.include", path)
-      .and("include", "/question");
+      cy.location("pathname", { timeout: 60000 })
+        .should("not.include", firstUrl)
+        .and("include", "/question");
+    });
   });
 
   it("should have back button", () => {
     cy.get("a.govuk-back-link")
-      .should("exist")
-      .invoke("text")
-      .should("equal", "Back");
+      .contains("Back")
+      .should("exist");
   });
 
   it("should have back button that navigates to last question once submitted", () => {
-    const FIRST_QUESTION = "question"; //TODO;
-    
-    cy.get("form div.govuk-radios div.govuk-radios__item input")
-      .first()
-      .click();
+    cy.url().then(firstUrl => {
+      //Select first radio button
+      cy.get("form div.govuk-radios div.govuk-radios__item input")
+        .first()
+        .click();
 
-    cy.get("form button.govuk-button").click();
+      //Submit
+      cy.get("form button.govuk-button")
+        .contains("Save and continue")
+        .click();
 
-    cy.location("pathname", { timeout: 60000 })
-      .should("not.include", FIRST_QUESTION)
-      .and("include", "/question");
+      //Ensure path changes
+      cy.location("pathname", { timeout: 60000 })
+        .should("not.equal", firstUrl)
+        .and("match", /question|check-answers/g)
 
-    cy.get("a.govuk-back-link")
-      .should("exist")
-      .and("have.attr", "href")
-      .and("include", FIRST_QUESTION);
+      cy.get("a.govuk-back-link")
+        .should("exist")
+        .and("have.attr", "href")
+        .and("include", firstUrl);
+    });
   });
-
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
@@ -1,10 +1,12 @@
 describe("landing page", () => {
-  const FIRST_QUESTION = "/question/6Z9tFZQmLhiMNDe2IA5qYE";
-
-  const url = Cypress.env("URL") + FIRST_QUESTION;
+  const url = Cypress.env("URL") + "/self-assessment";
 
   beforeEach(() => {
     cy.loginWithEnv(url);
+    cy.origin(Cypress.env("URL"), () => {
+      cy.get("ul.app-task-list__items > li a").first().click();
+      cy.get('a.govuk-button').contains('Continue').click();
+    });
   });
 
   it("should contain form", () => {
@@ -45,16 +47,20 @@ describe("landing page", () => {
   });
 
   it("should navigate to next page on submit", () => {
-    cy.origin(Cypress.env("URL"), { args: { FIRST_QUESTION } }, ({ FIRST_QUESTION }) => {
+    cy.origin(Cypress.env("URL"), () => {
+
+      const path = cy.location("pathname");
 
       cy.get("form div.govuk-radios div.govuk-radios__item input")
         .first()
         .click();
 
-      cy.get("form button.govuk-button").click();
+      cy.get("form button.govuk-button")
+        .contains("Save and continue")
+        .click();
 
       cy.location("pathname", { timeout: 60000 })
-        .should("not.include", FIRST_QUESTION)
+        .should("not.include", path)
         .and("include", "/question");
     });
   });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
@@ -2,8 +2,7 @@ describe("Question page", () => {
   const url = "/self-assessment";
 
   beforeEach(() => {
-    cy.loginWithEnv();
-    cy.visit(url);
+    cy.loginWithEnv(url);
 
     //Navigate to first section
     cy.get("ul.app-task-list__items > li a")

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
@@ -1,22 +1,22 @@
 describe("landing page", () => {
-  const url = Cypress.env("URL") + "/self-assessment";
+  const url = Cypress.env("/") + "/self-assessment";
 
   beforeEach(() => {
     cy.loginWithEnv(url);
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
       cy.get("ul.app-task-list__items > li a").first().click();
       cy.get('a.govuk-button').contains('Continue').click();
     });
   });
 
   it("should contain form", () => {
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
       cy.get("form").should("exist");
     });
   });
 
   it("should contain heading", () => {
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
       cy.get("form h1.govuk-fieldset__heading").should("exist");
 
       cy.get("form h1.govuk-fieldset__heading")
@@ -26,7 +26,7 @@ describe("landing page", () => {
   });
 
   it("should contain answers", () => {
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
       cy.get("form div.govuk-radios div.govuk-radios__item")
         .should("exist")
         .and("have.length.greaterThan", 1)
@@ -41,13 +41,13 @@ describe("landing page", () => {
   });
 
   it("should have submit button", () => {
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
       cy.get("form button.govuk-button").should("exist");
     });
   });
 
   it("should navigate to next page on submit", () => {
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
 
       const path = cy.location("pathname");
 
@@ -66,7 +66,7 @@ describe("landing page", () => {
   });
 
   it("should have back button", () => {
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
       cy.get("a.govuk-back-link")
         .should("exist")
         .invoke("text")
@@ -75,7 +75,7 @@ describe("landing page", () => {
   });
 
   it("should have back button that navigates to last question once submitted", () => {
-    cy.origin(Cypress.env("URL"), { args: { FIRST_QUESTION } }, ({ FIRST_QUESTION }) => {
+    cy.origin(Cypress.env("/"), { args: { FIRST_QUESTION } }, ({ FIRST_QUESTION }) => {
       cy.get("form div.govuk-radios div.govuk-radios__item input")
         .first()
         .click();

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
@@ -1,96 +1,81 @@
 describe("landing page", () => {
-  const url = Cypress.env("/") + "/self-assessment";
+  const url = "/self-assessment";
 
   beforeEach(() => {
     cy.loginWithEnv(url);
-    cy.origin(Cypress.env("/"), () => {
-      cy.get("ul.app-task-list__items > li a").first().click();
-      cy.get('a.govuk-button').contains('Continue').click();
-    });
+    cy.get("ul.app-task-list__items > li a").first().click();
+    cy.get('a.govuk-button').contains('Continue').click();
   });
 
   it("should contain form", () => {
-    cy.origin(Cypress.env("/"), () => {
-      cy.get("form").should("exist");
-    });
+    cy.get("form").should("exist");
   });
 
   it("should contain heading", () => {
-    cy.origin(Cypress.env("/"), () => {
-      cy.get("form h1.govuk-fieldset__heading").should("exist");
+    cy.get("form h1.govuk-fieldset__heading").should("exist");
 
-      cy.get("form h1.govuk-fieldset__heading")
-        .invoke("text")
-        .should("have.length.greaterThan", 1);
-    });
+    cy.get("form h1.govuk-fieldset__heading")
+      .invoke("text")
+      .should("have.length.greaterThan", 1);
   });
 
   it("should contain answers", () => {
-    cy.origin(Cypress.env("/"), () => {
-      cy.get("form div.govuk-radios div.govuk-radios__item")
-        .should("exist")
-        .and("have.length.greaterThan", 1)
-        .each((item) => {
-          cy.wrap(item)
-            .get("label")
-            .should("exist")
-            .invoke("text")
-            .should("have.length.greaterThan", 1);
-        });
-    });
+    cy.get("form div.govuk-radios div.govuk-radios__item")
+      .should("exist")
+      .and("have.length.greaterThan", 1)
+      .each((item) => {
+        cy.wrap(item)
+          .get("label")
+          .should("exist")
+          .invoke("text")
+          .should("have.length.greaterThan", 1);
+      });
   });
 
   it("should have submit button", () => {
-    cy.origin(Cypress.env("/"), () => {
-      cy.get("form button.govuk-button").should("exist");
-    });
+    cy.get("form button.govuk-button").should("exist");
   });
 
   it("should navigate to next page on submit", () => {
-    cy.origin(Cypress.env("/"), () => {
+    const path = cy.location("pathname");
 
-      const path = cy.location("pathname");
+    cy.get("form div.govuk-radios div.govuk-radios__item input")
+      .first()
+      .click();
 
-      cy.get("form div.govuk-radios div.govuk-radios__item input")
-        .first()
-        .click();
+    cy.get("form button.govuk-button")
+      .contains("Save and continue")
+      .click();
 
-      cy.get("form button.govuk-button")
-        .contains("Save and continue")
-        .click();
-
-      cy.location("pathname", { timeout: 60000 })
-        .should("not.include", path)
-        .and("include", "/question");
-    });
+    cy.location("pathname", { timeout: 60000 })
+      .should("not.include", path)
+      .and("include", "/question");
   });
 
   it("should have back button", () => {
-    cy.origin(Cypress.env("/"), () => {
-      cy.get("a.govuk-back-link")
-        .should("exist")
-        .invoke("text")
-        .should("equal", "Back");
-    });
+    cy.get("a.govuk-back-link")
+      .should("exist")
+      .invoke("text")
+      .should("equal", "Back");
   });
 
   it("should have back button that navigates to last question once submitted", () => {
-    cy.origin(Cypress.env("/"), { args: { FIRST_QUESTION } }, ({ FIRST_QUESTION }) => {
-      cy.get("form div.govuk-radios div.govuk-radios__item input")
-        .first()
-        .click();
+    const FIRST_QUESTION = "question"; //TODO;
+    
+    cy.get("form div.govuk-radios div.govuk-radios__item input")
+      .first()
+      .click();
 
-      cy.get("form button.govuk-button").click();
+    cy.get("form button.govuk-button").click();
 
-      cy.location("pathname", { timeout: 60000 })
-        .should("not.include", FIRST_QUESTION)
-        .and("include", "/question");
+    cy.location("pathname", { timeout: 60000 })
+      .should("not.include", FIRST_QUESTION)
+      .and("include", "/question");
 
-      cy.get("a.govuk-back-link")
-        .should("exist")
-        .and("have.attr", "href")
-        .and("include", FIRST_QUESTION);
-    });
+    cy.get("a.govuk-back-link")
+      .should("exist")
+      .and("have.attr", "href")
+      .and("include", FIRST_QUESTION);
   });
 
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
@@ -1,9 +1,16 @@
-describe("landing page", () => {
+describe("Question page", () => {
   const url = "/self-assessment";
 
   beforeEach(() => {
-    cy.loginWithEnv(url);
-    cy.clickFirstSection();
+    cy.loginWithEnv();
+    cy.visit(url);
+
+    //Navigate to first section
+    cy.get("ul.app-task-list__items > li a")
+      .first()
+      .click();
+
+    //Navigate to first question
     cy.get('a.govuk-button').contains('Continue').click();
   });
 
@@ -38,7 +45,7 @@ describe("landing page", () => {
 
   it("should navigate to next page on submit", () => {
     cy.url().then(firstUrl => {
-      
+
       cy.get("form div.govuk-radios div.govuk-radios__item input")
         .first()
         .click();

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
@@ -1,12 +1,12 @@
 describe("landing page", () => {
-  const url = Cypress.env("URL") + "/self-assessment";
+  const url = Cypress.env("/") + "/self-assessment";
 
   beforeEach(() => {
     cy.loginWithEnv(url);
   });
 
   it("should have heading", () => {
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
       cy.get("h1.govuk-heading-xl")
         .should("exist")
         .and("have.text", "Technology self-assessment");
@@ -14,13 +14,13 @@ describe("landing page", () => {
   });
 
   it("should contain categories", () => {
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
       cy.get("h2.govuk-heading-m").should("exist");
     });
   });
 
   it("should contain sections", () => {
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
       cy.get("ul.app-task-list__items > li")
         .should("exist")
         .and("have.length.greaterThan", 1);
@@ -28,7 +28,7 @@ describe("landing page", () => {
   });
 
   it("each section should link to a page", () => {
-    cy.origin(Cypress.env("URL"), () => {
+    cy.origin(Cypress.env("/"), () => {
       cy.get("ul.app-task-list__items > li a").each((link) => {
         cy.wrap(link)
           .should("have.attr", "href")

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
@@ -1,39 +1,31 @@
 describe("landing page", () => {
-  const url = Cypress.env("/") + "/self-assessment";
+  const url = "/self-assessment";
 
   beforeEach(() => {
     cy.loginWithEnv(url);
   });
 
   it("should have heading", () => {
-    cy.origin(Cypress.env("/"), () => {
-      cy.get("h1.govuk-heading-xl")
-        .should("exist")
-        .and("have.text", "Technology self-assessment");
-    });
+    cy.get("h1.govuk-heading-xl")
+      .should("exist")
+      .and("have.text", "Technology self-assessment");
   });
 
   it("should contain categories", () => {
-    cy.origin(Cypress.env("/"), () => {
-      cy.get("h2.govuk-heading-m").should("exist");
-    });
+    cy.get("h2.govuk-heading-m").should("exist");
   });
 
   it("should contain sections", () => {
-    cy.origin(Cypress.env("/"), () => {
-      cy.get("ul.app-task-list__items > li")
-        .should("exist")
-        .and("have.length.greaterThan", 1);
-    });
+    cy.get("ul.app-task-list__items > li")
+      .should("exist")
+      .and("have.length.greaterThan", 1);
   });
 
   it("each section should link to a page", () => {
-    cy.origin(Cypress.env("/"), () => {
-      cy.get("ul.app-task-list__items > li a").each((link) => {
-        cy.wrap(link)
-          .should("have.attr", "href")
-          .and("not.be.null");
-      });
+    cy.get("ul.app-task-list__items > li a").each((link) => {
+      cy.wrap(link)
+        .should("have.attr", "href")
+        .and("not.be.null");
     });
   });
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
@@ -2,7 +2,7 @@ describe("Self-assessment page", () => {
   const url = "/self-assessment";
 
   beforeEach(() => {
-    cy.loginWithEnv();
+    cy.loginWithEnv(url);
 });
 
   it("should have heading", () => {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
@@ -1,9 +1,9 @@
-describe("landing page", () => {
+describe("Self-assessment page", () => {
   const url = "/self-assessment";
 
   beforeEach(() => {
-    cy.loginWithEnv(url);
-  });
+    cy.loginWithEnv();
+});
 
   it("should have heading", () => {
     cy.get("h1.govuk-heading-xl")

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/support/commands.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/support/commands.js
@@ -1,1 +1,2 @@
 import "../commands/login";
+import "../commands/self-assessment-page";

--- a/tests/Dfe.PlanTech.Web.E2ETests/package-lock.json
+++ b/tests/Dfe.PlanTech.Web.E2ETests/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.13.0"
+        "cypress": "^12.17.3"
       }
     },
     "node_modules/@colors/colors": {
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.18.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.47.tgz",
-      "integrity": "sha512-OuJi8bIng4wYHHA3YpKauL58dZrPxro3d0tabPHyiNF8rKfGKuVfr83oFlPLmKri1cX+Z3cJP39GXmnqkP11Gw==",
+      "version": "16.18.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.40.tgz",
+      "integrity": "sha512-+yno3ItTEwGxXiS/75Q/aHaa5srkpnJaH+kdkTVJ3DtJEwv92itpKbxU+FjPoh2m/5G9zmUQfrL4A4C13c+iGA==",
       "dev": true
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -545,15 +545,15 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.13.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.13.0.tgz",
-      "integrity": "sha512-QJlSmdPk+53Zhy69woJMySZQJoWfEWun3X5OOenGsXjRPVfByVTHorxNehbzhZrEzH9RDUDqVcck0ahtlS+N/Q==",
+      "version": "12.17.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.3.tgz",
+      "integrity": "sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^2.88.11",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -588,7 +588,7 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
@@ -1615,9 +1615,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"

--- a/tests/Dfe.PlanTech.Web.E2ETests/package.json
+++ b/tests/Dfe.PlanTech.Web.E2ETests/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cypress": "^12.13.0"
+    "cypress": "^12.17.3"
   }
 }


### PR DESCRIPTION
- Fixes E2E tests that were no longer working properly
- Adds SQL stored procedure that deletes all `responses` and `submissions` for a given `establishmentRef`

**To come in another PR**:
- Add E2E testing to a workflow
- Before E2E testing is ran, call the SP mentioned above