### PR TITLE
feat: Amend code PR check to only trigger on changes to src or tests

### DIFF
--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -3,14 +3,14 @@ name: Code PR Check
 on:
   push:
     branches: [ "main" ]
-    paths-ignore:
-      - 'docs/**'
-      - 'terraform/**'
+    paths:
+      - 'src/**'
+      - 'tests/**'
   pull_request:
     branches: [ "main" ]
-    paths-ignore:
-      - 'docs/**'
-      - 'terraform/**'
+    paths:
+      - 'src/**'
+      - 'tests/**'
 
 env:
   DOTNET_VERSION: ${{ vars.DOTNET_VERSION }}


### PR DESCRIPTION
Amends the triggers on the `code-pr-check.yml` workflow to only trigger when changes have been made in the `src` or `tests` folder.