### PR TITLE
fix: Org name length + incorrect establishment ID usage

### DIFF
--- a/src/Dfe.PlanTech.Application/Users/Commands/CreateEstablishmentCommand.cs
+++ b/src/Dfe.PlanTech.Application/Users/Commands/CreateEstablishmentCommand.cs
@@ -19,20 +19,11 @@ public class CreateEstablishmentCommand : ICreateEstablishmentCommand
     /// <returns></returns>
     public async Task<int> CreateEstablishment(EstablishmentDto establishmentDto)
     {
-        if (establishmentDto == null)
-        {
-            throw new InvalidOperationException("Establishment dto cannot be null.");
-        }
-
-
-        if (establishmentDto.Urn == null && establishmentDto.Ukprn == null)
-        {
-            throw new InvalidOperationException("Both Urn and Ukprn cannot be null.");
-        }
+        if (establishmentDto == null) throw new ArgumentNullException(nameof(establishmentDto));
 
         var establishment = new Establishment()
         {
-            EstablishmentRef = establishmentDto.Urn ?? establishmentDto.Ukprn!,
+            EstablishmentRef = establishmentDto.Reference,
             EstablishmentType = establishmentDto.Type.Name,
             OrgName = establishmentDto.OrgName,
         };

--- a/src/Dfe.PlanTech.Application/Users/Commands/CreateEstablishmentCommand.cs
+++ b/src/Dfe.PlanTech.Application/Users/Commands/CreateEstablishmentCommand.cs
@@ -30,8 +30,8 @@ public class CreateEstablishmentCommand : ICreateEstablishmentCommand
 
         _db.AddEstablishment(establishment);
 
-        var establishmentId = await _db.SaveChangesAsync();
+        await _db.SaveChangesAsync();
 
-        return establishmentId;
+        return establishment.Id;
     }
 }

--- a/src/Dfe.PlanTech.Application/Users/Commands/RecordUserSigninCommand.cs
+++ b/src/Dfe.PlanTech.Application/Users/Commands/RecordUserSigninCommand.cs
@@ -88,7 +88,7 @@ public class RecordUserSignInCommand : IRecordUserSignInCommand
         });
     }
 
-    private static SignIn MapToSignIn(int userId, int establishmentId = 1)
+    private static SignIn MapToSignIn(int userId, int establishmentId)
     {
         if (userId == 0)
             throw new ArgumentNullException(nameof(userId), "User id cannot be null");

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230922_1813_AlterOrgNameLength.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20230922_1813_AlterOrgNameLength.sql
@@ -1,0 +1,6 @@
+BEGIN TRAN
+
+	ALTER TABLE [dbo].[establishment] 
+	ALTER COLUMN [orgName] [nvarchar](200) NOT NULL;
+
+COMMIT TRAN

--- a/src/Dfe.PlanTech.Domain/Establishments/Models/Establishment.cs
+++ b/src/Dfe.PlanTech.Domain/Establishments/Models/Establishment.cs
@@ -1,17 +1,57 @@
-﻿namespace Dfe.PlanTech.Domain.Establishments.Models
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Dfe.PlanTech.Domain.Establishments.Models;
+
+public class Establishment
 {
-    public class Establishment
+    public const int EstablishmentRefLength = 50;
+    public const int EstablishmentTypeLength = 50;
+    public const int OrgNameLength = 200;
+
+    private string _establishmentRef = null!;
+    private string _establishmentType = null!;
+    private string _orgName = null!;
+
+    public int Id { get; set; }
+
+    [StringLength(EstablishmentRefLength)]
+    public string EstablishmentRef
     {
-        public int Id { get; set; }
-        
-        public string EstablishmentRef { get; set; } = null!;
-
-        public string EstablishmentType { get; set; } = null!;
-
-        public string OrgName { get; set; } = null!;
-
-        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
-
-        public DateTime? DateLastUpdated { get; set; }
+        get => _establishmentRef;
+        set
+        {
+            _establishmentRef = value.Length < EstablishmentRefLength ?
+                                    value :
+                                    value.AsSpan(0, EstablishmentRefLength - 1).ToString();
+        }
     }
+
+    [StringLength(EstablishmentTypeLength)]
+    public string EstablishmentType
+    {
+        get => _establishmentType;
+        set
+        {
+            _establishmentType = value.Length < EstablishmentTypeLength ?
+                                    value :
+                                    value.AsSpan(0, EstablishmentTypeLength - 1).ToString();
+        }
+    }
+
+    [StringLength(OrgNameLength)]
+    public string OrgName
+    {
+        get => _orgName;
+        set
+        {
+            _orgName = value.Length < OrgNameLength ?
+                                    value :
+                                    value.AsSpan(0, OrgNameLength - 1).ToString();
+        }
+    }
+
+    public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+
+    public DateTime? DateLastUpdated { get; set; }
 }
+

--- a/src/Dfe.PlanTech.Domain/Establishments/Models/Establishment.cs
+++ b/src/Dfe.PlanTech.Domain/Establishments/Models/Establishment.cs
@@ -3,6 +3,7 @@
     public class Establishment
     {
         public int Id { get; set; }
+        
         public string EstablishmentRef { get; set; } = null!;
 
         public string EstablishmentType { get; set; } = null!;

--- a/src/Dfe.PlanTech.Domain/Establishments/Models/EstablishmentDto.cs
+++ b/src/Dfe.PlanTech.Domain/Establishments/Models/EstablishmentDto.cs
@@ -1,18 +1,13 @@
-using System.Text.Json.Serialization;
-
 namespace Dfe.PlanTech.Domain.Establishments.Models;
 
 public class EstablishmentDto
 {
-    [JsonPropertyName("ukprn")]
     public string? Ukprn { get; set; }
 
-    [JsonPropertyName("urn")] public string? Urn { get; set; }
+    public string? Urn { get; set; }
 
-    [JsonPropertyName("type")]
     public EstablishmentTypeDto Type { get; set; } = new EstablishmentTypeDto();
 
-    [JsonPropertyName("name")]
     public string OrgName { get; set; } = null!;
 
     public bool IsValid => References().Any(reference => !string.IsNullOrEmpty(reference));

--- a/src/Dfe.PlanTech.Domain/Establishments/Models/EstablishmentDto.cs
+++ b/src/Dfe.PlanTech.Domain/Establishments/Models/EstablishmentDto.cs
@@ -1,13 +1,18 @@
+using System.Text.Json.Serialization;
+
 namespace Dfe.PlanTech.Domain.Establishments.Models;
 
 public class EstablishmentDto
 {
+    [JsonPropertyName("ukprn")]
     public string? Ukprn { get; set; }
 
-    public string? Urn { get; set; }
+    [JsonPropertyName("urn")] public string? Urn { get; set; }
 
+    [JsonPropertyName("type")]
     public EstablishmentTypeDto Type { get; set; } = new EstablishmentTypeDto();
 
+    [JsonPropertyName("name")]
     public string OrgName { get; set; } = null!;
 
     public bool IsValid => References().Any(reference => !string.IsNullOrEmpty(reference));


### PR DESCRIPTION
- Increases `orgName` in `dbo.establishment` to 200 characters.
  - Truncates this, and the other two string columns, if they exceed their set length
  - Add data annotation attributes for catching this before SQL insertion
 
- Returns actual `Id` value for establishment, not the results of `SaveChangesAsync` (which returns changed row count - so in this instance was always returning either 1 for success or 0)

- Removes invalid `int establishmentId = 1` default method argument, as this will almost never be correct.