### PR TITLE
fix: Ignore autoincludes in find query

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -105,7 +105,7 @@ namespace Dfe.PlanTech.AzureFunctions
             var dbSet = GetIQueryableForEntity(model);
 
             var found = await dbSet.IgnoreAutoIncludes()
-                                    .FirstOrDefaultAsync(entity => entity.Id == entity.Id);
+                                    .FirstOrDefaultAsync(existing => existing.Id == entity.Id);
 
             return found ?? null;
         }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncEnumerable.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncEnumerable.cs
@@ -1,0 +1,18 @@
+using System.Linq.Expressions;
+
+namespace Dfe.PlanTech.AzureFunctions.UnitTests
+{
+  public class AsyncEnumerable<T> : EnumerableQuery<T>, IAsyncEnumerable<T>, IQueryable<T>
+  {
+    public AsyncEnumerable(IEnumerable<T> enumerable) : base(enumerable) { }
+
+    public AsyncEnumerable(Expression expression) : base(expression) { }
+
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+      return new AsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+    }
+
+    IQueryProvider IQueryable.Provider => this;
+  }
+}

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncEnumerable.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncEnumerable.cs
@@ -1,18 +1,17 @@
 using System.Linq.Expressions;
 
-namespace Dfe.PlanTech.AzureFunctions.UnitTests
+namespace Dfe.PlanTech.AzureFunctions.UnitTests;
+
+public class AsyncEnumerable<T> : EnumerableQuery<T>, IAsyncEnumerable<T>, IQueryable<T>
 {
-  public class AsyncEnumerable<T> : EnumerableQuery<T>, IAsyncEnumerable<T>, IQueryable<T>
+  public AsyncEnumerable(IEnumerable<T> enumerable) : base(enumerable) { }
+
+  public AsyncEnumerable(Expression expression) : base(expression) { }
+
+  public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
   {
-    public AsyncEnumerable(IEnumerable<T> enumerable) : base(enumerable) { }
-
-    public AsyncEnumerable(Expression expression) : base(expression) { }
-
-    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-    {
-      return new AsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
-    }
-
-    IQueryProvider IQueryable.Provider => this;
+    return new AsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
   }
+
+  IQueryProvider IQueryable.Provider => this;
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncEnumerator.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncEnumerator.cs
@@ -1,0 +1,28 @@
+namespace Dfe.PlanTech.AzureFunctions.UnitTests;
+
+public class AsyncEnumerator<T> : IAsyncEnumerator<T>
+{
+  private readonly IEnumerator<T> _inner;
+
+  public AsyncEnumerator(IEnumerator<T> inner)
+  {
+    _inner = inner;
+  }
+
+  public void Dispose()
+  {
+    _inner.Dispose();
+  }
+
+  public T Current => _inner.Current;
+
+  public ValueTask<bool> MoveNextAsync()
+  {
+    return ValueTask.FromResult(_inner.MoveNext());
+  }
+
+  public ValueTask DisposeAsync()
+  {
+    return ValueTask.CompletedTask;
+  }
+}

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncQueryProvider.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncQueryProvider.cs
@@ -1,0 +1,54 @@
+using System.Linq.Expressions;
+using Dfe.PlanTech.AzureFunctions.UnitTests;
+using Microsoft.EntityFrameworkCore.Query;
+
+public class AsyncQueryProvider<TEntity> : IAsyncQueryProvider
+{
+  private readonly IQueryProvider _inner;
+
+  internal AsyncQueryProvider(IQueryProvider inner)
+  {
+    _inner = inner;
+  }
+
+  public IQueryable CreateQuery(Expression expression)
+  {
+    return new AsyncEnumerable<TEntity>(expression);
+  }
+
+  public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+  {
+    return new AsyncEnumerable<TElement>(expression);
+  }
+
+  public object Execute(Expression expression)
+  {
+    return _inner.Execute(expression);
+  }
+
+  public TResult Execute<TResult>(Expression expression)
+  {
+    return _inner.Execute<TResult>(expression);
+  }
+
+  public IAsyncEnumerable<TResult> ExecuteAsync<TResult>(Expression expression)
+  {
+    return new AsyncEnumerable<TResult>(expression);
+  }
+
+  public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+  {
+    var expectedResultType = typeof(TResult).GetGenericArguments()[0];
+    var executionResult = typeof(IQueryProvider)
+                         .GetMethod(
+                              name: nameof(IQueryProvider.Execute),
+                              genericParameterCount: 1,
+                              types: new[] { typeof(Expression) })
+                         .MakeGenericMethod(expectedResultType)
+                         .Invoke(this, new[] { expression });
+
+    return (TResult)typeof(Task).GetMethod(nameof(Task.FromResult))
+                                ?.MakeGenericMethod(expectedResultType)
+                                 .Invoke(null, new[] { executionResult });
+  }
+}

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -4,9 +4,12 @@ using Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
+using System.Linq.Expressions;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -85,13 +88,40 @@ public class QueueReceiverTests
         await serviceBusMessageActionsMock.Received().DeadLetterMessageAsync(Arg.Any<ServiceBusReceivedMessage>());
     }
 
