### PR TITLE
feat: add axe tools to cypress

### DIFF
--- a/docs/adr/0027-accesibility-testing.md
+++ b/docs/adr/0027-accesibility-testing.md
@@ -1,0 +1,32 @@
+# 0026 - Accessibility Testing
+
+* **Status**: accepted
+
+## Context and Problem Statement
+
+How do we best test the website for accessibility issues?
+
+## Decision Drivers
+
+* Ease of testing
+* Reliability
+* Existing DFE usage
+
+## Considered Options
+
+### Manual Testing
+
+We could manually test the website, using tools such as [axe](https://www.deque.com/axe/), which is recommended by the Government & DFE.
+
+### Automation Testing
+
+We could automate the website testing in our end-to-end tests.
+
+## Decision Outcome
+
+We are using [cypress-axe](https://www.npmjs.com/package/cypress-axe) in our workflow for accessibility testing, and manual testing can be done seperately as/where needed.
+
+This is a great fit for us given that:
+1. We are already using Cypress
+2. It is easy to test each page using the tool
+3. Existing DFE projects use this solution

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,7 +11,7 @@ General information about architectural decision records is available at <https:
 ## List
 
 | Title                                                                                                       | Status   |
-|-------------------------------------------------------------------------------------------------------------|----------|
+| ----------------------------------------------------------------------------------------------------------- | -------- |
 | [0001 - Web Framework](./0001-web-framework.md)                                                             | Accepted |
 | [0002 - Application Framework](./0002-application-framework.md)                                             | Accepted |
 | [0003 - Build/Test/Deploy Environment](./0002-application-framework.md)                                     | Accepted |
@@ -37,4 +37,4 @@ General information about architectural decision records is available at <https:
 | [0023 - Executing Terraform Within GitHub Workflows](./0023-executing-terraform-within-github-workflows.md) | Proposed |
 | [0024 - Caching](./0024-caching.md)                                                                         | Proposed |
 | [0025 - Hybrid Matrix Deployments](./0025-hybrid-matrix-deployments.md)                                     | Accepted |
-
+| [0027 - Accesibility Testing](./0027-accesibility-testing.md)                                               | Accepted |

--- a/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
@@ -59,6 +59,8 @@ public class PagesController : BaseController<PagesController>
         string gtmHead = acceptCookies ?  Config.GetValue<string>("GTM:Head") ?? "" : "";
         string gtmBody = acceptCookies ?  Config.GetValue<string>("GTM:Body") ?? "" : "";
 
+        ViewData["Title"] = page.Title?.Text ?? "Plan Technology For Your School";
+
         return new PageViewModel()
         {
             Page = page,

--- a/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
@@ -7,6 +7,21 @@
 
 @{
     Layout = "_GovUkPageTemplate";
+
+    if(ViewData["Title"] == null){
+        var routeData = Context.GetRouteData();
+        var lastSlug = routeData.Values.Values.Last()?.ToString(); 
+        if(lastSlug != null && lastSlug.Any(c => Char.IsNumber(c))){
+            lastSlug = routeData.Values.Values.SkipLast(1).Last()?.ToString(); 
+        }
+
+        if(lastSlug != null){
+            //Add white space before every capital letter
+            lastSlug = string.Concat(lastSlug.Select(c => Char.IsUpper(c) ? " " + c : c.ToString())).TrimStart(' ');
+        }
+
+        ViewData["Title"] = lastSlug?.ToString() ?? "Plan Technology For Your School";
+    }
 }
 
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/README.md
+++ b/tests/Dfe.PlanTech.Web.E2ETests/README.md
@@ -11,13 +11,18 @@ Created using [Cypress](https://cypress.io)
 1. Copy the `cypress.env.json.example` file and rename it to `cypress.env.json` in the root of the `Dfe.PlanTech.Web.E2ETests` folder
 2. Populate the variables within it
 3. Install the necessary packages by running `npm install`
-4. Run Cypress by running `npx cypress open`
+4. Run Cypress by running `npx cypress open --config "baseUrl=URL"` where URL is the same as in the variables mentioned below
+
 
 ### Variables
 
-| Name     | Description                                  |
-| -------- | -------------------------------------------- |
-| URL      | URL to run tests on (e.g. www.plan-tech.com) |
-| DSiUrl   | URL for DFE Sign-in Interactions             |
-| Username | DFE Sign-in Username                         |
-| Password | DFE Sign-in Password                         |
+| Name         | Description                                  |
+| ------------ | -------------------------------------------- |
+| URL          | URL to run tests on (e.g. www.plan-tech.com) |
+| DSi_Url      | URL for DFE Sign-in Interactions             |
+| DSi_Email    | DFE Sign-in Username                         |
+| DSi_Password | DFE Sign-in Password                         |
+
+## Packages Used
+
+- [Cypress-Axe]() - Used for accessibility testing

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress.config.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress.config.js
@@ -4,8 +4,18 @@ module.exports = defineConfig({
   chromeWebSecurity: false,
   e2e: {
     setupNodeEvents(on, config) {
-      // implement node event listeners here
+      on('task', {
+        log(message) {
+          console.log(message)
+
+          return null
+        },
+        table(message) {
+          console.table(message)
+
+          return null
+        }
+      })
     },
   },
 })
-

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress.env.json.example
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress.env.json.example
@@ -1,6 +1,6 @@
 {
     "URL": "URL_VALUE",
-    "DSiUrl": "DSI_URL",
-    "Username": "DSI_USERNAME",
-    "Password": "DSI_PASSWORD"
+    "DSi_Url": "DSI_URL",
+    "DSi_Email": "DSI_USERNAME",
+    "DSi_Password": "DSI_PASSWORD"
 }

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/axe-tools.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/axe-tools.js
@@ -1,5 +1,8 @@
-//Logs specific accessibilty violations to console as table
-//Stolen from their documentation: https://github.com/component-driven/cypress-axe
+/**
+ * Logs specific accessibilty violations to console as table
+ * Stolen from their documentation: https://github.com/component-driven/cypress-axe
+ * @param {*} violations Violated accessibility rules
+ */
 export function terminalLog(violations) {
   cy.task(
     'log',
@@ -19,7 +22,11 @@ export function terminalLog(violations) {
   cy.task('table', violationData)
 }
 
-
+/**
+ * Wrapper around the cy.checkA11y command (i.e. the command to run axe tests)
+ * That adds default ignore rules, and outputs the failed accessibility rules via
+ * terminalLog method
+ */
 Cypress.Commands.add("runAxe", () => {
   cy.checkA11y(null, {
     rules: {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/axe-tools.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/axe-tools.js
@@ -27,5 +27,5 @@ Cypress.Commands.add("runAxe", () => {
       //Related to back button being outside of main + header tags, but this is based on GDS guidelines
       'region': { enabled: false },
     },
-  }, terminalLog);
+  }, terminalLog, true);
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/axe-tools.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/axe-tools.js
@@ -27,5 +27,5 @@ Cypress.Commands.add("runAxe", () => {
       //Related to back button being outside of main + header tags, but this is based on GDS guidelines
       'region': { enabled: false },
     },
-  }, terminalLog, true);
+  }, terminalLog);
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/axe-tools.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/axe-tools.js
@@ -1,0 +1,31 @@
+//Logs specific accessibilty violations to console as table
+//Stolen from their documentation: https://github.com/component-driven/cypress-axe
+export function terminalLog(violations) {
+  cy.task(
+    'log',
+    `${violations.length} accessibility violation${violations.length === 1 ? '' : 's'
+    } ${violations.length === 1 ? 'was' : 'were'} detected`
+  )
+
+  const violationData = violations.map(
+    ({ id, impact, description, nodes }) => ({
+      id,
+      impact,
+      description,
+      nodes: nodes.length
+    })
+  )
+
+  cy.task('table', violationData)
+}
+
+
+Cypress.Commands.add("runAxe", () => {
+  cy.checkA11y(null, {
+    rules: {
+      //Ignore warning about region
+      //Related to back button being outside of main + header tags, but this is based on GDS guidelines
+      'region': { enabled: false },
+    },
+  }, terminalLog);
+});

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/login.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/login.js
@@ -1,3 +1,6 @@
+/**
+ * Login to DFE
+ */
 Cypress.Commands.add("login", ({ email, password, url }) => {
     cy.visit(url);
     cy.get("input#username").type(email);
@@ -9,6 +12,9 @@ Cypress.Commands.add("login", ({ email, password, url }) => {
     });
 });
 
+/**
+ * Login to DFE using values from the environment variables
+ */
 Cypress.Commands.add("loginWithEnv", (url) => {
     const args = {
         email: Cypress.env("DSi_Email"),

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
@@ -3,11 +3,11 @@ describe("Interstitial page", () => {
     const url = "/broadband-connection";
 
     beforeEach(() => {
-        cy.injectAxe();
-
         cy.loginWithEnv("/self-assessment");
         cy.get("ul.app-task-list__items > li a").first().click();
         cy.url().should("contain", url);
+
+        cy.injectAxe();
       });
 
     it("should have content", () => {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
@@ -23,5 +23,7 @@ describe("Interstitial page", () => {
         cy.get("a.govuk-back-link").should("have.attr", "href").and("include", "self-assessment");
     });
 
-    cy.runAxe();
-});
+    it("passes accessibility tests", () => {
+        cy.runAxe();
+      });
+    });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
@@ -6,6 +6,7 @@ describe("Interstitial page", () => {
         cy.loginWithEnv("/self-assessment");
         cy.get("ul.app-task-list__items > li a").first().click();
         cy.url().should("contain", url);
+        cy.injectAxe();
       });
 
     it("should have content", () => {
@@ -21,4 +22,6 @@ describe("Interstitial page", () => {
         cy.get("a.govuk-back-link").should("exist");
         cy.get("a.govuk-back-link").should("have.attr", "href").and("include", "self-assessment");
     });
+
+    cy.runAxe();
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/interstitial-page.cy.js
@@ -3,10 +3,11 @@ describe("Interstitial page", () => {
     const url = "/broadband-connection";
 
     beforeEach(() => {
+        cy.injectAxe();
+
         cy.loginWithEnv("/self-assessment");
         cy.get("ul.app-task-list__items > li a").first().click();
         cy.url().should("contain", url);
-        cy.injectAxe();
       });
 
     it("should have content", () => {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
@@ -1,6 +1,7 @@
 describe("landing page", () => {
   beforeEach(() => {
     cy.visit("/");
+    cy.injectAxe();
   });
 
   it("should contain title", () => {
@@ -33,5 +34,9 @@ describe("landing page", () => {
     cy.get("a.govuk-button--start.govuk-button")
       .and("have.attr", "href")
       .and("equal", "/self-assessment");
+  });
+
+  it("passes accessibility tests", () => {
+    cy.runAxe();
   });
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
@@ -1,8 +1,7 @@
 describe("landing page", () => {
   beforeEach(() => {
-    cy.injectAxe();
-
     cy.visit("/");
+    cy.injectAxe();
   });
 
   it("should contain title", () => {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/landing-page.cy.js
@@ -1,7 +1,8 @@
 describe("landing page", () => {
   beforeEach(() => {
-    cy.visit("/");
     cy.injectAxe();
+
+    cy.visit("/");
   });
 
   it("should contain title", () => {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
@@ -1,5 +1,3 @@
-import { terminalLog } from "../../commands/axe-tools";
-
 describe("Question page", () => {
   const url = "/self-assessment";
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
@@ -4,8 +4,6 @@ describe("Question page", () => {
   const url = "/self-assessment";
 
   beforeEach(() => {
-    cy.injectAxe();
-
     cy.loginWithEnv(url);
 
     //Navigate to first section
@@ -15,6 +13,7 @@ describe("Question page", () => {
 
     //Navigate to first question
     cy.get('a.govuk-button').contains('Continue').click();
+    cy.injectAxe();
   });
 
   it("should contain form", () => {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
@@ -1,3 +1,5 @@
+import { terminalLog } from "../../commands/axe-tools";
+
 describe("Question page", () => {
   const url = "/self-assessment";
 
@@ -87,5 +89,9 @@ describe("Question page", () => {
         .and("have.attr", "href")
         .and("include", firstUrl);
     });
+  });
+
+  it("passes accessibility tests", () => {
+    cy.runAxe();
   });
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/question-page.cy.js
@@ -4,6 +4,8 @@ describe("Question page", () => {
   const url = "/self-assessment";
 
   beforeEach(() => {
+    cy.injectAxe();
+
     cy.loginWithEnv(url);
 
     //Navigate to first section

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
@@ -2,6 +2,8 @@ describe("Self-assessment page", () => {
   const url = "/self-assessment";
 
   beforeEach(() => {
+    cy.injectAxe();
+
     cy.loginWithEnv(url);
 });
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
@@ -28,4 +28,8 @@ describe("Self-assessment page", () => {
         .and("not.be.null");
     });
   });
+
+  it("passes accessibility tests", () => {
+    cy.runAxe();
+  });
 });

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/self-assessment.cy.js
@@ -2,15 +2,16 @@ describe("Self-assessment page", () => {
   const url = "/self-assessment";
 
   beforeEach(() => {
-    cy.injectAxe();
-
     cy.loginWithEnv(url);
+
+    cy.injectAxe();
 });
 
   it("should have heading", () => {
     cy.get("h1.govuk-heading-xl")
       .should("exist")
       .and("have.text", "Technology self-assessment");
+    
   });
 
   it("should contain categories", () => {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/support/commands.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/support/commands.js
@@ -1,2 +1,3 @@
 import "../commands/login";
 import "../commands/self-assessment-page";
+import "../commands/axe-tools";

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/support/e2e.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/support/e2e.js
@@ -1,1 +1,2 @@
 import "./commands";
+import 'cypress-axe';

--- a/tests/Dfe.PlanTech.Web.E2ETests/package-lock.json
+++ b/tests/Dfe.PlanTech.Web.E2ETests/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "cypress": "^12.17.3"
+        "cypress": "^12.17.3",
+        "cypress-axe": "^1.4.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -241,6 +242,16 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
+    },
+    "node_modules/axe-core": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
+      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -599,6 +610,19 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cypress-axe": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.4.0.tgz",
+      "integrity": "sha512-Ut7NKfzjyKm0BEbt2WxuKtLkIXmx6FD2j0RwdvO/Ykl7GmB/qRQkwbKLk3VP35+83hiIr8GKD04PDdrTK5BnyA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^10 || ^11 || ^12"
       }
     },
     "node_modules/dashdash": {

--- a/tests/Dfe.PlanTech.Web.E2ETests/package.json
+++ b/tests/Dfe.PlanTech.Web.E2ETests/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "cypress": "^12.17.3"
+    "cypress": "^12.17.3",
+    "cypress-axe": "^1.4.0"
   }
 }


### PR DESCRIPTION
- Adds accessibility checks in our E2E testing using axe via [cypress-axe](https://www.npmjs.com/package/cypress-axe)
- Adds a title to each page to pass an accessibility issue
- Adds ADR for the above

*Note*: The title for each page is expected to change, along with the functionality that creates it.