### PR TITLE
fix: Set default log level to warning

### DIFF
--- a/src/Dfe.PlanTech.Web/appsettings.json
+++ b/src/Dfe.PlanTech.Web/appsettings.json
@@ -4,12 +4,7 @@
     "CallbackUrl": "/auth/cb",
     "SignoutCallbackUrl": "/signout/complete",
     "SignoutRedirectUrl": "/",
-    "Scopes": [
-      "openid",
-      "email",
-      "profile",
-      "organisation"
-    ],
+    "Scopes": ["openid", "email", "profile", "organisation"],
     "CookieName": "sa-login",
     "CookieExpireTimeSpanInMinutes": 60,
     "GetClaimsFromUserInfoEndpoint": true,
@@ -20,7 +15,7 @@
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Warning",
       "Microsoft.AspNetCore": "Warning"
     }
   },


### PR DESCRIPTION
Huge amount of logs going on due to the log level being set at "Information", so this changes it to be "Warning" by default.

Note: We can change this per environment, whenever wanted, by changing the environment variables on the containers, or setting values in the Azure KeyVault.