+    static async IAsyncEnumerable<CategoryDbEntity> RangeAsync(int start, int count)
+    {
+        CategoryDbEntity contentComponent = new() { Archived = true, Published = true, Deleted = true };
+
+        yield return contentComponent;
+    }
+
+
     [Fact]
     public async Task QueueReceiverDbWriter_Should_MapExistingDbEntity_To_Message()
     {
-        ContentComponentDbEntityImplementation contentComponent = new() { Archived = true, Published = true, Deleted = true };
+        ContentComponentDbEntityImplementation contentComponent = new() { Archived = true, Published = true, Deleted = true, Id = "Testing" };
 
+        var list = new List<ContentComponentDbEntityImplementation>() { contentComponent };
+        IQueryable<ContentComponentDbEntityImplementation> queryable = list.AsQueryable();
         _cmsDbContextMock.SaveChangesAsync().Returns(1);
-        _cmsDbContextMock.Find(Arg.Any<Type>(), Arg.Any<String>()).Returns(contentComponent);
+
+        var asyncProvider = new AsyncQueryProvider<ContentComponentDbEntityImplementation>(queryable.Provider);
+
+        var mockSet = Substitute.For<DbSet<ContentComponentDbEntityImplementation>, IQueryable<ContentComponentDbEntityImplementation>>();
+        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).Provider.Returns(asyncProvider);
+        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).Expression.Returns(queryable.Expression);
+        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).ElementType.Returns(queryable.ElementType);
+        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).GetEnumerator().Returns(queryable.GetEnumerator());
+
+        var entityTypeMock = Substitute.For<IEntityType>();
+        entityTypeMock.ClrType.Returns(typeof(ContentComponentDbEntityImplementation));
+
+        _cmsDbContextMock.Model.FindEntityType(Arg.Any<Type>()).Returns(callInfo =>
+        {
+            return entityTypeMock;
+        });
+
+        _cmsDbContextMock.Set<ContentComponentDbEntityImplementation>().Returns(mockSet);
 
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -38,6 +38,29 @@ public class QueueReceiverTests
         });
 
         _cmsDbContextMock = Substitute.For<CmsDbContext>();
+        ContentComponentDbEntityImplementation contentComponent = new() { Archived = true, Published = true, Deleted = true, Id = "Testing" };
+
+        var list = new List<ContentComponentDbEntityImplementation>() { contentComponent };
+        IQueryable<ContentComponentDbEntityImplementation> queryable = list.AsQueryable();
+        _cmsDbContextMock.SaveChangesAsync().Returns(1);
+
+        var asyncProvider = new AsyncQueryProvider<ContentComponentDbEntityImplementation>(queryable.Provider);
+
+        var mockSet = Substitute.For<DbSet<ContentComponentDbEntityImplementation>, IQueryable<ContentComponentDbEntityImplementation>>();
+        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).Provider.Returns(asyncProvider);
+        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).Expression.Returns(queryable.Expression);
+        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).ElementType.Returns(queryable.ElementType);
+        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).GetEnumerator().Returns(queryable.GetEnumerator());
+
+        var entityTypeMock = Substitute.For<IEntityType>();
+        entityTypeMock.ClrType.Returns(typeof(ContentComponentDbEntityImplementation));
+
+        _cmsDbContextMock.Model.FindEntityType(Arg.Any<Type>()).Returns(callInfo =>
+        {
+            return entityTypeMock;
+        });
+
+        _cmsDbContextMock.Set<ContentComponentDbEntityImplementation>().Returns(mockSet);
 
         JsonSerializerOptions jsonOptions = new()
         {
@@ -99,30 +122,6 @@ public class QueueReceiverTests
     [Fact]
     public async Task QueueReceiverDbWriter_Should_MapExistingDbEntity_To_Message()
     {
-        ContentComponentDbEntityImplementation contentComponent = new() { Archived = true, Published = true, Deleted = true, Id = "Testing" };
-
-        var list = new List<ContentComponentDbEntityImplementation>() { contentComponent };
-        IQueryable<ContentComponentDbEntityImplementation> queryable = list.AsQueryable();
-        _cmsDbContextMock.SaveChangesAsync().Returns(1);
-
-        var asyncProvider = new AsyncQueryProvider<ContentComponentDbEntityImplementation>(queryable.Provider);
-
-        var mockSet = Substitute.For<DbSet<ContentComponentDbEntityImplementation>, IQueryable<ContentComponentDbEntityImplementation>>();
-        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).Provider.Returns(asyncProvider);
-        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).Expression.Returns(queryable.Expression);
-        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).ElementType.Returns(queryable.ElementType);
-        ((IQueryable<ContentComponentDbEntityImplementation>)mockSet).GetEnumerator().Returns(queryable.GetEnumerator());
-
-        var entityTypeMock = Substitute.For<IEntityType>();
-        entityTypeMock.ClrType.Returns(typeof(ContentComponentDbEntityImplementation));
-
-        _cmsDbContextMock.Model.FindEntityType(Arg.Any<Type>()).Returns(callInfo =>
-        {
-            return entityTypeMock;
-        });
-
-        _cmsDbContextMock.Set<ContentComponentDbEntityImplementation>().Returns(mockSet);
-
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
 


### PR DESCRIPTION
Due to changes in the CmsDbContext, relationship data was being pulled in when `_db.Find` was being executed.

As a result, when the additional relationship mapping was occurring, it appeared that we wanted to do things such as delete all the existing rows.

This PR changes the logic to ensure that AutoIncludes are disabled.