### PR TITLE
cicd: Restrict deployments to code changes

### DIFF
--- a/.github/workflows/matrix-deploy.yml
+++ b/.github/workflows/matrix-deploy.yml
@@ -11,7 +11,8 @@ on:
           - Production
   push:
     branches: [ "main" ]
-  
+    paths:
+      - 'src/**'
 
 jobs:
   deploy-to-environments:


### PR DESCRIPTION
- Limits app deployments to code changes only. Prevents having a ton of deployments when there have been 0 actual changes to deploy.