### PR TITLE
feat: Change workflows to use Ubuntu again

### DIFF
--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   build-test-web-app:  
     name: Build and run unit tests
-    runs-on: windows-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out repository

--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -50,17 +50,17 @@ jobs:
           
       - name: Start SonarCloud scanner
         run: |
-          dotnet-sonarscanner begin `
-            /k:"DFE-Digital_plan-technology-for-your-school" `
-            /o:"dfe-digital" `
-            /d:sonar.login="${{ secrets.SONAR_TOKEN }}" `
-            /d:sonar.host.url="https://sonarcloud.io" `
-            /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml `
-            /d:sonar.coverage.exclusions="src/**/Program.cs,src/Dfe.PlanTech.Web/gulpfile.js,src/Dfe.PlanTech.Web/wwwroot/**" `
-            /d:sonar.issue.ignore.multicriteria=e1 `
-            /d:sonar.issue.ignore.multicriteria.e1.ruleKey=csharpsquid:S6602 `
-            /d:sonar.issue.ignore.multicriteria.e1.resourceKey=src/**/*.cs
-          
+          dotnet-sonarscanner begin \
+          /k:"DFE-Digital_plan-technology-for-your-school" \
+          /o:"dfe-digital" \
+          /d:sonar.login="${{ secrets.SONAR_TOKEN }}" \
+          /d:sonar.host.url="https://sonarcloud.io" \
+          /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml \
+          /d:sonar.coverage.exclusions=src/**/Program.cs,src/Dfe.PlanTech.Web/gulpfile.js,src/Dfe.PlanTech.Web/wwwroot/** \
+          /d:sonar.issue.ignore.multicriteria=e1 \
+          /d:sonar.issue.ignore.multicriteria.e1.ruleKey=csharpsquid:S6602 \
+          /d:sonar.issue.ignore.multicriteria.e1.resourceKey=src/**/*.cs
+      
       - name: Build web app  
         uses: ./.github/actions/build-dotnet-app
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -75,7 +75,7 @@ jobs:
 
   run-tests:
     name: Run E2E Tests
-    runs-on: windows-latest
+    runs-on: ubuntu-20.04
     needs: [clear-db]
     env:
       PROJECT_PATH: ./src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj


### PR DESCRIPTION
- Changes build workflows back to using Ubuntu, not Windows, again. 
- This time targeting a specific, older version (20.04), which fixes the bug with the newer versions.
- End result is the unit + E2E testing workflows having their run time halved.