### PR TITLE
feat/189212 - Single error page

### DIFF
--- a/src/Dfe.PlanTech.Application/Constants/UrlConstants.cs
+++ b/src/Dfe.PlanTech.Application/Constants/UrlConstants.cs
@@ -9,4 +9,6 @@ public static class UrlConstants
     public const string OrgErrorPage = "/dsi-error-not-associated-organisation";
 
     public const string RoleErrorPage = "/dsi-error-organisation-approval";
+
+    public const string CombinedErrorPage = "dsi-error-no-organisation-or-approval";
 }

--- a/src/Dfe.PlanTech.Web/Middleware/ServiceExceptionHandlerMiddleWare.cs
+++ b/src/Dfe.PlanTech.Web/Middleware/ServiceExceptionHandlerMiddleWare.cs
@@ -23,8 +23,8 @@ public class ServiceExceptionHandlerMiddleWare : IExceptionHandlerMiddleware
         exception switch
         {
             null => UrlConstants.Error,
-            UserAccessUnavailableException => UrlConstants.RoleErrorPage,
-            UserAccessRoleNotFoundException => UrlConstants.RoleErrorPage,
+            UserAccessUnavailableException => UrlConstants.CombinedErrorPage,
+            UserAccessRoleNotFoundException => UrlConstants.CombinedErrorPage,
             ContentfulDataUnavailableException => UrlConstants.ServiceUnavailable,
             DatabaseException => UrlConstants.ServiceUnavailable,
             InvalidEstablishmentException => UrlConstants.ServiceUnavailable,

--- a/tests/Dfe.PlanTech.Web.UnitTests/Middleware/ServiceExceptionHandlerMiddlewareTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Middleware/ServiceExceptionHandlerMiddlewareTests.cs
@@ -42,7 +42,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Middleware
 
             //Assert
             Assert.NotNull(context.Response);
-            Assert.Equal(UrlConstants.RoleErrorPage, context.Response.Headers.Values.FirstOrDefault());
+            Assert.Equal(UrlConstants.CombinedErrorPage, context.Response.Headers.Values.FirstOrDefault());
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Middleware
 
             //Assert
             Assert.NotNull(context.Response);
-            Assert.Equal(UrlConstants.RoleErrorPage, context.Response.Headers.Values.FirstOrDefault());
+            Assert.Equal(UrlConstants.CombinedErrorPage, context.Response.Headers.Values.FirstOrDefault());
         }
 
         [Fact]


### PR DESCRIPTION
 - added single error page for organisation and service errors. Could be temporary if DSI team fix their issue around the data