### PR TITLE
fix: Spelling in SQL Script

### DIFF
--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230913_1224_UpdateSubmissionNullability.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230913_1224_UpdateSubmissionNullability.sql
@@ -9,6 +9,6 @@ BEGIN TRAN
 
   ALTER TABLE [dbo].[submission] ALTER COLUMN [sectionId] [NVARCHAR](50) NOT NULL
   ALTER TABLE [dbo].[submission] ALTER COLUMN [sectionName] [NVARCHAR](50) NOT NULL
-  ALTER TABLE [dbo].[submission] DROP COLUMN [recommendationId]
+  ALTER TABLE [dbo].[submission] DROP COLUMN [recomendationId]
   
 COMMIT TRAN


### PR DESCRIPTION
- Fixes column naming to match (misspelled) existing column name