### PR TITLE
fix: Google Tag Manager

### DIFF
--- a/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
@@ -11,12 +11,10 @@ namespace Dfe.PlanTech.Web.Controllers;
 public class PagesController : BaseController<PagesController>
 {
     public IConfiguration Config { get; }
-    private readonly ICookieService _cookieService;
 
-    public PagesController(ILogger<PagesController> logger, IConfiguration config, ICookieService cookieService) : base(logger)
+    public PagesController(ILogger<PagesController> logger, IConfiguration config) : base(logger)
     {
         Config = config ?? throw new ArgumentNullException(nameof(config));
-        _cookieService = cookieService;
     }
 
     [HttpGet("/")]
@@ -65,19 +63,12 @@ public class PagesController : BaseController<PagesController>
 
     private PageViewModel CreatePageModel(Page page, string param = null!)
     {
-        var acceptCookies = _cookieService.GetCookie().HasApproved;
-
-        string gtmHead = acceptCookies ? Config.GetValue<string>("GTM:Head") ?? "" : "";
-        string gtmBody = acceptCookies ? Config.GetValue<string>("GTM:Body") ?? "" : "";
-
         ViewData["Title"] = page.Title?.Text ?? "Plan Technology For Your School";
 
         return new PageViewModel()
         {
             Page = page,
             Param = param,
-            GTMHead = gtmHead,
-            GTMBody = gtmBody,
         };
     }
 

--- a/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
@@ -1,5 +1,4 @@
 ﻿using Dfe.PlanTech.Application.Content.Queries;
-using Dfe.PlanTech.Application.Cookie.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Web.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -10,11 +9,8 @@ namespace Dfe.PlanTech.Web.Controllers;
 
 public class PagesController : BaseController<PagesController>
 {
-    public IConfiguration Config { get; }
-
-    public PagesController(ILogger<PagesController> logger, IConfiguration config) : base(logger)
+    public PagesController(ILogger<PagesController> logger) : base(logger)
     {
-        Config = config ?? throw new ArgumentNullException(nameof(config));
     }
 
     [HttpGet("/")]

--- a/src/Dfe.PlanTech.Web/Helpers/GtmConfiguration.cs
+++ b/src/Dfe.PlanTech.Web/Helpers/GtmConfiguration.cs
@@ -1,7 +1,21 @@
-﻿namespace Dfe.PlanTech.Web.Helpers;
+﻿using Dfe.PlanTech.Application.Cookie.Interfaces;
+
+namespace Dfe.PlanTech.Web.Helpers;
 
 public sealed class GtmConfiguration
 {
-    public string Head { get; set; } = null!;
-    public string Body { get; set; } = null!;
+    private const string CONFIG_KEY = "GTM";
+    private readonly ICookieService _cookieService;
+
+    private readonly string _body;
+    private readonly string _head;
+
+    public GtmConfiguration(ICookieService cookieService, IConfiguration configuration)
+    {
+        _cookieService = cookieService;
+        _body = configuration.GetValue<string>($"{CONFIG_KEY}:Body") ?? "";
+        _head = configuration.GetValue<string>($"{CONFIG_KEY}:Head") ?? "";
+    }
+    public string Body => _cookieService.GetCookie().HasApproved ? _body : "";
+    public string Head => _cookieService.GetCookie().HasApproved ? _head : "";
 }

--- a/src/Dfe.PlanTech.Web/Models/PageViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/PageViewModel.cs
@@ -5,7 +5,5 @@ namespace Dfe.PlanTech.Web.Models;
 public class PageViewModel
 {
     public required Page Page { get; init; }
-    public required string GTMHead { get; set; }
-    public required string GTMBody { get; set; }
     public string Param { get; set; } = null!;
 }

--- a/src/Dfe.PlanTech.Web/Program.cs
+++ b/src/Dfe.PlanTech.Web/Program.cs
@@ -13,7 +13,7 @@ using Microsoft.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddApplicationInsightsTelemetry();
-builder.Services.AddGoogleTagManager(builder.Configuration);
+builder.Services.AddGoogleTagManager();
 // Add services to the container.
 
 builder.Services.AddControllersWithViews();

--- a/src/Dfe.PlanTech.Web/ProgramExtensions.cs
+++ b/src/Dfe.PlanTech.Web/ProgramExtensions.cs
@@ -37,7 +37,7 @@ public static class ProgramExtensions
     public static IServiceCollection AddContentfulServices(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddTransient<IContractResolver, DependencyInjectionContractResolver>();
-        
+
         services.SetupContentfulClient(configuration, "Contentful", HttpClientPolicyExtensions.AddRetryPolicy);
 
         services.AddScoped((services) =>
@@ -51,7 +51,7 @@ public static class ProgramExtensions
                     Classes = "govuk-body govuk-!-font-weight-bold",
                 }});
         });
