### PR TITLE
fix: Missing attributes on check answers page

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/CheckAnswers/CheckAnswers.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/CheckAnswers/CheckAnswers.cshtml
@@ -25,7 +25,10 @@
                         @questionWithAnswer.AnswerText
                     </dd>
                     <dd class="govuk-summary-list__actions spacer">
-                        @Html.RouteLink("Change", "ChangeAnswerRouteLink", new { questionRef=questionWithAnswer.QuestionRef, answerRef=questionWithAnswer.AnswerRef, submissionId=Model.SubmissionId}, new {@class="govuk-link"})
+                        @Html.RouteLink("Change",
+                                    "ChangeAnswerRouteLink", 
+                                    new { questionRef=questionWithAnswer.QuestionRef, answerRef=questionWithAnswer.AnswerRef, submissionId=Model.SubmissionId},
+                                    new {@class="govuk-link", aria_label=anchorLabel, title=questionWithAnswer.QuestionText})
                     </dd>
                 </div>
             }

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/question-page.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/question-page.js
@@ -1,6 +1,35 @@
-const selectFirstRadioButton = () => cy.get("form div.govuk-radios div.govuk-radios__item input")
-  .first()
-  .click();
+const selectFirstRadioButton = () => {
+  const questionWithAnswer = {
+    question: "",
+    answer: ""
+  };
+
+  cy.get("main form")
+    .then($form => {
+      cy.wrap($form)
+        .find("h1")
+        .should("exist")
+        .invoke("text")
+        .then(question => questionWithAnswer.question = question.trim());
+      
+      cy.wrap($form)
+        .find("div.govuk-radios div.govuk-radios__item")
+        .should("exist")
+        .and("length.of.at.least", 2)
+        .first()
+        .then(item => {            
+          cy.wrap(item)
+            .find("label")
+            .invoke("text")
+            .then(answer => questionWithAnswer.answer = answer.trim());
+
+          cy.wrap(item)
+            .find("input")
+            .click();
+        });
+    })
+    .then(() => cy.wrap(questionWithAnswer));
+}
 
 const saveAndContinue = () => cy.get("form button.govuk-button")
   .contains("Save and continue")

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/accessibility-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/accessibility-page.cy.js
@@ -28,34 +28,3 @@ describe("Accessibility Page - Unauthenticated", () => {
         cy.runAxe();
     });
 });
-
-describe("Accessibility Page - Authenticated", () => {
-    const url = "/self-assessment";
-
-    beforeEach(() => {
-        cy.loginWithEnv(url);
-        cy.get("footer.govuk-footer ul.govuk-footer__inline-list a.govuk-footer__link").contains("Accessibility").click();
-        cy.url().should("contain", "/accessibility");
-        cy.injectAxe();
-    });
-
-    it("Should Have Heading", () => {
-        cy.get("h1.govuk-heading-xl")
-            .should("exist")
-    });
-
-    it("Should Have Home Button", () => {
-        cy.get('a:contains("Home")')
-            .should("exist")
-            .should("have.attr", "href")
-            .and("include", "/self-assessment")
-    });
-
-    it("Should Have Content", () => {
-        cy.get("rich-text").should("exist");
-    });
-
-    it("Passes Accessibility Testing", () => {
-        cy.runAxe();
-    });
-});

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
@@ -69,20 +69,16 @@ describe("Check answers page", () => {
       });
   });
 
-  it("shows notification banner after submitting answers", () => {
-    submitAnswers();
-
-    cy.get("div.govuk-notification-banner__header").should("exist");
-  });
-
   it("passes accessibility tests", () => {
     cy.runAxe();
   });
 
