### PR TITLE
feature/184003 - Resolve E2E Test Environment Issue

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Create Cypress config
       shell: bash
       run: |
-        echo "{\"URL\": \"${{inputs.url}}\", \"DSi_Url\": \"${{inputs.dsi_url}}\", \"DSi_Email\": \"${{inputs.dsi_username}}\", \"DSi_Password\": \"${{inputs.dsi_password}}\" }" >cypress.env.json
+        echo "{\"URL\": \"${{ inputs.url }}\", \"DSi_Url\": \"${{ inputs.dsi_url }}\", \"DSi_Email\": \"${{ inputs.dsi_username }}\", \"DSi_Password\": \"${{inputs. dsi_password }}\" }" > cypress.env.json
       working-directory: ./tests/Dfe.PlanTech.Web.E2ETests/
 
     - name: Build and test project
@@ -30,7 +30,7 @@ runs:
       with:
         working-directory: ./tests/Dfe.PlanTech.Web.E2ETests/
         browser: chrome
-        config: baseUrl=${{inputs.url}}
+        config: baseUrl=${{ inputs.url }}
 
     - name: Store screenshots on test failure
       uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -115,10 +115,6 @@ jobs:
         az_keyvault_database_connectionstring_name: ${{ secrets.AZ_KEYVAULT_DATABASE_CONNECTIONSTRING_NAME }}
         az_sql_database_server_name: ${{ secrets.AZ_ENVIRONMENT }}${{ secrets.DFE_PROJECT_NAME }}
         az_resource_group_name: ${{ secrets.AZ_ENVIRONMENT }}${{ secrets.DFE_PROJECT_NAME }}
-        az_frontdoor_url: ${{ secrets.AZ_FRONTDOOR_URL }}
-        dsi_url: ${{ secrets.DSI_URL }}
-        dsi_username: ${{ secrets.DSI_USERNAME }}
-        dsi_password: ${{ secrets.DSI_PASSWORD }}
         SQL_IP_NAME: e2e-tests-clear-db
 
       steps:
@@ -160,23 +156,14 @@ jobs:
         with:
           connection-string: ${{ steps.get-connection-string.outputs.connection_string }}
           path: "./.github/scripts/drop-establishment-data.sql"