-        
+
         services.AddScoped((_) => new ParagraphRendererOptions()
         {
             Classes = "govuk-body",
@@ -113,7 +113,7 @@ public static class ProgramExtensions
 
         services.AddTransient<ICalculateMaturityCommand, CalculateMaturityCommand>();
         services.AddTransient<IGetSubmissionStatusesQuery, GetSubmissionStatusesQuery>();
-        
+
         services.AddTransient<ProcessCheckAnswerDtoCommand>();
 
         services.AddTransient<GetSubmitAnswerQueries>();
@@ -128,12 +128,9 @@ public static class ProgramExtensions
         return services;
     }
 
-    public static IServiceCollection AddGoogleTagManager(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddGoogleTagManager(this IServiceCollection services)
     {
-        var config = new GtmConfiguration();
-        configuration.GetSection("GTM").Bind(config);
-        services.AddSingleton((services) => config);
-
+        services.AddTransient<GtmConfiguration>();
         return services;
     }
 }

--- a/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
@@ -1,5 +1,5 @@
-@using Microsoft.EntityFrameworkCore
 @model Dfe.PlanTech.Web.Models.PageViewModel;
+
 @section BeforeContent {
     @if (Model.Page.DisplayBackButton)
     {
@@ -9,14 +9,6 @@
     {
         await Html.RenderPartialAsync("HomeButton", Model);
     }
-}
-
-@section Head {
-    @Html.Raw(Model.GTMHead)
-}
-
-@section Header {
-    @Html.Raw(Model.GTMBody)
 }
 
 @{

--- a/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
@@ -1,21 +1,26 @@
 ﻿@inject GovUk.Frontend.AspNetCore.PageTemplateHelper PageTemplateHelper
+@inject Dfe.PlanTech.Web.Helpers.GtmConfiguration GtmConfiguration
 
 @section Head {
     <link rel="stylesheet" href="~/css/application.css">
+    @Html.Raw(GtmConfiguration.Head);
     @RenderSection("Head", false)
 }
 
 @{
     Layout = "_GovUkPageTemplate";
 
-    if(ViewData["Title"] == null){
+    if (ViewData["Title"] == null)
+    {
         var routeData = Context.GetRouteData();
-        var lastSlug = routeData.Values.Values.Last()?.ToString(); 
-        if(lastSlug != null && lastSlug.Any(c => Char.IsNumber(c))){
-            lastSlug = routeData.Values.Values.SkipLast(1).Last()?.ToString(); 
+        var lastSlug = routeData.Values.Values.Last()?.ToString();
+        if (lastSlug != null && lastSlug.Any(c => Char.IsNumber(c)))
+        {
+            lastSlug = routeData.Values.Values.SkipLast(1).Last()?.ToString();
         }
 
-        if(lastSlug != null){
+        if (lastSlug != null)
+        {
             //Add white space before every capital letter
             lastSlug = string.Concat(lastSlug.Select(c => Char.IsUpper(c) ? " " + c : c.ToString())).TrimStart(' ');
         }
@@ -24,19 +29,22 @@
     }
 }
 
-
 @section Header {
-    @{
+    @Html.Raw(GtmConfiguration.Body);
+
+    @{    
         await Html.RenderPartialAsync("_CookieBanner");
         await Html.RenderPartialAsync("_Header");
     }
-@RenderSection("Header", false)
+
+    @RenderSection("Header", false)
 }
+
 @section BeforeContent{
     @{
         await Html.RenderPartialAsync("BetaHeader");
     }
-@RenderSection("BeforeContent", required: false)
+    @RenderSection("BeforeContent", required: false)
 }
 
 @RenderBody()

--- a/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 
 @section Head {
     <link rel="stylesheet" href="~/css/application.css">
-    @Html.Raw(GtmConfiguration.Head);
+    @Html.Raw(GtmConfiguration.Head)
     @RenderSection("Head", false)
 }
 
@@ -30,7 +30,7 @@
 }
 
 @section Header {
-    @Html.Raw(GtmConfiguration.Body);
+    @Html.Raw(GtmConfiguration.Body)
 
     @{    
         await Html.RenderPartialAsync("_CookieBanner");

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/PagesControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/PagesControllerTests.cs
@@ -67,25 +67,9 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
 
             var Logger = Substitute.For<ILogger<PagesController>>();
 
-            var config = new GtmConfiguration()
-            {
-                Head = "Test Head",
-                Body = "Test Body"
-            };
-
-            var inMemorySettings = new Dictionary<string, string?>
-            {
-                { "GTM:Head", config.Head },
-                { "GTM:Body", config.Body },
-            };
-
-            IConfiguration configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(initialData: inMemorySettings)
-                .Build();
-
             var controllerContext = ControllerHelpers.SubstituteControllerContext();
 
-            _controller = new PagesController(Logger, configuration, cookiesSubstitute)
+            _controller = new PagesController(Logger)
             {
                 ControllerContext = controllerContext,
                 TempData = Substitute.For<ITempDataDictionary>()
@@ -136,8 +120,6 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
 
             var asPage = model as PageViewModel;
             Assert.Equal(INDEX_SLUG, asPage!.Page.Slug);
-            Assert.Equal("Test Head", asPage!.GTMHead);
-            Assert.Equal("Test Body", asPage!.GTMBody);
             Assert.Contains(INDEX_TITLE, asPage!.Page.Title!.Text);
         }
 
@@ -186,37 +168,6 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
             var model = viewResult!.Model;
 
             Assert.IsType<ErrorViewModel>(model);
-        }
-
-        [Theory]
-        [InlineData("true")]
-        [InlineData("false")]
-        [InlineData("")]
-        public async Task GoogleTrackingCodesAddedDependingOnWhatCookiePreferenceSetTo(string cookiePreference)
-        {
-            bool.TryParse(cookiePreference, out bool preference);
-            var cookie = new DfeCookie { HasApproved = preference };
-            cookiesSubstitute.GetCookie().Returns(cookie);
-
-            var result = await _controller.GetByRoute(INDEX_SLUG, _query, CancellationToken.None);
-
-            Assert.IsType<ViewResult>(result);
-
-            var viewResult = result as ViewResult;
-
-            var model = viewResult!.Model;
-
-            var asPage = model as PageViewModel;
-            if (cookiePreference == "true")
-            {
-                Assert.Equal("Test Head", asPage!.GTMHead);
-                Assert.Equal("Test Body", asPage!.GTMBody);
-            }
-            else
-            {
-                Assert.NotEqual("Test Head", asPage!.GTMHead);
-                Assert.NotEqual("Test Body", asPage!.GTMBody);
-            }
         }
         
         [Fact]

--- a/tests/Dfe.PlanTech.Web.UnitTests/Helpers/GtmConfigurationTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Helpers/GtmConfigurationTests.cs
@@ -1,0 +1,62 @@
+using Dfe.PlanTech.Application.Cookie.Interfaces;
+using Dfe.PlanTech.Domain.Cookie;
+using Dfe.PlanTech.Web.Helpers;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Xunit;
+
+namespace Dfe.PlanTech.Web.UnitTests.Helpers;
+
+public class GtmConfigurationTests
+{
+  private const string GTM_BODY_KEY = "GTM:Body";
+  private const string GTM_BODY_VALUE = "<noscript>Google tag manager body</noscript>";
+
+  private const string GTM_HEAD_KEY = "GTM:Head";
+  private const string GTM_HEAD_VALUE = "<noscript>Google tag manager Head</noscript>";
+
+  public readonly ICookieService CookieService;
+  public readonly IConfiguration Configuration;
+
+  public GtmConfigurationTests()
+  {
+    var inMemorySettings = new Dictionary<string, string?> {
+      {GTM_BODY_KEY, GTM_BODY_VALUE},
+      {GTM_HEAD_KEY, GTM_HEAD_VALUE},
+    };
+
+    Configuration = new ConfigurationBuilder()
+        .AddInMemoryCollection(inMemorySettings)
+        .Build();
+
+    CookieService = Substitute.For<ICookieService>();
+  }
+
+  [Fact]
+  public void Should_Return_BodyAndHead_When_Cookies_Accepted()
+  {
+    CookieService.GetCookie().Returns((_) => new DfeCookie()
+    {
+      HasApproved = true
+    });
+
+    var gtmConfiguration = new GtmConfiguration(CookieService, Configuration);
+
+    Assert.Equal(GTM_BODY_VALUE, gtmConfiguration.Body);
+    Assert.Equal(GTM_HEAD_VALUE, gtmConfiguration.Head);
+  }
+
+  [Fact]
+  public void Should_Return_Empty_When_Cookies_Not_Accepted()
+  {
+    CookieService.GetCookie().Returns((_) => new DfeCookie()
+    {
+      HasApproved = false
+    });
+
+    var gtmConfiguration = new GtmConfiguration(CookieService, Configuration);
+
+    Assert.Empty(gtmConfiguration.Body);
+    Assert.Empty(gtmConfiguration.Head);
+  }
+}


### PR DESCRIPTION
- Moves GTM code around so that it is added in `_Layout.cshtml`, not `Page.cshtml`
- The latter is not used for every page, meaning a large majority of pages did not actually include the GTM code