-  it("submits answers", () => {
+  //This needs to be last on this test run, so that the question-page tests have a clean slate to work from!
+  it("submits answers and shows notification", () => {
     submitAnswers();
 
     cy.url().should("contain", "self-assessment");
+    cy.get("div.govuk-notification-banner__header").should("exist");
   });
 });
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
@@ -27,6 +27,7 @@ describe("Check answers page", () => {
       .should("exist")
       .and("have.length", selectedQuestionsWithAnswers.length)
       .each((row) => {
+        //Get question and answer tecxt for each row
         const questionWithAnswer = {
           question: null,
           answer: null,
@@ -43,6 +44,8 @@ describe("Check answers page", () => {
           .invoke("text")
           .then((answer) => (questionWithAnswer.answer = answer.trim()));
 
+          
+        //Ensure it matches one of the items in array
         cy.wrap(questionWithAnswer).then(() => {
           cy.log(JSON.stringify(selectedQuestionsWithAnswers));
 
@@ -56,6 +59,19 @@ describe("Check answers page", () => {
           expect(matchingQuestionWithAnswer.answer).to.equal(
             questionWithAnswer.answer
           );
+
+          //Has "Change" me link with accessibility attributes
+          cy.wrap(row)
+            .find("a")
+            .contains("Change")
+            .and("have.attr", "aria-label")
+            .and("contain", questionWithAnswer.question);
+          
+            cy.wrap(row)
+            .find("a")
+            .contains("Change")
+            .and("have.attr", "title")
+              .and("equal", questionWithAnswer.question);
         });
       });
   });
@@ -64,15 +80,6 @@ describe("Check answers page", () => {
     submitAnswers();
 
     cy.get("div.govuk-notification-banner__header").should("exist");
-  });
-
-  it("each change answer link should have correct attributes", () => {
-    cy.get("a")
-      .contains("Change")
-      .each((link) => {
-        cy.wrap(link).should("have.attr", "aria-label");
-        cy.wrap(link).should("have.attr", "title");
-      });
   });
 
   it("passes accessibility tests", () => {
@@ -102,9 +109,7 @@ const navigateThroughQuestions = () => {
 
       return navigateThroughQuestions();
     })
-    .then(() => {
-
-    });
+    .then(() => {});
 };
 
 const submitAnswers = () =>

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
@@ -1,24 +1,63 @@
+let selectedQuestionsWithAnswers = [];
+
 describe("Check answers page", () => {
   const url = "/self-assessment";
 
   beforeEach(() => {
+    selectedQuestionsWithAnswers = [];
     cy.loginWithEnv(url);
 
     navigateToCheckAnswersPage();
+
+    cy.log(selectedQuestionsWithAnswers);
 
     cy.url().should("contain", "check-answers");
 
     cy.injectAxe();
   });
 
-  it("passes accessibility tests", () => {
-    cy.runAxe();
-  });
-
   it("submits answers", () => {
     submitAnswers();
 
     cy.url().should("contain", "self-assessment");
+  });
+
+  it("should show each selected question with answer", () => {
+    cy.get("div.govuk-summary-list__row")
+      .should("exist")
+      .and("have.length", selectedQuestionsWithAnswers.length)
+      .each((row) => {
+        const questionWithAnswer = {
+          question: null,
+          answer: null,
+        };
+
+        cy.wrap(row)
+          .find("dt.govuk-summary-list__key")
+          .should("exist")
+          .invoke("text")
+          .then((question) => (questionWithAnswer.question = question.trim()));
+
+        cy.wrap(row)
+          .find("dd.govuk-summary-list__value")
+          .invoke("text")
+          .then((answer) => (questionWithAnswer.answer = answer.trim()));
+
+        cy.wrap(questionWithAnswer).then(() => {
+          cy.log(JSON.stringify(selectedQuestionsWithAnswers));
+
+          const matchingQuestionWithAnswer = selectedQuestionsWithAnswers.find(
+            (qwa) => {
+              cy.log("looking for ", qwa);
+              return qwa.question == questionWithAnswer.question.trim();
+            }
+          );
+
+          expect(matchingQuestionWithAnswer.answer).to.equal(
+            questionWithAnswer.answer
+          );
+        });
+      });
   });
 
   it("shows notification banner after submitting answers", () => {
@@ -35,33 +74,38 @@ describe("Check answers page", () => {
         cy.wrap(link).should("have.attr", "title");
       });
   });
+
+  it("passes accessibility tests", () => {
+    cy.runAxe();
+  });
 });
 
 const navigateToCheckAnswersPage = () => {
   cy.clickFirstSection();
   cy.clickContinueButton();
 
-  navigateThroughQuestions();
+  return navigateThroughQuestions();
 };
 
-const navigateThroughQuestions = () =>
-  cy
-    .get("main")
+const navigateThroughQuestions = () => {
+  cy.get("main")
     .then(($main) => $main.find("form div.govuk-radios").length > 0)
     .then((onQuestionPage) => {
       if (!onQuestionPage) {
-        cy.log("no longer on question page");
         return Promise.resolve();
       }
 
-      cy.log("On question page");
-
-      cy.selectFirstRadioButton();
+      cy.selectFirstRadioButton().then((questionWithAnswer) =>
+        selectedQuestionsWithAnswers.push(questionWithAnswer)
+      );
       cy.saveAndContinue();
 
       return navigateThroughQuestions();
-    });
+    })
+    .then(() => {
 
-function submitAnswers() {
+    });
+};
+
+const submitAnswers = () =>
   cy.get("button.govuk-button").contains("Save and Submit").click();
-}

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
@@ -16,12 +16,6 @@ describe("Check answers page", () => {
     cy.injectAxe();
   });
 
-  it("submits answers", () => {
-    submitAnswers();
-
-    cy.url().should("contain", "self-assessment");
-  });
-
   it("should show each selected question with answer", () => {
     cy.get("div.govuk-summary-list__row")
       .should("exist")
@@ -44,7 +38,6 @@ describe("Check answers page", () => {
           .invoke("text")
           .then((answer) => (questionWithAnswer.answer = answer.trim()));
 
-          
         //Ensure it matches one of the items in array
         cy.wrap(questionWithAnswer).then(() => {
           cy.log(JSON.stringify(selectedQuestionsWithAnswers));
@@ -66,12 +59,12 @@ describe("Check answers page", () => {
             .contains("Change")
             .and("have.attr", "aria-label")
             .and("contain", questionWithAnswer.question);
-          
-            cy.wrap(row)
+
+          cy.wrap(row)
             .find("a")
             .contains("Change")
             .and("have.attr", "title")
-              .and("equal", questionWithAnswer.question);
+            .and("equal", questionWithAnswer.question);
         });
       });
   });
@@ -84,6 +77,12 @@ describe("Check answers page", () => {
 
   it("passes accessibility tests", () => {
     cy.runAxe();
+  });
+
+  it("submits answers", () => {
+    submitAnswers();
+
+    cy.url().should("contain", "self-assessment");
   });
 });
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
@@ -26,6 +26,15 @@ describe("Check answers page", () => {
 
     cy.get("div.govuk-notification-banner__header").should("exist");
   });
+
+  it("each change answer link should have correct attributes", () => {
+    cy.get("a")
+      .contains("Change")
+      .each((link) => {
+        cy.wrap(link).should("have.attr", "aria-label");
+        cy.wrap(link).should("have.attr", "title");
+      });
+  });
 });
 
 const navigateToCheckAnswersPage = () => {
@@ -33,10 +42,12 @@ const navigateToCheckAnswersPage = () => {
   cy.clickContinueButton();
 
   navigateThroughQuestions();
-}
+};
 
 const navigateThroughQuestions = () =>
-  cy.get("main").then(($main) => $main.find("form div.govuk-radios").length > 0)
+  cy
+    .get("main")
+    .then(($main) => $main.find("form div.govuk-radios").length > 0)
     .then((onQuestionPage) => {
       if (!onQuestionPage) {
         cy.log("no longer on question page");
@@ -50,7 +61,7 @@ const navigateThroughQuestions = () =>
 
       return navigateThroughQuestions();
     });
+
 function submitAnswers() {
   cy.get("button.govuk-button").contains("Save and Submit").click();
 }
-

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/privacy-policy-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/privacy-policy-page.cy.js
@@ -28,34 +28,3 @@ describe("Privacy Policy Page - Unauthenticated", () => {
         cy.runAxe();
     });
 });
-
-describe("Privacy Policy Page - Authenticated", () => {
-    const url = "/self-assessment";
-
-    beforeEach(() => {
-        cy.loginWithEnv(url);
-        cy.get("footer.govuk-footer ul.govuk-footer__inline-list a.govuk-footer__link").contains("Privacy").click();
-        cy.url().should("contain", "/privacy");
-        cy.injectAxe();
-    });
-
-    it("Should Have Heading", () => {
-        cy.get("h1.govuk-heading-xl")
-            .should("exist")
-    });
-
-    it("Should Have Home Button", () => {
-        cy.get('a:contains("Home")')
-            .should("exist")
-            .should("have.attr", "href")
-            .and("include", "/self-assessment")
-    });
-
-    it("Should Have Content", () => {
-        cy.get("rich-text").should("exist");
-    });
-
-    it("Passes Accessibility Testing", () => {
-        cy.runAxe();
-    });
-});


### PR DESCRIPTION
- Re-adds some missing attributes on `Change` links on the `Check Answers` page that had been removed accidentally in recent work.
- Removes a few tests that should be unnecessary, to reduce test run time
- Adds another test for Check Answers page, that checks:
   - Every chosen question + answer exists on the Check Answers page
   - Each has a "Change" link
      - Each link has an `aria-label` and a `title` attribute with the correct expected values