### PR TITLE
fix: Add missing FKs and indexes

### DIFF
--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
@@ -4,64 +4,43 @@ GO
 -- Buttons
 ALTER TABLE [Contentful].[Buttons]
 ADD CONSTRAINT [FK_Buttons_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
 GO
 
-CREATE INDEX [IX_Buttons_Id] ON [Contentful].[Buttons] ([Id]);
-GO
+-- ComponentDropdowns
+ALTER TABLE [Contentful].[ComponentDropdowns]
+ADD CONSTRAINT [FK_ComponentDropdowns_ContentComponents_Id]
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
 
 -- Headers
 ALTER TABLE [Contentful].[Headers]
 ADD CONSTRAINT [FK_Headers_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
-GO
-
-CREATE INDEX [IX_Headers_Id] ON [Contentful].[Headers] ([Id]);
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
 GO
 
 -- InsetTexts
 ALTER TABLE [Contentful].[InsetTexts]
 ADD CONSTRAINT [FK_InsetTexts_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
 GO 
-
-CREATE INDEX [IX_InsetTexts_Id] ON [Contentful].[InsetTexts] ([Id]);
-GO
 
 -- NavigationLink
 ALTER TABLE [Contentful].[NavigationLink]
 ADD CONSTRAINT [FK_NavigationLink_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
 GO
 
-CREATE INDEX [IX_NavigationLink_Id] ON [Contentful].[NavigationLink] ([Id]);
-GO
-
--- RichTextContents
-ALTER TABLE [Contentful].[RichTextContents]
-ADD CONSTRAINT [FK_RichTextContents_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
-GO
-
-CREATE INDEX [IX_RichTextContents_Id] ON [Contentful].[RichTextContents] ([Id]);
-GO
 
 -- TextBodies
 ALTER TABLE [Contentful].[TextBodies]
 ADD CONSTRAINT [FK_TextBodies_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
-GO
-
-CREATE INDEX [IX_TextBodies_Id] ON [Contentful].[TextBodies] ([Id]);
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
 GO
 
 -- Warnings
 ALTER TABLE [Contentful].[Warnings]
 ADD CONSTRAINT [FK_Warnings_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
-GO
-
-CREATE INDEX [IX_Warnings_Id] ON [Contentful].[Warnings] ([Id]);
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
 GO
 
 COMMIT;

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
@@ -30,11 +30,5 @@ ADD CONSTRAINT [FK_NavigationLink_ContentComponents_Id]
 FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
 GO
 
--- Warnings
-ALTER TABLE [Contentful].[Warnings]
-ADD CONSTRAINT [FK_Warnings_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
-GO
-
 COMMIT;
 GO

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
@@ -1,14 +1,6 @@
 BEGIN TRANSACTION;
 GO
 
-IF SCHEMA_ID(N'Contentful') IS NULL EXEC(N'CREATE SCHEMA [Contentful];');
-GO
-
--- Your existing table creation statements go here...
-
--- Add foreign key constraints for tables with "Id varchar(30)" column
--- The key name should be "FK_TABLENAME_ContentComponents_Id"
-
 -- Buttons
 ALTER TABLE [Contentful].[Buttons]
 ADD CONSTRAINT [FK_Buttons_ContentComponents_Id]
@@ -67,9 +59,6 @@ GO
 ALTER TABLE [Contentful].[TextBodies]
 ADD CONSTRAINT [FK_TextBodies_ContentComponents_Id]
 FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
-GO
-
-CREATE INDEX [IX_TextBodies_Id] ON [Contentful].[TextBodies] ([Id]);
 GO
 
 -- Warnings

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
@@ -43,9 +43,6 @@ ADD CONSTRAINT [FK_Titles_ContentComponents_Id]
 FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
 GO
 
-CREATE INDEX [IX_Titles_Id] ON [Contentful].[Titles] ([Id]);
-GO
-
 -- RichTextContents
 ALTER TABLE [Contentful].[RichTextContents]
 ADD CONSTRAINT [FK_RichTextContents_ContentComponents_Id]
@@ -59,6 +56,9 @@ GO
 ALTER TABLE [Contentful].[TextBodies]
 ADD CONSTRAINT [FK_TextBodies_ContentComponents_Id]
 FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+GO
+
+CREATE INDEX [IX_TextBodies_Id] ON [Contentful].[TextBodies] ([Id]);
 GO
 
 -- Warnings

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
@@ -1,0 +1,85 @@
+BEGIN TRANSACTION;
+GO
+
+IF SCHEMA_ID(N'Contentful') IS NULL EXEC(N'CREATE SCHEMA [Contentful];');
+GO
+
+-- Your existing table creation statements go here...
+
+-- Add foreign key constraints for tables with "Id varchar(30)" column
+-- The key name should be "FK_TABLENAME_ContentComponents_Id"
+
+-- Buttons
+ALTER TABLE [Contentful].[Buttons]
+ADD CONSTRAINT [FK_Buttons_ContentComponents_Id]
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+GO
+
+CREATE INDEX [IX_Buttons_Id] ON [Contentful].[Buttons] ([Id]);
+GO
+
+-- Headers
+ALTER TABLE [Contentful].[Headers]
+ADD CONSTRAINT [FK_Headers_ContentComponents_Id]
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+GO
+
+CREATE INDEX [IX_Headers_Id] ON [Contentful].[Headers] ([Id]);
+GO
+
+-- InsetTexts
+ALTER TABLE [Contentful].[InsetTexts]
+ADD CONSTRAINT [FK_InsetTexts_ContentComponents_Id]
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+GO 
+
+CREATE INDEX [IX_InsetTexts_Id] ON [Contentful].[InsetTexts] ([Id]);
+GO
+
+-- NavigationLink
+ALTER TABLE [Contentful].[NavigationLink]
+ADD CONSTRAINT [FK_NavigationLink_ContentComponents_Id]
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+GO
+
+CREATE INDEX [IX_NavigationLink_Id] ON [Contentful].[NavigationLink] ([Id]);
+GO
+
+-- Titles
+ALTER TABLE [Contentful].[Titles]
+ADD CONSTRAINT [FK_Titles_ContentComponents_Id]
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+GO
+
+CREATE INDEX [IX_Titles_Id] ON [Contentful].[Titles] ([Id]);
+GO
+
+-- RichTextContents
+ALTER TABLE [Contentful].[RichTextContents]
+ADD CONSTRAINT [FK_RichTextContents_ContentComponents_Id]
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+GO
+
+CREATE INDEX [IX_RichTextContents_Id] ON [Contentful].[RichTextContents] ([Id]);
+GO
+
+-- TextBodies
+ALTER TABLE [Contentful].[TextBodies]
+ADD CONSTRAINT [FK_TextBodies_ContentComponents_Id]
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+GO
+
+CREATE INDEX [IX_TextBodies_Id] ON [Contentful].[TextBodies] ([Id]);
+GO
+
+-- Warnings
+ALTER TABLE [Contentful].[Warnings]
+ADD CONSTRAINT [FK_Warnings_ContentComponents_Id]
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+GO
+
+CREATE INDEX [IX_Warnings_Id] ON [Contentful].[Warnings] ([Id]);
+GO
+
+COMMIT;
+GO

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
@@ -30,13 +30,6 @@ ADD CONSTRAINT [FK_NavigationLink_ContentComponents_Id]
 FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
 GO
 
-
--- TextBodies
-ALTER TABLE [Contentful].[TextBodies]
-ADD CONSTRAINT [FK_TextBodies_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
-GO
-
 -- Warnings
 ALTER TABLE [Contentful].[Warnings]
 ADD CONSTRAINT [FK_Warnings_ContentComponents_Id]

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
@@ -37,12 +37,6 @@ GO
 CREATE INDEX [IX_NavigationLink_Id] ON [Contentful].[NavigationLink] ([Id]);
 GO
 
--- Titles
-ALTER TABLE [Contentful].[Titles]
-ADD CONSTRAINT [FK_Titles_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
-GO
-
 -- RichTextContents
 ALTER TABLE [Contentful].[RichTextContents]
 ADD CONSTRAINT [FK_RichTextContents_ContentComponents_Id]

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240109_1124_CreateMissingIndexesAndRelationships.sql
@@ -4,7 +4,7 @@ GO
 -- Buttons
 ALTER TABLE [Contentful].[Buttons]
 ADD CONSTRAINT [FK_Buttons_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
 GO
 
 CREATE INDEX [IX_Buttons_Id] ON [Contentful].[Buttons] ([Id]);
@@ -13,7 +13,7 @@ GO
 -- Headers
 ALTER TABLE [Contentful].[Headers]
 ADD CONSTRAINT [FK_Headers_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
 GO
 
 CREATE INDEX [IX_Headers_Id] ON [Contentful].[Headers] ([Id]);
@@ -22,7 +22,7 @@ GO
 -- InsetTexts
 ALTER TABLE [Contentful].[InsetTexts]
 ADD CONSTRAINT [FK_InsetTexts_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
 GO 
 
 CREATE INDEX [IX_InsetTexts_Id] ON [Contentful].[InsetTexts] ([Id]);
@@ -31,7 +31,7 @@ GO
 -- NavigationLink
 ALTER TABLE [Contentful].[NavigationLink]
 ADD CONSTRAINT [FK_NavigationLink_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
 GO
 
 CREATE INDEX [IX_NavigationLink_Id] ON [Contentful].[NavigationLink] ([Id]);
@@ -40,7 +40,7 @@ GO
 -- RichTextContents
 ALTER TABLE [Contentful].[RichTextContents]
 ADD CONSTRAINT [FK_RichTextContents_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
 GO
 
 CREATE INDEX [IX_RichTextContents_Id] ON [Contentful].[RichTextContents] ([Id]);
@@ -49,7 +49,7 @@ GO
 -- TextBodies
 ALTER TABLE [Contentful].[TextBodies]
 ADD CONSTRAINT [FK_TextBodies_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
 GO
 
 CREATE INDEX [IX_TextBodies_Id] ON [Contentful].[TextBodies] ([Id]);
@@ -58,7 +58,7 @@ GO
 -- Warnings
 ALTER TABLE [Contentful].[Warnings]
 ADD CONSTRAINT [FK_Warnings_ContentComponents_Id]
-FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]) ON DELETE CASCADE;
+FOREIGN KEY ([Id]) REFERENCES [Contentful].[ContentComponents] ([Id]);
 GO
 
 CREATE INDEX [IX_Warnings_Id] ON [Contentful].[Warnings] ([Id]);

--- a/terraform/container-app/terraform-configuration.md
+++ b/terraform/container-app/terraform-configuration.md
@@ -38,7 +38,7 @@ We use two external modules to create the majority of the resources required:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.85.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.86.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
 
 ## Modules


### PR DESCRIPTION
Adds missing foreign keys for certain tables to `ContentComponent` table. 

- `Buttons`
- `ComponentDropdowns`
- `Headers`
- `InsetTexts`
- `NavigationLink`