### PR TITLE
Fix Pipeline Skipping Issue

### DIFF
--- a/.github/workflows/build-and-deploy-azure-function.yml
+++ b/.github/workflows/build-and-deploy-azure-function.yml
@@ -8,7 +8,7 @@ on:
                 required: true
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
+    group: ${{ github.workflow }}-${{ github.event.inputs.environment }}-azure-function
     cancel-in-progress: true
 
 env:

--- a/.github/workflows/matrix-deploy.yml
+++ b/.github/workflows/matrix-deploy.yml
@@ -7,11 +7,6 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/matrix-deploy.yml"
-  pull_request:                               # DEBUG --- REMOVE AFTER TESTING
-    branches: ["development"]                 # DEBUG --- REMOVE AFTER TESTING
-    paths:                                    # DEBUG --- REMOVE AFTER TESTING
-      - "src/**"                              # DEBUG --- REMOVE AFTER TESTING
-      - ".github/workflows/matrix-deploy.yml" # DEBUG --- REMOVE AFTER TESTING
 
 jobs:
   set-env:

--- a/.github/workflows/matrix-deploy.yml
+++ b/.github/workflows/matrix-deploy.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/matrix-deploy.yml"
+  pull_request:                               # DEBUG --- REMOVE AFTER TESTING
+    branches: ["development"]                 # DEBUG --- REMOVE AFTER TESTING
+    paths:                                    # DEBUG --- REMOVE AFTER TESTING
+      - "src/**"                              # DEBUG --- REMOVE AFTER TESTING
+      - ".github/workflows/matrix-deploy.yml" # DEBUG --- REMOVE AFTER TESTING
 
 jobs:
   set-env:

--- a/.github/workflows/validate-scripts.yml
+++ b/.github/workflows/validate-scripts.yml
@@ -54,6 +54,10 @@ jobs:
           shell: bash
           run: docker run --cap-add SYS_PTRACE -e 'ACCEPT_EULA=1' -e 'MSSQL_SA_PASSWORD=${{ env.FAKE_PASSWORD }}' -p 1433:1433 --name azuresqledge -d mcr.microsoft.com/azure-sql-edge
 
+        - name: Wait for Docker Image to Startup
+          shell: bash
+          run: sleep 16s
+
         - name: Run Database Upgrader
           shell: bash
           run: dotnet ./build/Dfe.PlanTech.DatabaseUpgrader.dll -c "${{ steps.connection-string.outputs.CONNECTION_STRING }}"


### PR DESCRIPTION
The Matrix Build & Deploy for [PR 307](https://github.com/DFE-Digital/plan-technology-for-your-school/actions/runs/7248765753) is skipping jobs unexpectedly, this PR is for implementing a fix.

Also adds a wait timer to the `validate-scripts.yml` pipeline, as this should ensure the Docker daemon for the SQL server has started up before DbUpgrader runs on it. Could be replaced with a more sophisticated wait method in the future but would be complex.