### PR TITLE
feat: Add remaining caching mappers

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonDbMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonDbMapper.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.AzureFunctions.Mappings;
+
+public class ButtonDbMapper : JsonToDbMapper<ButtonDbEntity>
+{
+  public ButtonDbMapper(ILogger<ButtonDbMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
+  {
+  }
+
+  public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
+  {
+    return values;
+  }
+}

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonWithEntryReferenceMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonWithEntryReferenceMapper.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.AzureFunctions.Mappings;
+
+public class ButtonWithEntryReferenceMapper : JsonToDbMapper<ButtonWithEntryReferenceDbEntity>
+{
+  public ButtonWithEntryReferenceMapper(ILogger<ButtonWithEntryReferenceMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
+  {
+  }
+
+  public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
+  {
+    values = MoveValueToNewKey(values, "button", "buttonId");
+    values = MoveValueToNewKey(values, "linkToEntry", "linkToEntryId");
+
+    return values;
+  }
+}

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonWithLinkMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonWithLinkMapper.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.AzureFunctions.Mappings;
+
+public class ButtonWithLinkMapper : JsonToDbMapper<ButtonWithLinkDbEntity>
+{
+  public ButtonWithLinkMapper(ILogger<ButtonWithLinkMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
+  {
+  }
+
+  public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
+  {
+    values = MoveValueToNewKey(values, "button", "buttonId");
+
+    return values;
+  }
+}

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/CategoryMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/CategoryMapper.cs
@@ -18,7 +18,6 @@ public class CategoryMapper : JsonToDbMapper<CategoryDbEntity>
   {
     values = MoveValueToNewKey(values, "header", "headerId");
 
-    UpdateReferencesArray(values, "recommendations", _db.RecommendationPages, (id, recommendationPage) => recommendationPage.SectionId = Payload!.Sys.Id);
     UpdateReferencesArray(values, "sections", _db.Sections, (id, section) => section.CategoryId = Payload!.Sys.Id);
 
     return values;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/CategoryMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/CategoryMapper.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.AzureFunctions.Mappings;
+
+public class CategoryMapper : JsonToDbMapper<CategoryDbEntity>
+{
+  private readonly CmsDbContext _db;
+
+  public CategoryMapper(CmsDbContext db, ILogger<CategoryMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
+  {
+    _db = db;
+  }
+
+  public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
+  {
+    values = MoveValueToNewKey(values, "header", "headerId");
+
+    UpdateReferencesArray(values, "recommendations", _db.RecommendationPages, (id, recommendationPage) => recommendationPage.SectionId = Payload!.Sys.Id);
+    UpdateReferencesArray(values, "sections", _db.Sections, (id, section) => section.CategoryId = Payload!.Sys.Id);
+
+    return values;
+  }
+}

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
@@ -91,7 +91,7 @@ public abstract class JsonToDbMapper
     }
 
     public virtual bool AcceptsContentType(string contentType)
-      => _entityType.Name.Contains(contentType, StringComparison.InvariantCultureIgnoreCase);
+      => _entityType.Name.Equals($"{contentType}DbEntity", StringComparison.InvariantCultureIgnoreCase);
 
     public abstract ContentComponentDbEntity MapEntity(CmsWebHookPayload payload);
 

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Content.Models;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
@@ -36,6 +37,43 @@ where TEntity : ContentComponentDbEntity, new()
     public override ContentComponentDbEntity MapEntity(CmsWebHookPayload payload) => ToEntity(payload);
 
     public abstract Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values);
+
+    protected void UpdateReferencesArray<TRelatedEntity>(Dictionary<string, object?> values, string key, DbSet<TRelatedEntity> dbSet, Action<string, TRelatedEntity> updateEntity)
+        where TRelatedEntity : ContentComponentDbEntity, new()
+    {
+        if (values.TryGetValue(key, out object? referencesArray) && referencesArray is object[] inners)
+        {
+            foreach (var inner in inners)
+            {
+                UpdateRelatedEntity(inner, dbSet, updateEntity);
+            }
+
+            values.Remove(key);
+        }
+        else
+        {
+            Logger.LogError("Expected {key} to be references array but received {type}", key, referencesArray?.GetType());
+        }
+    }
+
+    protected void UpdateRelatedEntity<TRelatedEntity>(object inner, DbSet<TRelatedEntity> dbSet, Action<string, TRelatedEntity> updateEntity)
+        where TRelatedEntity : ContentComponentDbEntity, new()
+    {
+        if (inner is not string id)
+        {
+            Logger.LogWarning("Expected string but received {innerType}", inner.GetType());
+            return;
+        }
+
+        var relatedEntity = new TRelatedEntity()
+        {
+            Id = id
+        };
+
+        dbSet.Attach(relatedEntity);
+
+        updateEntity(id, relatedEntity);
+    }
 }
 
 public abstract class JsonToDbMapper

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/QuestionMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/QuestionMapper.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.Extensions.Logging;
@@ -24,32 +23,6 @@ public class QuestionMapper : JsonToDbMapper<QuestionDbEntity>
 
     private void UpdateAnswersParentQuestionIds(Dictionary<string, object?> values)
     {
-        if (values.TryGetValue("answers", out object? answersArray) && answersArray is object[] inners)
-        {
-            foreach (var inner in inners)
-            {
-                UpdateAnswerParentQuestionId(inner);
-            }
-
-            values.Remove("answers");
-        }
-    }
-
-    private void UpdateAnswerParentQuestionId(object inner)
-    {
-        if (inner is not string id)
-        {
-            Logger.LogWarning("Expected string but received {innerType}", inner.GetType());
-            return;
-        }
-
-        var answer = new AnswerDbEntity()
-        {
-            Id = id
-        };
-
-        _db.Answers.Attach(answer);
-
-        answer.ParentQuestionId = Payload!.Sys.Id;
+        UpdateReferencesArray(values, "answers", _db.Answers, (id, answer) => answer.ParentQuestionId = Payload!.Sys.Id);
     }
 }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/RecommendationPageMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/RecommendationPageMapper.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.AzureFunctions.Mappings;
+
+public class RecommendationPageMapper : JsonToDbMapper<RecommendationPageDbEntity>
+{
+  public RecommendationPageMapper(ILogger<RecommendationPageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
+  {
+  }
+
+  public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
+  {
+    values = MoveValueToNewKey(values, "page", "pageId");
+
+    return values;
+  }
+}

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/SectionMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/SectionMapper.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.AzureFunctions.Mappings;
+
+public class SectionMapper : JsonToDbMapper<SectionDbEntity>
+{
+    private readonly CmsDbContext _db;
+
+    public SectionMapper(CmsDbContext db, ILogger<SectionMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
+    {
+        _db = db;
+    }
+
+    public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
+    {
+        values = MoveValueToNewKey(values, "interstitialPage", "interstitialPageId");
+
+        UpdateReferencesArray(values, "questions", _db.Questions, (id, question) => question.SectionId = Payload!.Sys.Id);
+
+        return values;
+    }
+}

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2023/20231206_1457_CreateCmsDbSchemas.sql
@@ -195,11 +195,11 @@ CREATE TABLE [Contentful].[RecommendationPages] (
     [DisplayName] nvarchar(max) NOT NULL,
     [Maturity] int NOT NULL,
     [PageId] nvarchar(30) NOT NULL,
-    [SectionDbEntityId] nvarchar(30) NULL,
+    [SectionId] nvarchar(30) NULL,
     CONSTRAINT [PK_RecommendationPages] PRIMARY KEY ([Id]),
     CONSTRAINT [FK_RecommendationPages_ContentComponents_Id] FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE,
     CONSTRAINT [FK_RecommendationPages_Pages_PageId] FOREIGN KEY ([PageId]) REFERENCES [Contentful].[Pages] ([Id]) ON DELETE NO ACTION,
-    CONSTRAINT [FK_RecommendationPages_Sections_SectionDbEntityId] FOREIGN KEY ([SectionDbEntityId]) REFERENCES [Contentful].[Sections] ([Id])
+    CONSTRAINT [FK_RecommendationPages_Sections_SectionId] FOREIGN KEY ([SectionId]) REFERENCES [Contentful].[Sections] ([Id])
 );
 GO
 

--- a/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonDbEntity.cs
@@ -4,7 +4,7 @@ namespace Dfe.PlanTech.Domain.Content.Models.Buttons;
 
 public class ButtonDbEntity : ContentComponentDbEntity, IButton
 {
-    public string Value { get; init; } = null!;
+    public string Value { get; set; } = null!;
 
-    public bool IsStartButton { get; init; }
+    public bool IsStartButton { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonWithEntryReferenceDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonWithEntryReferenceDbEntity.cs
@@ -9,6 +9,10 @@ public class ButtonWithEntryReferenceDbEntity : ContentComponentDbEntity, IButto
 {
     public ButtonDbEntity Button { get; set; } = null!;
 
+    public string ButtonId { get; set; } = null!;
+
     public ContentComponentDbEntity LinkToEntry { get; set; } = null!;
+
+    public string LinkToEntryId { get; set; } = null!;
 }
 

--- a/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonWithLinkDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonWithLinkDbEntity.cs
@@ -9,6 +9,7 @@ namespace Dfe.PlanTech.Domain.Content.Models.Buttons;
 public class ButtonWithLinkDbEntity : ContentComponentDbEntity, IButtonWithLink<ButtonDbEntity>
 {
     public ButtonDbEntity Button { get; set; } = null!;
+    public string ButtonId { get; set; } = null!;
 
     public string Href { get; set; } = null!;
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/CategoryDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/CategoryDbEntity.cs
@@ -5,6 +5,7 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class CategoryDbEntity : ContentComponentDbEntity, ICategory<HeaderDbEntity, SectionDbEntity>
 {
+    public string HeaderId { get; set; } = null!;
     public HeaderDbEntity Header { get; set; } = null!;
 
     public List<SectionDbEntity> Sections { get; set; } = new();

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationPageDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationPageDbEntity.cs
@@ -15,4 +15,8 @@ public class RecommendationPageDbEntity : ContentComponentDbEntity, IRecommendat
     public PageDbEntity Page { get; set; } = null!;
 
     public string PageId { get; set; } = null!;
+
+    public Section? Section { get; set; }
+
+    public string? SectionId { get; set; }
 }

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -33,6 +33,8 @@ public class CmsDbContext : DbContext
 
     public DbSet<PageContentDbEntity> PageContents { get; set; }
 
+    public DbSet<QuestionDbEntity> Questions { get; set; }
+
     public DbSet<RecommendationPageDbEntity> RecommendationPages { get; set; }
 
     public DbSet<RichTextContentDbEntity> RichTextContents { get; set; }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/AnswerMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/AnswerMapperTests.cs
@@ -45,6 +45,5 @@ public class AnswerMapperTests : BaseMapperTests
     Assert.True(string.Equals(AnswerMaturity.ToString(), concrete.Maturity, StringComparison.InvariantCultureIgnoreCase));
     Assert.Equal(AnswerText, concrete.Text);
     Assert.Equal(NextQuestion.Sys.Id, concrete.NextQuestionId);
-
   }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/BaseMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/BaseMapperTests.cs
@@ -19,7 +19,6 @@ public abstract class BaseMapperTests
     [localisation] = toWrap
   };
 
-
   protected CmsWebHookPayload CreatePayload(Dictionary<string, object?> fields, string entityId)
   {
     var asJson = JsonSerializer.Serialize(fields, JsonOptions);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonMapperTests.cs
@@ -1,0 +1,47 @@
+using Dfe.PlanTech.AzureFunctions.Mappings;
+using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dfe.PlanTech.AzureFunctions.UnitTests;
+
+public class ButtonMapperTests : BaseMapperTests
+{
+  private const string ButtonId = "ButtonId Id";
+
+  private readonly ButtonDbMapper _mapper;
+  private readonly ILogger<ButtonDbMapper> _logger;
+
+  public ButtonMapperTests()
+  {
+    _logger = Substitute.For<ILogger<ButtonDbMapper>>();
+    _mapper = new ButtonDbMapper(_logger, JsonOptions);
+  }
+
+  [Theory]
+  [InlineData("Button value", true)]
+  [InlineData("Button value", false)]
+  [InlineData("", true)]
+  [InlineData("", false)]
+  public void Mapper_Should_Map_Button(string buttonValue, bool isStartButton)
+  {
+    var fields = new Dictionary<string, object?>()
+    {
+      ["value"] = WrapWithLocalisation(buttonValue),
+      ["isStartButton"] = WrapWithLocalisation(isStartButton),
+    };
+
+    var payload = CreatePayload(fields, ButtonId);
+
+    var mapped = _mapper.MapEntity(payload);
+
+    Assert.NotNull(mapped);
+
+    var concrete = mapped as ButtonDbEntity;
+    Assert.NotNull(concrete);
+
+    Assert.Equal(ButtonId, concrete.Id);
+    Assert.True(string.Equals(buttonValue.ToString(), concrete.Value, StringComparison.InvariantCultureIgnoreCase));
+    Assert.Equal(isStartButton, concrete.IsStartButton);
+  }
+}

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonWithEntryReferenceMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonWithEntryReferenceMapperTests.cs
@@ -1,0 +1,58 @@
+using Dfe.PlanTech.AzureFunctions.Mappings;
+using Dfe.PlanTech.Domain.Caching.Models;
+using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dfe.PlanTech.AzureFunctions.UnitTests;
+
+public class ButtonWithEntryReferenceMapperTests : BaseMapperTests
+{
+  private const string ButtonWithEntryReferenceId = "ButtonId Id";
+  private readonly CmsWebHookSystemDetailsInnerContainer EntryReference = new()
+  {
+    Sys = new()
+    {
+      Id = "Entry reference Id"
+    }
+  };
+  private readonly CmsWebHookSystemDetailsInnerContainer ButtonReference = new()
+  {
+    Sys = new()
+    {
+      Id = "Button reference Id"
+    }
+  };
+
+  private readonly ButtonWithEntryReferenceMapper _mapper;
+  private readonly ILogger<ButtonWithEntryReferenceMapper> _logger;
+
+  public ButtonWithEntryReferenceMapperTests()
+  {
+    _logger = Substitute.For<ILogger<ButtonWithEntryReferenceMapper>>();
+    _mapper = new ButtonWithEntryReferenceMapper(_logger, JsonOptions);
+  }
+
+  [Fact]
+  public void Mapper_Should_Map_ButtonWithEntryReference()
+  {
+    var fields = new Dictionary<string, object?>()
+    {
+      ["button"] = WrapWithLocalisation(ButtonReference),
+      ["linkToEntry"] = WrapWithLocalisation(EntryReference),
+    };
+
+    var payload = CreatePayload(fields, ButtonWithEntryReferenceId);
+
+    var mapped = _mapper.MapEntity(payload);
+
+    Assert.NotNull(mapped);
+
+    var concrete = mapped as ButtonWithEntryReferenceDbEntity;
+    Assert.NotNull(concrete);
+
+    Assert.Equal(ButtonWithEntryReferenceId, concrete.Id);
+    Assert.Equal(EntryReference.Sys.Id, concrete.LinkToEntryId);
+    Assert.Equal(ButtonReference.Sys.Id, concrete.ButtonId);
+  }
+}

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonWithLinkMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonWithLinkMapperTests.cs
@@ -1,0 +1,52 @@
+using Dfe.PlanTech.AzureFunctions.Mappings;
+using Dfe.PlanTech.Domain.Caching.Models;
+using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dfe.PlanTech.AzureFunctions.UnitTests;
+
+public class ButtonWithLinkMapperTests : BaseMapperTests
+{
+  private const string ButtonWithLinkId = "ButtonId Id";
+  private const string Href = "www.website.com";
+  private readonly CmsWebHookSystemDetailsInnerContainer ButtonReference = new()
+  {
+    Sys = new()
+    {
+      Id = "Button reference Id"
+    }
+  };
+
+  private readonly ButtonWithLinkMapper _mapper;
+  private readonly ILogger<ButtonWithLinkMapper> _logger;
+
+  public ButtonWithLinkMapperTests()
+  {
+    _logger = Substitute.For<ILogger<ButtonWithLinkMapper>>();
+    _mapper = new ButtonWithLinkMapper(_logger, JsonOptions);
+  }
+
+  [Fact]
+  public void Mapper_Should_Map_ButtonWithEntryReference()
+  {
+    var fields = new Dictionary<string, object?>()
+    {
+      ["button"] = WrapWithLocalisation(ButtonReference),
+      ["href"] = WrapWithLocalisation(Href),
+    };
+
+    var payload = CreatePayload(fields, ButtonWithLinkId);
+
+    var mapped = _mapper.MapEntity(payload);
+
+    Assert.NotNull(mapped);
+
+    var concrete = mapped as ButtonWithLinkDbEntity;
+    Assert.NotNull(concrete);
+
+    Assert.Equal(ButtonWithLinkId, concrete.Id);
+    Assert.Equal(Href, concrete.Href);
+    Assert.Equal(ButtonReference.Sys.Id, concrete.ButtonId);
+  }
+}

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/CategoryMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/CategoryMapperTests.cs
@@ -1,0 +1,79 @@
+using Dfe.PlanTech.AzureFunctions.Mappings;
+using Dfe.PlanTech.Domain.Answers.Models;
+using Dfe.PlanTech.Domain.Caching.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dfe.PlanTech.AzureFunctions.UnitTests;
+
+public class CategoryMapperTests : BaseMapperTests
+{
+  private readonly CmsWebHookSystemDetailsInnerContainer[] Sections = new[]{
+    new CmsWebHookSystemDetailsInnerContainer() {Sys = new() { Id = "Section One Id" } },
+    new CmsWebHookSystemDetailsInnerContainer() {Sys = new() { Id = "Section Two Id" } },
+    new CmsWebHookSystemDetailsInnerContainer() {Sys = new() { Id = "Section Three Id" } },
+    };
+  private readonly CmsWebHookSystemDetailsInnerContainer Header = new()
+  {
+    Sys = new()
+    {
+      Id = "Header Id"
+    }
+  };
+  private const string CategoryId = "Category Id";
+
+  private readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
+  private readonly CategoryMapper _mapper;
+  private readonly ILogger<CategoryMapper> _logger;
+
+  private readonly DbSet<SectionDbEntity> _sectionsDbSet = Substitute.For<DbSet<SectionDbEntity>>();
+  private readonly List<SectionDbEntity> _attachedSections = new(4);
+
+  public CategoryMapperTests()
+  {
+    _logger = Substitute.For<ILogger<CategoryMapper>>();
+    _mapper = new CategoryMapper(_db, _logger, JsonOptions);
+
+    _db.Sections = _sectionsDbSet;
+
+    _sectionsDbSet.WhenForAnyArgs(sectionDbSet => sectionDbSet.Attach(Arg.Any<SectionDbEntity>()))
+                .Do(callinfo =>
+                {
+                  var section = callinfo.ArgAt<SectionDbEntity>(0);
+                  _attachedSections.Add(section);
+                });
+  }
+
+  [Fact]
+  public void Mapper_Should_Map_Category()
+  {
+    var fields = new Dictionary<string, object?>()
+    {
+      ["header"] = WrapWithLocalisation(Header),
+      ["sections"] = WrapWithLocalisation(Sections),
+    };
+
+    var payload = CreatePayload(fields, CategoryId);
+
+    var mapped = _mapper.MapEntity(payload);
+
+    Assert.NotNull(mapped);
+
+    var concrete = mapped as CategoryDbEntity;
+    Assert.NotNull(concrete);
+
+    Assert.Equal(CategoryId, concrete.Id);
+    Assert.Equal(Header.Sys.Id, concrete.HeaderId);
+
+    Assert.Equal(Sections.Length, _attachedSections.Count);
+
+    foreach (var section in Sections)
+    {
+      var contains = _attachedSections.Any(attached => attached.Id == section.Sys.Id);
+      Assert.True(contains);
+    }
+  }
+}

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/JsonToDbMapperUnitTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/JsonToDbMapperUnitTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using Dfe.PlanTech.AzureFunctions.Mappings;
 using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Content.Models.Buttons;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
@@ -15,6 +16,7 @@ public class JsonToDbMapperUnitTests : BaseMapperTests
   private readonly string[] ArrayValueTest = new[] { "one", "two", "three" };
   private const int NumberValueTest = 10000;
   private const string EntityId = "Testing Id";
+
   private readonly CmsWebHookSystemDetailsInnerContainer[] ReferencesValueTest = new[] {
         new CmsWebHookSystemDetailsInnerContainer(){
           Sys = new(){
@@ -29,7 +31,7 @@ public class JsonToDbMapperUnitTests : BaseMapperTests
 
   private readonly JsonToDbMapperImplementation _mapper;
 
-  private readonly Type _type = typeof(ContentComponentDbEntityImplementation);
+  private readonly Type _type = typeof(ButtonWithLinkDbEntity);
 
   private readonly ILogger _logger = Substitute.For<ILogger>();
 
@@ -38,20 +40,15 @@ public class JsonToDbMapperUnitTests : BaseMapperTests
     _mapper = new JsonToDbMapperImplementation(_type, _logger, JsonOptions);
   }
 
-  [Fact]
-  public void AcceptsContentType_Should_Return_True_When_Matched()
+  [Theory]
+  [InlineData("ButtonWithLink", true)]
+  [InlineData("Button", false)]
+  [InlineData("ButtonWithEntryReference", false)]
+  public void AcceptsContentType_Should_Return_Correct_Output(string typeName, bool expectedResult)
   {
-    var acceptsContentType = _mapper.AcceptsContentType(_type.Name);
+    var acceptsContentType = _mapper.AcceptsContentType(typeName);
 
-    Assert.True(acceptsContentType);
-  }
-
-  [Fact]
-  public void AcceptsContentType_Should_Return_False_When_Not_Matched()
-  {
-    var acceptsContentType = _mapper.AcceptsContentType("Different content type");
-
-    Assert.False(acceptsContentType);
+    Assert.Equal(expectedResult, acceptsContentType);
   }
 
   [Fact]

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/QuestionMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/QuestionMapperTests.cs
@@ -14,8 +14,8 @@ namespace Dfe.PlanTech.AzureFunctions.UnitTests;
 public class QuestionMapperTests : BaseMapperTests
 {
   private const string QuestionText = "Question text goes here";
-  private const string QuestionHelpText = "";
-  private const string QuestionSlug = "";
+  private const string QuestionHelpText = "Question help text";
+  private const string QuestionSlug = "/question-slug";
   private readonly CmsWebHookSystemDetailsInnerContainer[] Answers = new[]{
     new CmsWebHookSystemDetailsInnerContainer() {Sys = new() { Id = "Answer One Id" } },
     new CmsWebHookSystemDetailsInnerContainer() {Sys = new() { Id = "Answer Two Id" } },

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationPageMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationPageMapperTests.cs
@@ -1,0 +1,58 @@
+using Dfe.PlanTech.AzureFunctions.Mappings;
+using Dfe.PlanTech.Domain.Caching.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Enums;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dfe.PlanTech.AzureFunctions.UnitTests;
+
+public class RecommendationPageMapperTests : BaseMapperTests
+{
+  private const string RecommendationId = "Recommendation Id 1234";
+  private const string DisplayName = "Recommendation page display name";
+  private const string InternalName = "Recommendation page internal name";
+  private const Maturity RecommendationMaturity = Maturity.Medium;
+  private readonly CmsWebHookSystemDetailsInnerContainer Page = new()
+  {
+    Sys = new()
+    {
+      Id = "Page Reference Id"
+    }
+  };
+
+  private readonly RecommendationPageMapper _mapper;
+  private readonly ILogger<RecommendationPageMapper> _logger;
+
+  public RecommendationPageMapperTests()
+  {
+    _logger = Substitute.For<ILogger<RecommendationPageMapper>>();
+    _mapper = new RecommendationPageMapper(_logger, JsonOptions);
+  }
+
+  [Fact]
+  public void Mapper_Should_Map_Relationship()
+  {
+    var fields = new Dictionary<string, object?>()
+    {
+      ["displayName"] = WrapWithLocalisation(DisplayName),
+      ["internalName"] = WrapWithLocalisation(InternalName),
+      ["maturity"] = WrapWithLocalisation(RecommendationMaturity),
+      ["page"] = WrapWithLocalisation(Page),
+    };
+
+    var payload = CreatePayload(fields, RecommendationId);
+
+    var mapped = _mapper.MapEntity(payload);
+
+    Assert.NotNull(mapped);
+
+    var concrete = mapped as RecommendationPageDbEntity;
+    Assert.NotNull(concrete);
+
+    Assert.Equal(RecommendationId, concrete.Id);
+    Assert.Equal(DisplayName, concrete.DisplayName);
+    Assert.Equal(InternalName, concrete.InternalName);
+    Assert.Equal(Page.Sys.Id, concrete.PageId);
+  }
+}


### PR DESCRIPTION
**Features**:

Adds remaining mappers for Contentful -> Db:
- Buttons
- Category
- RecommendationPage
- Section

**Minor changes**:
- Rename a column in table to match the other's naming convention
- Refactor a couple methods
- Add a missing field for relationship