-        
-      - name: Run Cypress Tests
-        uses: cypress-io/github-action@v6
-        with:
-          working-directory: ./tests/Dfe.PlanTech.Web.E2ETests/
-          browser: chrome
-          config: baseUrl=${{ env.az_frontdoor_url }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Cypress Testing
-      #   uses: ./.github/actions/run-e2e-tests
-      #   with:
-      #     url: ${{ env.az_frontdoor_url }}
-      #     dsi_url: ${{ env.dsi_url }}
-      #     dsi_username: ${{ env.dsi_username }}
-      #     dsi_password: ${{ env.dsi_password }}
+      - name: Cypress Testing
+        uses: ./.github/actions/run-e2e-tests
+        with:
+          url: ${{ secrets.AZ_FRONTDOOR_URL }}
+          dsi_url: ${{ secrets.DSI_URL }}
+          dsi_username: ${{ secrets.DSI_USERNAME }}
+          dsi_password: ${{ secrets.DSI_PASSWORD }}
         
       - name: Remove Azure Firewall Rules
         if: always()
@@ -188,17 +175,3 @@ jobs:
           az_ip_name: ${{ env.SQL_IP_NAME }}
           az_resource_group: ${{ env.az_resource_group_name}}
           az_sql_database_server_name: ${{ env.az_sql_database_server_name }}
-      
-      - name: Store Videos from Cypress Testing
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: cypress-videos
-          path: ./tests/Dfe.PlanTech.Web.E2ETests/cypress/videos
-      
-      - name: Store Screenshots from Cypress Testing on Failure
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: cypress-screenshots
-          path: ./tests/Dfe.PlanTech.Web.E2ETests/cypress/screenshots

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -31,7 +31,7 @@ jobs:
 
             - id: var
               run: |
-                RELEASE=${ENVIRONMENT,,}-`date +%Y-%m-%d`.${{ github.run_number }}
+                RELEASE=${{ inputs.environment }}-`date +%Y-%m-%d`.${{ github.run_number }}
                 GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
                 echo "release=${RELEASE}" >> $GITHUB_OUTPUT
                 echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
@@ -159,14 +159,23 @@ jobs:
         with:
           connection-string: ${{ steps.get-connection-string.outputs.connection_string }}
           path: "./.github/scripts/drop-establishment-data.sql"
-
-      - name: Cypress Testing
-        uses: ./.github/actions/run-e2e-tests
+        
+      - name: Run Cypress Tests
+        uses: cypress-io/github-action@v6
         with:
-          url: ${{ env.az_frontdoor_url }}
-          dsi_url: ${{ env.dsi_url }}
-          dsi_username: ${{ env.dsi_username }}
-          dsi_password: ${{ env.dsi_password }}
+          working-directory: ./tests/Dfe.PlanTech.Web.E2ETests/
+          browser: chrome
+          config: baseUrl=${{ env.az_frontdoor_url }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Cypress Testing
+      #   uses: ./.github/actions/run-e2e-tests
+      #   with:
+      #     url: ${{ env.az_frontdoor_url }}
+      #     dsi_url: ${{ env.dsi_url }}
+      #     dsi_username: ${{ env.dsi_username }}
+      #     dsi_password: ${{ env.dsi_password }}
         
       - name: Remove Azure Firewall Rules
         if: always()
@@ -178,3 +187,17 @@ jobs:
           az_ip_name: ${{ env.SQL_IP_NAME }}
           az_resource_group: ${{ env.az_resource_group_name}}
           az_sql_database_server_name: ${{ env.az_sql_database_server_name }}
+      
+      - name: Store Videos from Cypress Testing
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-videos
+          path: ./tests/Dfe.PlanTech.Web.E2ETests/cypress/videos
+      
+      - name: Store Screenshots from Cypress Testing on Failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-screenshots
+          path: ./tests/Dfe.PlanTech.Web.E2ETests/cypress/screenshots

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -107,8 +107,7 @@ jobs:
         
       runs-on: ubuntu-22.04
       name: Clear Database & Run E2E Tests on ${{ inputs.environment }}
-      if: ${{ inputs.environment == 'dev' || inputs.environment == 'staging' }}
-      # TODO: CHANGE 'dev' BACK TO 'tst' AFTER TESTING
+      if: ${{ inputs.environment == 'tst' || inputs.environment == 'staging' }}
       environment: ${{ inputs.environment }}
       needs: [set-env, pull-image-from-gcr-and-publish-to-acr, deploy-image]
       env:

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -12,6 +12,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
+    AZ_FRONTDOOR_URL: ${{ inputs.environment == 'staging' && secrets.AZ_FRONTDOOR_URL_STAGING || secrets.AZ_FRONTDOOR_URL }}
     GCR_DOCKER_IMAGE: plan-technology-for-your-school
     ACR_DOCKER_IMAGE: plan-tech-app
     GITHUB_CONTAINER_REGISTRY: ghcr.io
@@ -160,7 +161,7 @@ jobs:
       - name: Cypress Testing
         uses: ./.github/actions/run-e2e-tests
         with:
-          url: ${{ secrets.AZ_FRONTDOOR_URL }}
+          url: ${{ env.AZ_FRONTDOOR_URL }}
           dsi_url: ${{ secrets.DSI_URL }}
           dsi_username: ${{ secrets.DSI_USERNAME }}
           dsi_password: ${{ secrets.DSI_PASSWORD }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -106,7 +106,8 @@ jobs:
         
       runs-on: ubuntu-22.04
       name: Clear Database & Run E2E Tests on ${{ inputs.environment }}
-      if: ${{ inputs.environment == 'tst' || inputs.environment == 'staging' }}
+      if: ${{ inputs.environment == 'dev' || inputs.environment == 'staging' }}
+      # TODO: CHANGE 'dev' BACK TO 'tst' AFTER TESTING
       environment: ${{ inputs.environment }}
       needs: [set-env, pull-image-from-gcr-and-publish-to-acr, deploy-image]
       env:

--- a/.github/workflows/matrix-deploy.yml
+++ b/.github/workflows/matrix-deploy.yml
@@ -7,11 +7,6 @@ on:
     paths:
       - 'src/**'
       - '.github/workflows/matrix-deploy.yml'
-  pull_request: # TODO: REMOVE AFTER TESTING
-    branches: ["development"]
-    paths:
-      - 'src/**'
-      - '.github/workflows/matrix-deploy.yml'
     
 jobs:
 

--- a/.github/workflows/matrix-deploy.yml
+++ b/.github/workflows/matrix-deploy.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - 'src/**'
       - '.github/workflows/matrix-deploy.yml'
+  pull_request: # TODO: REMOVE AFTER TESTING
+    branches: ["development"]
+    paths:
+      - 'src/**'
+      - '.github/workflows/matrix-deploy.yml'
     
 jobs:
 


### PR DESCRIPTION
This PR is part of the resolution to fix the environment referencing issue.

We now know that the workflow is referencing the repository secret instead of the environment secret specifically for the "Cypress Testing" stage, but not for the rest of the steps even within the same job.