### PR TITLE
fix: Terraform WAF settings

### DIFF
--- a/terraform/terraform-configuration.md
+++ b/terraform/terraform-configuration.md
@@ -37,7 +37,7 @@ We use two external modules to create the majority of the resources required:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.71.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.73.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
 
 ## Modules

--- a/terraform/terraform-configuration.md
+++ b/terraform/terraform-configuration.md
@@ -37,7 +37,7 @@ We use two external modules to create the majority of the resources required:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.70.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.71.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
 
 ## Modules
@@ -45,7 +45,7 @@ We use two external modules to create the majority of the resources required:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_main_hosting"></a> [main\_hosting](#module\_main\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.19.4 |
-| <a name="module_waf"></a> [waf](#module\_waf) | github.com/dfe-digital/terraform-azurerm-front-door-app-gateway-waf | v0.3.2 |
+| <a name="module_waf"></a> [waf](#module\_waf) | github.com/dfe-digital/terraform-azurerm-front-door-app-gateway-waf | v0.3.3 |
 
 ## Resources
 

--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -23,7 +23,7 @@ module "waf" {
   cdn_waf_enable_rate_limiting              = true
   cdn_waf_rate_limiting_duration_in_minutes = 5
   cdn_waf_rate_limiting_threshold           = 1000
-  cdn_waf_rate_limiting_action              = "Block" # one of "Allow", "Block", "Log"
+  cdn_waf_rate_limiting_action              = "Block"
 
   cdn_waf_managed_rulesets = {
     "Microsoft_DefaultRuleSet" = {
@@ -33,6 +33,27 @@ module "waf" {
     "Microsoft_BotManagerRuleSet" = {
       version = "1.0",
       action  = "Block"
+      override = {
+        rule_group_name = "RFI"
+        rule = {
+          action  = "Log"
+          enabled = false
+          rule_id = "931130"
+        }
+      }
+      override = {
+        rule_group_name = "SQLI"
+        rule = {
+          action  = "Log"
+          enabled = false
+          rule_id = "942200"
+        }
+        rule = {
+          action  = "Log"
+          enabled = false
+          rule_id = "942340"
+        }
+      }
     }
   }
 

--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -1,5 +1,5 @@
 module "waf" {
-  source = "github.com/dfe-digital/terraform-azurerm-front-door-app-gateway-waf?ref=v0.3.2"
+  source = "github.com/dfe-digital/terraform-azurerm-front-door-app-gateway-waf?ref=v0.3.3"
 
   depends_on = [module.main_hosting]
 

--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -33,25 +33,19 @@ module "waf" {
     "Microsoft_BotManagerRuleSet" = {
       version = "1.0",
       action  = "Block"
-      override = {
-        rule_group_name = "RFI"
-        rule = {
-          action  = "Log"
-          enabled = false
-          rule_id = "931130"
-        }
-      }
-      override = {
-        rule_group_name = "SQLI"
-        rule = {
-          action  = "Log"
-          enabled = false
-          rule_id = "942200"
-        }
-        rule = {
-          action  = "Log"
-          enabled = false
-          rule_id = "942340"
+      overrides = {
+        "SQLI" = {
+          "942200" = {
+            action = "Log"
+          },
+          "942340" = {
+            action = "Log"
+          }
+        },
+        "RFI" = {
+          "931130" = {
+            action = "Log"
+          }
         }
       }
     }

--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -37,6 +37,9 @@ module "waf" {
           },
           "942340" = {
             action = "Log"
+          },
+          "942450" = {
+            action = "Log"
           }
         },
         "RFI" = {

--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -28,11 +28,7 @@ module "waf" {
   cdn_waf_managed_rulesets = {
     "Microsoft_DefaultRuleSet" = {
       version = "2.1",
-      action  = "Block"
-    },
-    "Microsoft_BotManagerRuleSet" = {
-      version = "1.0",
-      action  = "Block"
+      action  = "Block",
       overrides = {
         "SQLI" = {
           "942200" = {
@@ -48,6 +44,10 @@ module "waf" {
           }
         }
       }
+    },
+    "Microsoft_BotManagerRuleSet" = {
+      version = "1.0",
+      action  = "Block"
     }
   }
 

--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -14,7 +14,8 @@ module "waf" {
 
   waf_targets = {
     "container-app-url" = {
-      domain = local.cdn_frontdoor_origin_host_header_override
+      domain                    = local.cdn_frontdoor_origin_host_header_override
+      health_probe_request_type = "GET"
     }
   }
 


### PR DESCRIPTION
- Updates the DFE TF WAF Module to latest version
  - This fixes a few minor things, notably it stops a couple of unnecessary resources being created
- Adds certain WAF rules to `Log`
- Sets healthprobe to GET instead of HEAD

**NOTE**: There is no option in the WAF module to _disable_ rules, only what `Action` they should be set to. Therefore these rules end up being set back to `Enabled`, even though we want them disabled. A PR to enable this functionality is awaiting review: https://github.com/DFE-Digital/terraform-azurerm-front-door-app-gateway-waf/pull/27