### PR TITLE
fix: Missing rich texts

### DIFF
--- a/src/Dfe.PlanTech.Application/Content/Queries/GetPageQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetPageQuery.cs
@@ -111,14 +111,13 @@ public class GetPageQuery : ContentRetriever, IGetPageQuery
     {
         try
         {
-            var textBodyContentIds = page.Content.Concat(page.BeforeTitleContent)
+            var textBodyContents = page.Content.Concat(page.BeforeTitleContent)
                                                 .OfType<IHasRichText>()
-                                                .Select(content => content!.RichTextId)
                                                 .ToArray();
 
-            if (textBodyContentIds.Length == 0) return;
+            if (!textBodyContents.Any()) return;
 
-            await _db.ToListAsync(_db.LoadRichTextContentsByParentIds(textBodyContentIds), cancellationToken);
+            await _db.ToListAsync(_db.RichTextContentsByPageSlug(page.Slug), cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Dfe.PlanTech.Application/Persistence/Interfaces/ICmsDbContext.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Interfaces/ICmsDbContext.cs
@@ -50,5 +50,5 @@ public interface ICmsDbContext
 
     public Task<PageDbEntity?> GetPageBySlug(string slug, CancellationToken cancellationToken = default);
 
-    public IQueryable<RichTextContentDbEntity> LoadRichTextContentsByParentIds(IEnumerable<long> parentIds);
+    public IQueryable<RichTextContentDbEntity> RichTextContentsByPageSlug(string pageSlug);
 }

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240111_0919_CreateAllRichTextContentForPageSlugFunction.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240111_0919_CreateAllRichTextContentForPageSlugFunction.sql
@@ -1,0 +1,33 @@
+
+CREATE FUNCTION [Contentful].[SelectAllRichTextContentForPageSlug] (
+    @PageSlug NVARCHAR(MAX)
+)
+RETURNS @ReturnTable table(Id BIGINT, [Value] NVARCHAR(MAX), NodeType NVARCHAR(MAX), DataId BIGINT, ParentId BIGINT)
+BEGIN
+  DECLARE @ContentComponentIds TABLE (Id NVARCHAR(MAX))
+  DECLARE @RichTextIds TABLE (Id NVARCHAR(MAX))
+
+  INSERT INTO @ContentComponentIds
+  SELECT CONCAT([BeforeContentComponentId], [ContentComponentId]) ContentComponentId FROM [Contentful].[PageContents] PC
+  LEFT JOIN [Contentful].[Pages] P ON PC.PageId = P.Id
+  WHERE P.Slug = @PageSlug
+
+  INSERT INTO @RichTextIds
+  SELECT RichTextId FROM [Contentful].[TextBodies] WHERE Id IN (SELECT * FROM @ContentComponentIds)
+  UNION
+  SELECT RichTextId FROM [Contentful].[Warnings] AS W
+  LEFT JOIN [Contentful].[TextBodies] AS TB ON W.TextId = TB.ID
+  WHERE W.Id IN (SELECT * FROM @ContentComponentIds)
+
+  DECLARE @idColumn INT
+
+  SELECT @idColumn = min(Id) FROM @RichTextIds
+
+  WHILE @idColumn IS NOT NULL
+    BEGIN
+      INSERT INTO @ReturnTable SELECT [Id], [Value], [NodeType], [DataId], [ParentId] FROM [Contentful].[SelectAllRichTextContentForParentId](@idColumn)
+      SELECT @idColumn = min(Id) FROM @RichTextIds WHERE Id > @idColumn
+    END
+  
+  RETURN
+END

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240111_0926_DropOldFunctionAndType.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240111_0926_DropOldFunctionAndType.sql
@@ -1,0 +1,5 @@
+DROP TYPE IdTableType;
+GO;
+
+DROP FUNCTION [Contentful].[SelectAllRichTextContentForParentIds];
+GO;

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240111_0926_DropOldFunctionAndType.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240111_0926_DropOldFunctionAndType.sql
@@ -1,5 +1,5 @@
-DROP TYPE IdTableType;
+DROP FUNCTION [Contentful].[SelectAllRichTextContentForParentIds];
 GO;
 
-DROP FUNCTION [Contentful].[SelectAllRichTextContentForParentIds];
+DROP TYPE IdTableType;
 GO;

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IHasRichText.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IHasRichText.cs
@@ -4,6 +4,6 @@ namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
 public interface IHasRichText
 {
-    public RichTextContentDbEntity RichText { get; }
+    public RichTextContentDbEntity RichText { get; set; }
     public long RichTextId { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/WarningComponentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/WarningComponentDbEntity.cs
@@ -1,4 +1,5 @@
 
+using System.ComponentModel.DataAnnotations.Schema;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Content.Models;
@@ -8,6 +9,13 @@ public class WarningComponentDbEntity : ContentComponentDbEntity, IWarningCompon
     public string TextId { get; set; } = null!;
     public TextBodyDbEntity Text { get; set; } = null!;
 
-    public RichTextContentDbEntity RichText => Text.RichText;
+    [NotMapped]
+    public RichTextContentDbEntity RichText
+    {
+        get => Text.RichText;
+        set => Text.RichText = value;
+    }
+
+    [NotMapped]
     public long RichTextId => Text.RichTextId;
 }

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -207,5 +207,5 @@ public class CmsDbContext : DbContext, ICmsDbContext
             .FirstOrDefaultAsync(page => page.Slug == slug, cancellationToken);
 
     public IQueryable<RichTextContentDbEntity> RichTextContentsByPageSlug(string pageSlug)
-        => RichTextContents.FromSql($"SELECT * FROM [Contentful].[SelectAllRichTextContentForParentIdsTest]({pageSlug})");
+        => RichTextContents.FromSql($"SELECT * FROM [Contentful].[SelectAllRichTextContentForPageSlug]({pageSlug})");
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
@@ -308,7 +308,7 @@ public class GetPageQueryTests
         await _cmsDbSubstitute.ReceivedWithAnyArgs(1).GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await _cmsDbSubstitute.ReceivedWithAnyArgs(0).ToListAsync(Arg.Any<IQueryable<SectionDbEntity>>(), Arg.Any<CancellationToken>());
         await _cmsDbSubstitute.ReceivedWithAnyArgs(0).ToListAsync(Arg.Any<IQueryable<ButtonWithEntryReferenceDbEntity>>(), Arg.Any<CancellationToken>());
-        _cmsDbSubstitute.ReceivedWithAnyArgs(0).LoadRichTextContentsByParentIds(Arg.Any<IEnumerable<long>>());
+        _cmsDbSubstitute.ReceivedWithAnyArgs(0).RichTextContentsByPageSlug(Arg.Any<string>());
     }
 
     [Fact]
@@ -406,7 +406,7 @@ public class GetPageQueryTests
 
         await _repoSubstitute.ReceivedWithAnyArgs(0).GetEntities<Page>(Arg.Any<IGetEntitiesOptions>(), Arg.Any<CancellationToken>());
         await _cmsDbSubstitute.ReceivedWithAnyArgs(1).GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        _cmsDbSubstitute.ReceivedWithAnyArgs(1).LoadRichTextContentsByParentIds(Arg.Any<IEnumerable<long>>());
+        _cmsDbSubstitute.ReceivedWithAnyArgs(1).RichTextContentsByPageSlug(Arg.Any<string>());
     }
 
     [Fact]


### PR DESCRIPTION
A bug was added from the recent caching feature being added.

The query that retrieved rich text content for TextBody components was caching every query as just one (i.e. it didn't matter if the query was for a different bunch of TextBodys or not, it was all treated as the same query). As a result, RichText was not loaded/displayed correctly for the majority of pages once you navigated through.