### PR TITLE
fix: Caching SQL Table fixes

### DIFF
--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
@@ -145,14 +145,15 @@ CREATE TABLE [Contentful].[TextBodies] (
 );
 GO
 
-CREATE TABLE [Contentful].[PageContents] (
+CREATE TABLE [Contentful].[PageContentDbEntity] (
+    [Id] bigint NOT NULL IDENTITY,
     [PageId] nvarchar(30) NOT NULL,
-    [ContentComponentId] nvarchar(30) NOT NULL,
+    [ContentComponentId] nvarchar(30) NULL,
     [BeforeContentComponentId] nvarchar(30) NULL,
-    CONSTRAINT [PK_PageContents] PRIMARY KEY ([PageId], [ContentComponentId]),
-    CONSTRAINT [FK_PageContents_ContentComponents_BeforeContentComponentId] FOREIGN KEY ([BeforeContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
-    CONSTRAINT [FK_PageContents_ContentComponents_ContentComponentId] FOREIGN KEY ([ContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
-    CONSTRAINT [FK_PageContents_Pages_PageId] FOREIGN KEY ([PageId]) REFERENCES [Contentful].[Pages] ([Id]) ON DELETE NO ACTION
+    CONSTRAINT [PK_PageContentDbEntity] PRIMARY KEY ([Id]),
+    CONSTRAINT [FK_PageContentDbEntity_ContentComponents_BeforeContentComponentId] FOREIGN KEY ([BeforeContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
+    CONSTRAINT [FK_PageContentDbEntity_ContentComponents_ContentComponentId] FOREIGN KEY ([ContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
+    CONSTRAINT [FK_PageContentDbEntity_Pages_PageId] FOREIGN KEY ([PageId]) REFERENCES [Contentful].[Pages] ([Id]) ON DELETE NO ACTION
 );
 GO
 
@@ -237,10 +238,13 @@ GO
 CREATE UNIQUE INDEX [IX_ComponentDropDowns_RichTextContentId] ON [Contentful].[ComponentDropDowns] ([RichTextContentId]) WHERE [RichTextContentId] IS NOT NULL;
 GO
 
-CREATE INDEX [IX_PageContents_BeforeContentComponentId] ON [Contentful].[PageContents] ([BeforeContentComponentId]);
+CREATE INDEX [IX_PageContentDbEntity_BeforeContentComponentId] ON [Contentful].[PageContentDbEntity] ([BeforeContentComponentId]);
 GO
 
-CREATE INDEX [IX_PageContents_ContentComponentId] ON [Contentful].[PageContents] ([ContentComponentId]);
+CREATE INDEX [IX_PageContentDbEntity_ContentComponentId] ON [Contentful].[PageContentDbEntity] ([ContentComponentId]);
+GO
+
+CREATE INDEX [IX_PageContentDbEntity_PageId] ON [Contentful].[PageContentDbEntity] ([PageId]);
 GO
 
 CREATE INDEX [IX_Pages_TitleId] ON [Contentful].[Pages] ([TitleId]);

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
@@ -146,9 +146,11 @@ CREATE TABLE [Contentful].[TextBodies] (
 GO
 
 CREATE TABLE [Contentful].[PageContents] (
-    [ContentComponentId] nvarchar(30) NOT NULL,
     [PageId] nvarchar(30) NOT NULL,
-    CONSTRAINT [PK_PageContents] PRIMARY KEY ([ContentComponentId], [PageId]),
+    [ContentComponentId] nvarchar(30) NOT NULL,
+    [BeforeContentComponentId] nvarchar(30) NULL,
+    CONSTRAINT [PK_PageContents] PRIMARY KEY ([PageId], [ContentComponentId]),
+    CONSTRAINT [FK_PageContents_ContentComponents_BeforeContentComponentId] FOREIGN KEY ([BeforeContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
     CONSTRAINT [FK_PageContents_ContentComponents_ContentComponentId] FOREIGN KEY ([ContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
     CONSTRAINT [FK_PageContents_Pages_PageId] FOREIGN KEY ([PageId]) REFERENCES [Contentful].[Pages] ([Id]) ON DELETE NO ACTION
 );
@@ -168,10 +170,10 @@ GO
 
 CREATE TABLE [Contentful].[Warnings] (
     [Id] nvarchar(30) NOT NULL,
-    [TextId] nvarchar(30) NULL,
+    [TextId] nvarchar(30) NOT NULL,
     CONSTRAINT [PK_Warnings] PRIMARY KEY ([Id]),
     CONSTRAINT [FK_Warnings_ContentComponents_Id] FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE,
-    CONSTRAINT [FK_Warnings_TextBodies_TextId] FOREIGN KEY ([TextId]) REFERENCES [Contentful].[TextBodies] ([Id])
+    CONSTRAINT [FK_Warnings_TextBodies_TextId] FOREIGN KEY ([TextId]) REFERENCES [Contentful].[TextBodies] ([Id]) ON DELETE NO ACTION
 );
 GO
 
@@ -232,10 +234,13 @@ GO
 CREATE INDEX [IX_Categories_HeaderId] ON [Contentful].[Categories] ([HeaderId]);
 GO
 
-CREATE INDEX [IX_ComponentDropDowns_RichTextContentId] ON [Contentful].[ComponentDropDowns] ([RichTextContentId]);
+CREATE UNIQUE INDEX [IX_ComponentDropDowns_RichTextContentId] ON [Contentful].[ComponentDropDowns] ([RichTextContentId]) WHERE [RichTextContentId] IS NOT NULL;
 GO
 
-CREATE INDEX [IX_PageContents_PageId] ON [Contentful].[PageContents] ([PageId]);
+CREATE INDEX [IX_PageContents_BeforeContentComponentId] ON [Contentful].[PageContents] ([BeforeContentComponentId]);
+GO
+
+CREATE INDEX [IX_PageContents_ContentComponentId] ON [Contentful].[PageContents] ([ContentComponentId]);
 GO
 
 CREATE INDEX [IX_Pages_TitleId] ON [Contentful].[Pages] ([TitleId]);

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
@@ -146,10 +146,10 @@ CREATE TABLE [Contentful].[TextBodies] (
 GO
 
 CREATE TABLE [Contentful].[PageContents] (
-    [PageId] nvarchar(30) NOT NULL,
-    [ContentComponentId] nvarchar(30) NOT NULL,
     [Id] bigint NOT NULL IDENTITY,
     [BeforeContentComponentId] nvarchar(30) NULL,
+    [ContentComponentId] nvarchar(30) NULL,
+    [PageId] nvarchar(30) NOT NULL,
     CONSTRAINT [PK_PageContents] PRIMARY KEY ([PageId], [ContentComponentId]),
     CONSTRAINT [FK_PageContents_ContentComponents_BeforeContentComponentId] FOREIGN KEY ([BeforeContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
     CONSTRAINT [FK_PageContents_ContentComponents_ContentComponentId] FOREIGN KEY ([ContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
@@ -145,15 +145,15 @@ CREATE TABLE [Contentful].[TextBodies] (
 );
 GO
 
-CREATE TABLE [Contentful].[PageContentDbEntity] (
-    [Id] bigint NOT NULL IDENTITY,
+CREATE TABLE [Contentful].[PageContents] (
     [PageId] nvarchar(30) NOT NULL,
-    [ContentComponentId] nvarchar(30) NULL,
+    [ContentComponentId] nvarchar(30) NOT NULL,
+    [Id] bigint NOT NULL IDENTITY,
     [BeforeContentComponentId] nvarchar(30) NULL,
-    CONSTRAINT [PK_PageContentDbEntity] PRIMARY KEY ([Id]),
-    CONSTRAINT [FK_PageContentDbEntity_ContentComponents_BeforeContentComponentId] FOREIGN KEY ([BeforeContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
-    CONSTRAINT [FK_PageContentDbEntity_ContentComponents_ContentComponentId] FOREIGN KEY ([ContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
-    CONSTRAINT [FK_PageContentDbEntity_Pages_PageId] FOREIGN KEY ([PageId]) REFERENCES [Contentful].[Pages] ([Id]) ON DELETE NO ACTION
+    CONSTRAINT [PK_PageContents] PRIMARY KEY ([PageId], [ContentComponentId]),
+    CONSTRAINT [FK_PageContents_ContentComponents_BeforeContentComponentId] FOREIGN KEY ([BeforeContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
+    CONSTRAINT [FK_PageContents_ContentComponents_ContentComponentId] FOREIGN KEY ([ContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
+    CONSTRAINT [FK_PageContents_Pages_PageId] FOREIGN KEY ([PageId]) REFERENCES [Contentful].[Pages] ([Id]) ON DELETE NO ACTION
 );
 GO
 
@@ -238,13 +238,13 @@ GO
 CREATE UNIQUE INDEX [IX_ComponentDropDowns_RichTextContentId] ON [Contentful].[ComponentDropDowns] ([RichTextContentId]) WHERE [RichTextContentId] IS NOT NULL;
 GO
 
-CREATE INDEX [IX_PageContentDbEntity_BeforeContentComponentId] ON [Contentful].[PageContentDbEntity] ([BeforeContentComponentId]);
+CREATE INDEX [IX_PageContents_BeforeContentComponentId] ON [Contentful].[PageContents] ([BeforeContentComponentId]);
 GO
 
-CREATE INDEX [IX_PageContentDbEntity_ContentComponentId] ON [Contentful].[PageContentDbEntity] ([ContentComponentId]);
+CREATE INDEX [IX_PageContents_ContentComponentId] ON [Contentful].[PageContents] ([ContentComponentId]);
 GO
 
-CREATE INDEX [IX_PageContentDbEntity_PageId] ON [Contentful].[PageContentDbEntity] ([PageId]);
+CREATE INDEX [IX_PageContents_PageId] ON [Contentful].[PageContents] ([PageId]);
 GO
 
 CREATE INDEX [IX_Pages_TitleId] ON [Contentful].[Pages] ([TitleId]);

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
@@ -146,11 +146,10 @@ CREATE TABLE [Contentful].[TextBodies] (
 GO
 
 CREATE TABLE [Contentful].[PageContents] (
-    [Id] bigint NOT NULL IDENTITY,
+    [Id] bigint NOT NULL PRIMARY KEY IDENTITY,
     [BeforeContentComponentId] nvarchar(30) NULL,
     [ContentComponentId] nvarchar(30) NULL,
     [PageId] nvarchar(30) NOT NULL,
-    CONSTRAINT [PK_PageContents] PRIMARY KEY ([PageId], [ContentComponentId]),
     CONSTRAINT [FK_PageContents_ContentComponents_BeforeContentComponentId] FOREIGN KEY ([BeforeContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
     CONSTRAINT [FK_PageContents_ContentComponents_ContentComponentId] FOREIGN KEY ([ContentComponentId]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE NO ACTION,
     CONSTRAINT [FK_PageContents_Pages_PageId] FOREIGN KEY ([PageId]) REFERENCES [Contentful].[Pages] ([Id]) ON DELETE NO ACTION

--- a/src/Dfe.PlanTech.Domain/Content/Models/ComponentDropDownDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/ComponentDropDownDbEntity.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations.Schema;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Content.Models;
@@ -12,8 +13,11 @@ public class ComponentDropDownDbEntity : ContentComponentDbEntity, IComponentDro
     /// </summary>
     public string Title { get; set; } = null!;
 
+    [ForeignKey("RichTextContentId")]
     /// <summary>
     /// The Content to display.
     /// </summary>
     public RichTextContentDbEntity Content { get; set; } = null!;
+
+    public long RichTextContentId { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/PageContentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/PageContentDbEntity.cs
@@ -1,7 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace Dfe.PlanTech.Domain.Content.Models;
 
 public class PageContentDbEntity
 {
+  [Key]
+  [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+  public long Id { get; set; }
+
   public string PageId { get; set; } = null!;
   public PageDbEntity Page { get; set; } = null!;
 

--- a/src/Dfe.PlanTech.Domain/Content/Models/PageContentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/PageContentDbEntity.cs
@@ -2,7 +2,12 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 
 public class PageContentDbEntity
 {
-    public PageDbEntity Page { get; set; } = null!;
+  public string PageId { get; set; } = null!;
+  public PageDbEntity Page { get; set; } = null!;
 
-    public ContentComponentDbEntity ContentComponent { get; set; } = null!;
+  public string? ContentComponentId { get; set; }
+  public ContentComponentDbEntity? ContentComponent { get; set; }
+
+  public string? BeforeContentComponentId { get; set; }
+  public ContentComponentDbEntity? BeforeContentComponent { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/RichTextContentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/RichTextContentDbEntity.cs
@@ -30,4 +30,6 @@ public class RichTextContentDbEntity : IRichTextContent<RichTextMarkDbEntity, Ri
     public RichTextContentDbEntity? Parent { get; set; }
 
     public long? ParentId { get; set; }
+
+    public ComponentDropDownDbEntity? DropDown { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/TextBodyDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/TextBodyDbEntity.cs
@@ -10,4 +10,6 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 public class TextBodyDbEntity : ContentComponentDbEntity, ITextBody<RichTextContentDbEntity>
 {
     public RichTextContentDbEntity RichText { get; set; } = null!;
+
+    public List<WarningComponentDbEntity> Warnings { get; set; } = new();
 }

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -31,8 +31,6 @@ public class CmsDbContext : DbContext
 
     public DbSet<PageDbEntity> Pages { get; set; }
 
-    public DbSet<PageContentDbEntity> PageContents { get; set; }
-
     public DbSet<RecommendationPageDbEntity> RecommendationPages { get; set; }
 
     public DbSet<RichTextContentDbEntity> RichTextContents { get; set; }
@@ -146,6 +144,11 @@ public class CmsDbContext : DbContext
         modelBuilder.Entity<TitleDbEntity>(entity =>
         {
             entity.ToTable("Titles", Schema);
+        });
+
+        modelBuilder.Entity<WarningComponentDbEntity>(entity =>
+        {
+            entity.HasOne(warning => warning.Text).WithMany(text => text.Warnings).OnDelete(DeleteBehavior.Restrict);
         });
     }
 }

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -31,6 +31,8 @@ public class CmsDbContext : DbContext
 
     public DbSet<PageDbEntity> Pages { get; set; }
 
+    public DbSet<PageContentDbEntity> PageContents { get; set; }
+
     public DbSet<RecommendationPageDbEntity> RecommendationPages { get; set; }
 
     public DbSet<RichTextContentDbEntity> RichTextContents { get; set; }

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -86,12 +86,6 @@ public class CmsDbContext : DbContext
             entity.ToTable("Categories", Schema);
         });
 
-        modelBuilder.Entity<PageContentDbEntity>(entity =>
-        {
-            entity.ToTable("PageContents", Schema);
-            entity.HasKey(pageContent => new { pageContent.PageId, pageContent.ContentComponentId });
-        });
-
         modelBuilder.Entity<PageDbEntity>(entity =>
         {
             entity.HasMany(page => page.BeforeTitleContent)

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -31,6 +31,8 @@ public class CmsDbContext : DbContext
 
     public DbSet<PageDbEntity> Pages { get; set; }
 
+    public DbSet<PageContentDbEntity> PageContents { get; set; }
+
     public DbSet<RecommendationPageDbEntity> RecommendationPages { get; set; }
 
     public DbSet<RichTextContentDbEntity> RichTextContents { get; set; }
@@ -89,6 +91,7 @@ public class CmsDbContext : DbContext
         modelBuilder.Entity<PageContentDbEntity>(entity =>
         {
             entity.ToTable("PageContents", Schema);
+            entity.HasKey(pageContent => new { pageContent.PageId, pageContent.ContentComponentId });
         });
 
         modelBuilder.Entity<PageDbEntity>(entity =>
@@ -96,13 +99,16 @@ public class CmsDbContext : DbContext
             entity.HasMany(page => page.BeforeTitleContent)
               .WithMany(c => c.BeforeTitleContentPages)
               .UsingEntity<PageContentDbEntity>(
-                left => left.HasOne(pageContent => pageContent.ContentComponent).WithMany().OnDelete(DeleteBehavior.Restrict),
-                right => right.HasOne(pageContent => pageContent.Page).WithMany().OnDelete(DeleteBehavior.Restrict)
+                left => left.HasOne(pageContent => pageContent.BeforeContentComponent).WithMany().HasForeignKey("BeforeContentComponentId").OnDelete(DeleteBehavior.Restrict),
+                right => right.HasOne(pageContent => pageContent.Page).WithMany().HasForeignKey("PageId").OnDelete(DeleteBehavior.Restrict)
               );
 
             entity.HasMany(page => page.Content)
               .WithMany(c => c.ContentPages)
-              .UsingEntity<PageContentDbEntity>();
+              .UsingEntity<PageContentDbEntity>(
+                left => left.HasOne(pageContent => pageContent.ContentComponent).WithMany().HasForeignKey("ContentComponentId").OnDelete(DeleteBehavior.Restrict),
+                right => right.HasOne(pageContent => pageContent.Page).WithMany().HasForeignKey("PageId").OnDelete(DeleteBehavior.Restrict)
+              );
 
             entity.HasOne(page => page.Title).WithMany(title => title.Pages).OnDelete(DeleteBehavior.Restrict);
 


### PR DESCRIPTION
Minor changes to the SQL table schemas:

- Fixes missing Page -> Content relationship
- Adds foreign key field to DropDown class for the RichText content, and renames the actual foreign key due to name already in use
- Fixes warning -> textbody relationship not working
- Updates SQL script