### PR TITLE
feat: Remove SQL Analytics User

### DIFF
--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230816_132200_CreateAnalyticsUser.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230816_132200_CreateAnalyticsUser.sql
@@ -1,7 +1,0 @@
--- $Analytics_Username$ $Analytics_Password$
-IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = '$Analytics_Username$')
-BEGIN
-    CREATE USER [$Analytics_Username$] WITH PASSWORD = '$Analytics_Password$'
-    ALTER ROLE [db_datareader] ADD MEMBER [$Analytics_Username$]
-    GRANT SELECT ON SCHEMA :: [dbo] to [AnalyticsUser];
-END

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230921_1150_DeleteAnalyticsUser.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230921_1150_DeleteAnalyticsUser.sql
@@ -1,0 +1,5 @@
+-- $Analytics_Username$ $Analytics_Password$
+IF EXISTS (SELECT * FROM sys.database_principals WHERE name = '$Analytics_Username$')
+BEGIN
+    DROP USER [$Analytics_Username$]
+END

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230921_1150_DeleteAnalyticsUser.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230921_1150_DeleteAnalyticsUser.sql
@@ -1,5 +1,4 @@
--- $Analytics_Username$ $Analytics_Password$
-IF EXISTS (SELECT * FROM sys.database_principals WHERE name = '$Analytics_Username$')
+IF EXISTS (SELECT * FROM sys.database_principals WHERE name = 'AnalyticsUser')
 BEGIN
-    DROP USER [$Analytics_Username$]
+    DROP USER [AnalyticsUser]
 END


### PR DESCRIPTION
As we've moved to Azure AD auth for the SQL server, this user is no longer necessary.

- Removes script that creates user
- Adds a script that drops the user from the DB if exists

Note: I've inlined the user username as:
1. It should no longer be a security issue, since it will be deleted
2. Otherwise we'll need to keep the secret for the username in GitHub indefinitely; inlining it allows us to clear it out.