### PR TITLE
refactor: Split page queries

### DIFF
--- a/src/Dfe.PlanTech.Application/Content/Queries/GetButtonWithEntryReferencesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetButtonWithEntryReferencesQuery.cs
@@ -9,53 +9,53 @@ namespace Dfe.PlanTech.Application.Content.Queries;
 
 public class GetButtonWithEntryReferencesQuery : IGetPageChildrenQuery
 {
-  private readonly ICmsDbContext _db;
-  private readonly ILogger<GetButtonWithEntryReferencesQuery> _logger;
+    private readonly ICmsDbContext _db;
+    private readonly ILogger<GetButtonWithEntryReferencesQuery> _logger;
 
-  public GetButtonWithEntryReferencesQuery(ICmsDbContext db, ILogger<GetButtonWithEntryReferencesQuery> logger)
-  {
-    _db = db;
-    _logger = logger;
-  }
-
-  /// <summary>
-  /// If the Page.Content has any <see cref="ButtonWithEntryReferenceDbEntity"/>s, load the link to entry reference from the database for it
-  /// </summary>
-  /// <param name="page"></param>
-  /// <param name="cancellationToken"></param>
-  /// <returns></returns>
-  public async Task TryLoadChildren(PageDbEntity page, CancellationToken cancellationToken)
-  {
-    try
+    public GetButtonWithEntryReferencesQuery(ICmsDbContext db, ILogger<GetButtonWithEntryReferencesQuery> logger)
     {
-      var buttons = page.Content.Exists(content => content is ButtonWithEntryReferenceDbEntity);
-
-      if (!buttons) return;
-
-      var buttonQuery = ButtonWithEntryReferencesQueryable(page);
-
-      await _db.ToListAsync(buttonQuery, cancellationToken);
+        _db = db;
+        _logger = logger;
     }
-    catch (Exception ex)
+
+    /// <summary>
+    /// If the Page.Content has any <see cref="ButtonWithEntryReferenceDbEntity"/>s, load the link to entry reference from the database for it
+    /// </summary>
+    /// <param name="page"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task TryLoadChildren(PageDbEntity page, CancellationToken cancellationToken)
     {
-      _logger.LogError(ex, "Error loading button references for {page}", page.Id);
-      throw;
-    }
-  }
+        try
+        {
+            var buttons = page.Content.Exists(content => content is ButtonWithEntryReferenceDbEntity);
 
-  /// <summary>
-  /// Quer to get <see cref="ButtonWithEntryReferenceDbEntity">s for the given page, but with only necessary information we require
-  /// </summary>
-  /// <param name="page"></param>
-  /// <returns></returns>
-  private IQueryable<ButtonWithEntryReferenceDbEntity> ButtonWithEntryReferencesQueryable(PageDbEntity page)
-  => _db.ButtonWithEntryReferences.Where(button => button.ContentPages.Any(contentPage => contentPage.Id == page.Id))
-                                  .Select(button => new ButtonWithEntryReferenceDbEntity()
-                                  {
-                                    Id = button.Id,
-                                    LinkToEntry = new PageDbEntity()
+            if (!buttons) return;
+
+            var buttonQuery = ButtonWithEntryReferencesQueryable(page);
+
+            await _db.ToListAsync(buttonQuery, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading button references for {page}", page.Id);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Quer to get <see cref="ButtonWithEntryReferenceDbEntity">s for the given page, but with only necessary information we require
+    /// </summary>
+    /// <param name="page"></param>
+    /// <returns></returns>
+    private IQueryable<ButtonWithEntryReferenceDbEntity> ButtonWithEntryReferencesQueryable(PageDbEntity page)
+    => _db.ButtonWithEntryReferences.Where(button => button.ContentPages.Any(contentPage => contentPage.Id == page.Id))
+                                    .Select(button => new ButtonWithEntryReferenceDbEntity()
                                     {
-                                      Slug = ((IHasSlug)button.LinkToEntry).Slug
-                                    }
-                                  });
+                                        Id = button.Id,
+                                        LinkToEntry = new PageDbEntity()
+                                        {
+                                            Slug = ((IHasSlug)button.LinkToEntry).Slug
+                                        }
+                                    });
 }

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetButtonWithEntryReferencesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetButtonWithEntryReferencesQuery.cs
@@ -1,0 +1,61 @@
+using AutoMapper;
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.Application.Content.Queries;
+
+public class GetButtonWithEntryReferencesQuery
+{
+  private readonly ICmsDbContext _db;
+  private readonly ILogger<GetButtonWithEntryReferencesQuery> _logger;
+
+  public GetButtonWithEntryReferencesQuery(ICmsDbContext db, ILogger<GetButtonWithEntryReferencesQuery> logger, IMapper mapperConfiguration)
+  {
+    _db = db;
+    _logger = logger;
+  }
+
+  /// <summary>
+  /// If the Page.Content has any <see cref="ButtonWithEntryReferenceDbEntity"/>s, load the link to entry reference from the database for it
+  /// </summary>
+  /// <param name="page"></param>
+  /// <param name="cancellationToken"></param>
+  /// <returns></returns>
+  public async Task TryLoadButtonReferences(PageDbEntity page, CancellationToken cancellationToken)
+  {
+    try
+    {
+      var buttons = page.Content.Exists(content => content is ButtonWithEntryReferenceDbEntity);
+
+      if (!buttons) return;
+
+      var buttonQuery = ButtonWithEntryReferencesQueryable(page);
+
+      await _db.ToListAsync(buttonQuery, cancellationToken);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error loading button references for {page}", page.Id);
+      throw;
+    }
+  }
+
+  /// <summary>
+  /// Quer to get <see cref="ButtonWithEntryReferenceDbEntity">s for the given page, but with only necessary information we require
+  /// </summary>
+  /// <param name="page"></param>
+  /// <returns></returns>
+  private IQueryable<ButtonWithEntryReferenceDbEntity> ButtonWithEntryReferencesQueryable(PageDbEntity page)
+  => _db.ButtonWithEntryReferences.Where(button => button.ContentPages.Any(contentPage => contentPage.Id == page.Id))
+                                  .Select(button => new ButtonWithEntryReferenceDbEntity()
+                                  {
+                                    Id = button.Id,
+                                    LinkToEntry = new PageDbEntity()
+                                    {
+                                      Slug = ((IHasSlug)button.LinkToEntry).Slug
+                                    }
+                                  });
+}

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetButtonWithEntryReferencesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetButtonWithEntryReferencesQuery.cs
@@ -12,7 +12,7 @@ public class GetButtonWithEntryReferencesQuery : IGetPageChildrenQuery
   private readonly ICmsDbContext _db;
   private readonly ILogger<GetButtonWithEntryReferencesQuery> _logger;
 
-  public GetButtonWithEntryReferencesQuery(ICmsDbContext db, ILogger<GetButtonWithEntryReferencesQuery> logger, IMapper mapperConfiguration)
+  public GetButtonWithEntryReferencesQuery(ICmsDbContext db, ILogger<GetButtonWithEntryReferencesQuery> logger)
   {
     _db = db;
     _logger = logger;

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetButtonWithEntryReferencesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetButtonWithEntryReferencesQuery.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Dfe.PlanTech.Application.Content.Queries;
 
-public class GetButtonWithEntryReferencesQuery
+public class GetButtonWithEntryReferencesQuery : IGetPageChildrenQuery
 {
   private readonly ICmsDbContext _db;
   private readonly ILogger<GetButtonWithEntryReferencesQuery> _logger;
@@ -24,7 +24,7 @@ public class GetButtonWithEntryReferencesQuery
   /// <param name="page"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  public async Task TryLoadButtonReferences(PageDbEntity page, CancellationToken cancellationToken)
+  public async Task TryLoadChildren(PageDbEntity page, CancellationToken cancellationToken)
   {
     try
     {

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetCategorySectionsQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetCategorySectionsQuery.cs
@@ -1,0 +1,100 @@
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.Application.Content.Queries;
+
+public class GetCategorySectionsQuery
+{
+    private readonly ICmsDbContext _db;
+    private readonly ILogger<GetCategorySectionsQuery> _logger;
+
+    public GetCategorySectionsQuery(ICmsDbContext db, ILogger<GetCategorySectionsQuery> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// If there are any "Category" components in the Page.Content, then load the required Section information for each one.
+    /// </summary>
+    /// <param name="page"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task TryLoadCategorySections(PageDbEntity page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var pageHasCategories = page.Content.Exists(content => content is CategoryDbEntity);
+
+            if (!pageHasCategories) return;
+
+            var sections = await _db.ToListAsync(SectionsForPageQueryable(page), cancellationToken);
+
+            CopySectionsToPage(page, sections);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching categories for {page}", page.Id);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Copies the retrieved Sections from the database over the corresponding Category's section
+    /// </summary>
+    /// <param name="page">Page that contains categories</param>
+    /// <param name="sections">"Complete" section from database</param>
+    private static void CopySectionsToPage(PageDbEntity page, List<SectionDbEntity> sections)
+    {
+        var sectionsGroupedByCategory = sections.GroupBy(section => section.CategoryId);
+
+        foreach (var cat in sectionsGroupedByCategory)
+        {
+            var matching = page.Content.OfType<CategoryDbEntity>()
+                                        .FirstOrDefault(category => category != null && category.Id == cat.Key);
+
+            if (matching == null)
+            {
+                continue;
+            }
+
+            matching.Sections = cat.ToList();
+        }
+    }
+
+
+    /// <summary>
+    /// Quer to get <see cref="SectionDbEntity">s for the given page, but with only necessary information we require
+    /// </summary>
+    /// <param name="page"></param>
+    /// <returns></returns>
+    private IQueryable<SectionDbEntity> SectionsForPageQueryable(PageDbEntity page)
+    => _db.Sections.Where(section => section.Category != null && section.Category.ContentPages.Any(categoryPage => categoryPage.Slug == page.Slug))
+                .Select(section => new SectionDbEntity()
+                {
+                    CategoryId = section.CategoryId,
+                    Id = section.Id,
+                    Name = section.Name,
+                    Questions = section.Questions.Select(question => new QuestionDbEntity()
+                    {
+                        Slug = question.Slug,
+                        Id = question.Id,
+                    }).ToList(),
+                    Recommendations = section.Recommendations.Select(recommendation => new RecommendationPageDbEntity()
+                    {
+                        DisplayName = recommendation.DisplayName,
+                        Maturity = recommendation.Maturity,
+                        Page = new PageDbEntity()
+                        {
+                            Slug = recommendation.Page.Slug
+                        }
+                    }).ToList(),
+                    InterstitialPage = section.InterstitialPage == null ? null : new PageDbEntity()
+                    {
+                        Slug = section.InterstitialPage.Slug,
+                        Id = section.InterstitialPage.Id
+                    }
+                });
+}

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetCategorySectionsQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetCategorySectionsQuery.cs
@@ -1,11 +1,12 @@
 using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Dfe.PlanTech.Application.Content.Queries;
 
-public class GetCategorySectionsQuery
+public class GetCategorySectionsQuery : IGetPageChildrenQuery
 {
     private readonly ICmsDbContext _db;
     private readonly ILogger<GetCategorySectionsQuery> _logger;
@@ -22,7 +23,7 @@ public class GetCategorySectionsQuery
     /// <param name="page"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public async Task TryLoadCategorySections(PageDbEntity page, CancellationToken cancellationToken)
+    public async Task TryLoadChildren(PageDbEntity page, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetCategorySectionsQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetCategorySectionsQuery.cs
@@ -90,7 +90,8 @@ public class GetCategorySectionsQuery : IGetPageChildrenQuery
                         Page = new PageDbEntity()
                         {
                             Slug = recommendation.Page.Slug
-                        }
+                        },
+                        Id = recommendation.Id
                     }).ToList(),
                     InterstitialPage = section.InterstitialPage == null ? null : new PageDbEntity()
                     {

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetRichTextsQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetRichTextsQuery.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Dfe.PlanTech.Application.Content.Queries;
 
-public class GetRichTextsQuery
+public class GetRichTextsQuery : IGetPageChildrenQuery
 {
     private readonly ICmsDbContext _db;
     private readonly ILogger<GetRichTextsQuery> _logger;
@@ -16,14 +16,13 @@ public class GetRichTextsQuery
         _logger = logger;
     }
 
-
     /// <summary>
     /// Load RichTextContents for the given page from database 
     /// </summary>
     /// <param name="page"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public async Task TryLoadRichTextContents(PageDbEntity page, CancellationToken cancellationToken)
+    public async Task TryLoadChildren(PageDbEntity page, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetRichTextsQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetRichTextsQuery.cs
@@ -26,11 +26,11 @@ public class GetRichTextsQuery : IGetPageChildrenQuery
     {
         try
         {
-            var textBodyContents = page.Content.Concat(page.BeforeTitleContent)
+            var hasTextBodyContents = page.Content.Concat(page.BeforeTitleContent)
                                                 .OfType<IHasRichText>()
-                                                .ToArray();
+                                                .Any();
 
-            if (!textBodyContents.Any()) return;
+            if (!hasTextBodyContents) return;
 
             await _db.ToListAsync(_db.RichTextContentsByPageSlug(page.Slug), cancellationToken);
         }

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetRichTextsQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetRichTextsQuery.cs
@@ -1,0 +1,44 @@
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.Application.Content.Queries;
+
+public class GetRichTextsQuery
+{
+    private readonly ICmsDbContext _db;
+    private readonly ILogger<GetRichTextsQuery> _logger;
+
+    public GetRichTextsQuery(ICmsDbContext db, ILogger<GetRichTextsQuery> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+
+    /// <summary>
+    /// Load RichTextContents for the given page from database 
+    /// </summary>
+    /// <param name="page"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task TryLoadRichTextContents(PageDbEntity page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var textBodyContents = page.Content.Concat(page.BeforeTitleContent)
+                                                .OfType<IHasRichText>()
+                                                .ToArray();
+
+            if (!textBodyContents.Any()) return;
+
+            await _db.ToListAsync(_db.RichTextContentsByPageSlug(page.Slug), cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching rich text content from Database for {pageId}", page.Id);
+            throw;
+        }
+    }
+}

--- a/src/Dfe.PlanTech.Application/Helpers/QueryServiceSetup.cs
+++ b/src/Dfe.PlanTech.Application/Helpers/QueryServiceSetup.cs
@@ -1,5 +1,7 @@
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Queries;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 
@@ -25,6 +27,9 @@ public static class QueryServiceSetup
         }
 
         services.AddScoped<IGetPageQuery, GetPageQuery>();
+        services.AddScoped<IGetPageChildrenQuery, GetButtonWithEntryReferencesQuery>();
+        services.AddScoped<IGetPageChildrenQuery, GetCategorySectionsQuery>();
+        services.AddScoped<IGetPageChildrenQuery, GetRichTextsQuery>();
 
         return services;
     }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IGetNavigationQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IGetNavigationQuery.cs
@@ -1,5 +1,3 @@
-using Dfe.PlanTech.Domain.Content.Models;
-
 namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
 /// <summary>

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IGetPageChildrenQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IGetPageChildrenQuery.cs
@@ -1,0 +1,8 @@
+using Dfe.PlanTech.Domain.Content.Models;
+
+namespace Dfe.PlanTech.Domain.Content.Interfaces;
+
+public interface IGetPageChildrenQuery
+{
+  public Task TryLoadChildren(PageDbEntity page, CancellationToken cancellationToken);
+}

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IGetPageChildrenQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IGetPageChildrenQuery.cs
@@ -4,5 +4,5 @@ namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
 public interface IGetPageChildrenQuery
 {
-  public Task TryLoadChildren(PageDbEntity page, CancellationToken cancellationToken);
+    public Task TryLoadChildren(PageDbEntity page, CancellationToken cancellationToken);
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IGetPageQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IGetPageQuery.cs
@@ -1,7 +1,7 @@
 
 using Dfe.PlanTech.Domain.Content.Models;
 
-namespace Dfe.PlanTech.Application.Content.Queries;
+namespace Dfe.PlanTech.Domain.Content.Queries;
 
 /// <summary>
 /// Retrieves a page from contentful

--- a/src/Dfe.PlanTech.Web/Authorisation/PageModelAuthorisationPolicy.cs
+++ b/src/Dfe.PlanTech.Web/Authorisation/PageModelAuthorisationPolicy.cs
@@ -1,5 +1,5 @@
-using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Content.Queries;
 using Microsoft.AspNetCore.Authorization;
 
 namespace Dfe.PlanTech.Web.Authorisation;

--- a/src/Dfe.PlanTech.Web/Routing/CheckAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/CheckAnswersRouter.cs
@@ -1,6 +1,6 @@
-using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Exceptions;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Content.Queries;
 using Dfe.PlanTech.Domain.Responses.Interfaces;
 using Dfe.PlanTech.Domain.Submissions.Enums;
 using Dfe.PlanTech.Domain.Submissions.Interfaces;

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -1,5 +1,5 @@
-using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Exceptions;
+using Dfe.PlanTech.Domain.Content.Queries;
 using Dfe.PlanTech.Domain.Submissions.Enums;
 using Dfe.PlanTech.Domain.Submissions.Interfaces;
 using Dfe.PlanTech.Domain.Users.Interfaces;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetButtonWithEntryReferencesQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetButtonWithEntryReferencesQueryTests.cs
@@ -1,0 +1,116 @@
+using Dfe.PlanTech.Application.Content.Queries;
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dfe.PlanTech.Application.UnitTests.Content.Queries;
+
+public class GetButtonWithEntryReferencesQueryTests
+{
+  private readonly ICmsDbContext _db = Substitute.For<ICmsDbContext>();
+  private readonly ILogger<GetButtonWithEntryReferencesQuery> _logger = Substitute.For<ILogger<GetButtonWithEntryReferencesQuery>>();
+
+  private readonly IGetPageChildrenQuery _getButtonWithEntryReferencesQuery;
+
+  private readonly static PageDbEntity _pageWithButton = new()
+  {
+    Id = "Page-id",
+    Content = new()
+    {
+
+    }
+  };
+
+
+  private readonly static PageDbEntity _pageWithoutButton = new()
+  {
+    Id = "Page-id",
+    Content = new()
+    {
+
+    }
+  };
+
+  private readonly static PageDbEntity _linkedPage = new()
+  {
+    Id = "linked-page",
+    Slug = "/linked-page-slug"
+  };
+
+  private readonly static ButtonWithEntryReferenceDbEntity _button = new()
+  {
+    Id = "ABCD",
+    LinkToEntryId = _linkedPage.Id,
+    LinkToEntry = _linkedPage,
+    ContentPages = new(){
+      _pageWithButton
+    }
+  };
+
+  private readonly List<ButtonWithEntryReferenceDbEntity> _buttons;
+
+  private readonly List<ButtonWithEntryReferenceDbEntity> _returnedButtons = new();
+
+  public GetButtonWithEntryReferencesQueryTests()
+  {
+    _getButtonWithEntryReferencesQuery = new GetButtonWithEntryReferencesQuery(_db, _logger);
+
+    _buttons = new()
+    {
+      _button
+    };
+
+    _pageWithButton.Content.Add(_button);
+    _db.ButtonWithEntryReferences.Returns(_buttons.AsQueryable());
+
+    _db.ToListAsync(Arg.Any<IQueryable<ButtonWithEntryReferenceDbEntity>>(), Arg.Any<CancellationToken>())
+        .Returns(callinfo =>
+        {
+          var queryable = callinfo.ArgAt<IQueryable<ButtonWithEntryReferenceDbEntity>>(0);
+
+          var result = queryable.ToList();
+
+          _returnedButtons.AddRange(result);
+
+          return result;
+        });
+  }
+
+  [Fact]
+  public async Task Should_Retrieve_ButtonWithEntryReferences_For_Page_When_Existing()
+  {
+    await _getButtonWithEntryReferencesQuery.TryLoadChildren(_pageWithButton, CancellationToken.None);
+
+    await _db.ReceivedWithAnyArgs(1)
+                 .ToListAsync(Arg.Any<IQueryable<ButtonWithEntryReferenceDbEntity>>(), Arg.Any<CancellationToken>());
+
+    Assert.Single(_returnedButtons);
+
+    var returnedButton = _returnedButtons.First();
+
+    var linkToEntry = returnedButton.LinkToEntry as IHasSlug;
+
+    Assert.NotNull(linkToEntry);
+
+    Assert.Equal(_linkedPage.Slug, linkToEntry.Slug);
+    Assert.Equal(returnedButton.Id, _button.Id);
+
+    var page = returnedButton.LinkToEntry as PageDbEntity;
+
+    Assert.NotNull(page);
+    Assert.Empty(page.Content);
+    Assert.Empty(page.BeforeTitleContent);
+  }
+
+  [Fact]
+  public async Task Should_Not_Retrieve_ButtonWithEntryReferences_For_Page_When_NoButtons()
+  {
+    await _getButtonWithEntryReferencesQuery.TryLoadChildren(_pageWithoutButton, CancellationToken.None);
+
+    await _db.ReceivedWithAnyArgs(0)
+                 .ToListAsync(Arg.Any<IQueryable<ButtonWithEntryReferenceDbEntity>>(), Arg.Any<CancellationToken>());
+  }
+}

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetCategorySectionsQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetCategorySectionsQueryTests.cs
@@ -1,0 +1,219 @@
+using Dfe.PlanTech.Application.Content.Queries;
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Enums;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dfe.PlanTech.Application.UnitTests.Content.Queries;
+
+public class GetCategorySectionsQueryTests
+{
+  private readonly ICmsDbContext _db = Substitute.For<ICmsDbContext>();
+  private readonly ILogger<GetCategorySectionsQuery> _logger = Substitute.For<ILogger<GetCategorySectionsQuery>>();
+
+  private readonly IGetPageChildrenQuery _getCategorySectionsQuery;
+
+  private readonly static PageDbEntity _loadedPage = new()
+  {
+    Id = "Page-id",
+    Content = new()
+    {
+
+    }
+  };
+
+  private readonly static CategoryDbEntity _category = new()
+  {
+    Id = "category-id",
+    ContentPages = new()
+    {
+
+    },
+    Sections = new()
+    {
+
+    }
+  };
+
+  private readonly List<SectionDbEntity> _categorySections = new(){
+    new(){
+      Category = _category,
+      CategoryId = _category.Id,
+      Id = "section-one",
+      Name = "section-one-name",
+      Questions = new(){
+        new(){
+          Id = "Question-one",
+          Slug = "/question-one",
+          HelpText = "helptext-should-be-null",
+          Text = "text-should-be-null"
+          },
+          new(){
+            Id = "Question-two",
+            Slug = "/question-two",
+            HelpText = "helptext-should-be-null",
+            Text = "text-should-be-null"
+            }
+          },
+          Recommendations = new(){
+            new(){
+              InternalName = "internalname-should-be-null",
+              DisplayName = "Recommendation-one",
+              Maturity = Maturity.High,
+              Page = new(){
+                Slug = "/recommendation-one-slug",
+                Id = "recommendation-page-one"
+              },
+              Id = "recommendation-one"
+            },
+             new(){
+              InternalName = "internalname-should-be-null",
+              DisplayName = "Recommendation-two",
+              Maturity = Maturity.Medium,
+              Page = new(){
+                Slug = "/recommendation-two-slug",
+                Id = "recommendation-page-two"
+              },
+              Id = "recommendation-two"
+            }
+          },
+          InterstitialPage = new(){
+            Id = "interstitial-page-one",
+            Slug = "/page-one",
+            InternalName = "should-be-null"
+          },
+          InterstitialPageId = "interstitial-page-one",
+    },
+    new(){
+      Category = _category,
+      CategoryId = _category.Id,
+      Id = "section-two",
+      Name = "section-two-name",
+      Questions = new(){
+        new(){
+          Id = "Question-three",
+          Slug = "/question-three",
+          HelpText = "helptext-should-be-null",
+          Text = "text-should-be-null"
+          },
+          new(){
+            Id = "Question-four",
+            Slug = "/question-four",
+            HelpText = "helptext-should-be-null",
+            Text = "text-should-be-null"
+            }
+          },
+          Recommendations = new(){
+            new(){
+              InternalName = "internalname-should-be-null",
+              DisplayName = "Recommendation-three",
+              Maturity = Maturity.High,
+              Page = new(){
+                Slug = "/recommendation-three-slug",
+                Id = "recommendation-page-three"
+              },
+              Id = "recommendation-three"
+            },
+             new(){
+              InternalName = "internalname-should-be-null",
+              DisplayName = "Recommendation-four",
+              Maturity = Maturity.Medium,
+              Page = new(){
+                Slug = "/recommendation-four-slug",
+                Id = "recommendation-page-four"
+              },
+              Id = "recommendation-four"
+            }
+          },
+          InterstitialPage = new(){
+            Id = "interstitial-page-two",
+            Slug = "/page-two",
+            InternalName = "should-be-null"
+          },
+          InterstitialPageId = "interstitial-page-one",
+
+    },
+  };
+
+  private readonly List<SectionDbEntity> _sections = new()
+  {
+    new(){
+      Category = new(){
+
+      },
+      CategoryId = "other-category"
+    }
+  };
+
+  public GetCategorySectionsQueryTests()
+  {
+    _loadedPage.Content.Clear();
+    _category.ContentPages.Add(_loadedPage);
+    _sections.AddRange(_categorySections);
+
+    _getCategorySectionsQuery = new GetCategorySectionsQuery(_db, _logger);
+
+    _db.Sections.Returns(_sections.AsQueryable());
+
+    _db.ToListAsync(Arg.Any<IQueryable<SectionDbEntity>>(), Arg.Any<CancellationToken>())
+        .Returns(callinfo =>
+        {
+          var queryable = callinfo.ArgAt<IQueryable<SectionDbEntity>>(0);
+
+          return queryable.ToList();
+        });
+  }
+
+  [Fact]
+  public async Task Should_Retrieve_Sections_When_Page_Has_Category()
+  {
+    _loadedPage.Content.Add(_category);
+
+    await _getCategorySectionsQuery.TryLoadChildren(_loadedPage, CancellationToken.None);
+
+    await _db.ReceivedWithAnyArgs(1)
+                 .ToListAsync(Arg.Any<IQueryable<SectionDbEntity>>(), Arg.Any<CancellationToken>());
+
+    var category = _category;
+
+    Assert.Equal(_categorySections.Count, category.Sections.Count);
+
+    foreach (var section in _categorySections)
+    {
+      var matching = category.Sections.Find(s => section.Id == s.Id);
+
+      Assert.NotNull(matching);
+
+      foreach (var question in section.Questions)
+      {
+        var matchingQuestion = matching.Questions.Find(q => q.Id == question.Id);
+        Assert.NotNull(matchingQuestion);
+        Assert.Equal(question.Slug, matchingQuestion.Slug);
+        Assert.Null(matchingQuestion.Text);
+        Assert.Null(matchingQuestion.HelpText);
+      }
+
+      foreach (var recommendation in section.Recommendations)
+      {
+        var matchingRecommendation = matching.Recommendations.Find(r => r.Id == recommendation.Id);
+        Assert.NotNull(matchingRecommendation);
+        Assert.Equal(recommendation.DisplayName, matchingRecommendation.DisplayName);
+        Assert.Equal(recommendation.Maturity, matchingRecommendation.Maturity);
+        Assert.NotNull(matchingRecommendation.DisplayName);
+        Assert.Null(matchingRecommendation.InternalName);
+      }
+    }
+  }
+
+  [Fact]
+  public async Task Should_Not_Retrieve_ButtonWithEntryReferences_For_Page_When_NoButtons()
+  {
+    await _getCategorySectionsQuery.TryLoadChildren(_loadedPage, CancellationToken.None);
+
+    await _db.ReceivedWithAnyArgs(0)
+                 .ToListAsync(Arg.Any<IQueryable<SectionDbEntity>>(), Arg.Any<CancellationToken>());
+  }
+}

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
@@ -4,8 +4,10 @@ using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Exceptions;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Caching.Models;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Dfe.PlanTech.Domain.Content.Queries;
 using Dfe.PlanTech.Domain.Questionnaire.Enums;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Infrastructure.Application.Models;
@@ -166,6 +168,8 @@ public class GetPageQueryTests
         }
     };
 
+    private IGetPageChildrenQuery _getPageChildrenQuery = Substitute.For<IGetPageChildrenQuery>();
+
     public GetPageQueryTests()
     {
         _cmsDbSubstitute.ToListAsync(Arg.Any<IQueryable<SectionDbEntity>>())
@@ -248,6 +252,9 @@ public class GetPageQueryTests
         _pageWithCategories.Content.Add(_category);
 
         _cmsDbSubstitute.Sections.Returns(_sections.AsQueryable());
+
+        _getPageChildrenQuery.TryLoadChildren(Arg.Any<PageDbEntity>(), Arg.Any<CancellationToken>())
+                            .Returns(Task.CompletedTask);
     }
 
     private void SetupRepository()
@@ -271,8 +278,8 @@ public class GetPageQueryTests
         });
     }
 
-    private GetPageQuery CreateGetPageQuery()
-        => new(_cmsDbSubstitute, _logger, _mapperSubstitute, _questionnaireCacherSubstitute, _repoSubstitute);
+    private IGetPageQuery CreateGetPageQuery()
+        => new GetPageQuery(_cmsDbSubstitute, _logger, _mapperSubstitute, _questionnaireCacherSubstitute, _repoSubstitute, new[] { _getPageChildrenQuery });
 
     private void SetupQuestionnaireCacher()
     {
@@ -288,7 +295,7 @@ public class GetPageQueryTests
     [Fact]
     public async Task Should_Retrieve_Page_By_Slug_From_Db()
     {
-        GetPageQuery query = CreateGetPageQuery();
+        var query = CreateGetPageQuery();
 
         _cmsDbSubstitute.Pages.Returns(_pagesFromDb.AsQueryable());
         _cmsDbSubstitute.GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -309,128 +316,8 @@ public class GetPageQueryTests
         await _cmsDbSubstitute.ReceivedWithAnyArgs(0).ToListAsync(Arg.Any<IQueryable<SectionDbEntity>>(), Arg.Any<CancellationToken>());
         await _cmsDbSubstitute.ReceivedWithAnyArgs(0).ToListAsync(Arg.Any<IQueryable<ButtonWithEntryReferenceDbEntity>>(), Arg.Any<CancellationToken>());
         _cmsDbSubstitute.ReceivedWithAnyArgs(0).RichTextContentsByPageSlug(Arg.Any<string>());
-    }
 
-    [Fact]
-    public async Task Should_Retrieve_Buttons_For_Page_When_Existing()
-    {
-        GetPageQuery query = CreateGetPageQuery();
-
-        _cmsDbSubstitute.Pages.Returns(_pagesFromDb.AsQueryable());
-        _cmsDbSubstitute.GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>())
-                        .Returns(callinfo =>
-                        {
-                            var slug = callinfo.ArgAt<string>(0);
-
-                            return _cmsDbSubstitute.Pages.FirstOrDefault(page => string.Equals(page.Slug, slug));
-                        });
-
-        var result = await query.GetPageBySlug(_pageWithButton.Slug);
-
-        Assert.NotNull(result);
-        Assert.Equal(_pageWithButton.Slug, result.Slug);
-
-        await _repoSubstitute.ReceivedWithAnyArgs(0).GetEntities<Page>(Arg.Any<IGetEntitiesOptions>(), Arg.Any<CancellationToken>());
-        await _cmsDbSubstitute.ReceivedWithAnyArgs(1).GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await _cmsDbSubstitute.ReceivedWithAnyArgs(1).ToListAsync(Arg.Any<IQueryable<ButtonWithEntryReferenceDbEntity>>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task Should_Retrieve_Sections_For_Page_When_Page_Has_Categories()
-    {
-        GetPageQuery query = CreateGetPageQuery();
-
-        _cmsDbSubstitute.Pages.Returns(_pagesFromDb.AsQueryable());
-        _cmsDbSubstitute.GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>())
-                        .Returns(callinfo =>
-                        {
-                            var slug = callinfo.ArgAt<string>(0);
-
-                            return _cmsDbSubstitute.Pages.FirstOrDefault(page => string.Equals(page.Slug, slug));
-                        });
-
-        _cmsDbSubstitute.Sections.Returns(_sections.AsQueryable());
-
-        var result = await query.GetPageBySlug(_pageWithCategories.Slug);
-
-        Assert.NotNull(result);
-        Assert.Equal(_pageWithCategories.Slug, result.Slug);
-
-        await _repoSubstitute.ReceivedWithAnyArgs(0).GetEntities<Page>(Arg.Any<IGetEntitiesOptions>(), Arg.Any<CancellationToken>());
-        await _cmsDbSubstitute.ReceivedWithAnyArgs(1).GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await _cmsDbSubstitute.ReceivedWithAnyArgs(1).ToListAsync(Arg.Any<IQueryable<SectionDbEntity>>(), Arg.Any<CancellationToken>());
-
-        var category = result.Content.Where(content => content is Category).Select(cat => cat as Category).FirstOrDefault();
-
-        Assert.NotNull(category);
-        Assert.Equal(_sections.Count, category.Sections.Count);
-
-        foreach (var section in _sections)
-        {
-            var matching = category.Sections.Find(pageSection => section.Id == pageSection.Sys.Id);
-
-            Assert.NotNull(matching);
-
-            foreach (var question in section.Questions)
-            {
-                var matchingQuestion = matching.Questions.Find(pageQuestion => pageQuestion.Sys.Id == question.Id);
-                Assert.NotNull(matchingQuestion);
-            }
-
-            foreach (var recommendation in section.Recommendations)
-            {
-                var matchingRecommendation = matching.Recommendations.Find(pageRecommendation => pageRecommendation.Sys.Id == recommendation.Id);
-                Assert.NotNull(matchingRecommendation);
-            }
-        }
-    }
-
-    [Fact]
-    public async Task Should_Retrieve_RichText_For_Page()
-    {
-        GetPageQuery query = CreateGetPageQuery();
-
-        _cmsDbSubstitute.Pages.Returns(_pagesFromDb.AsQueryable());
-        _cmsDbSubstitute.GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>())
-                        .Returns(callinfo =>
-                        {
-                            var slug = callinfo.ArgAt<string>(0);
-
-                            return _cmsDbSubstitute.Pages.FirstOrDefault(page => string.Equals(page.Slug, slug));
-                        });
-
-        var result = await query.GetPageBySlug(_pageWithRichTextContent.Slug);
-
-        Assert.NotNull(result);
-        Assert.Equal(_pageWithRichTextContent.Slug, result.Slug);
-
-        await _repoSubstitute.ReceivedWithAnyArgs(0).GetEntities<Page>(Arg.Any<IGetEntitiesOptions>(), Arg.Any<CancellationToken>());
-        await _cmsDbSubstitute.ReceivedWithAnyArgs(1).GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        _cmsDbSubstitute.ReceivedWithAnyArgs(1).RichTextContentsByPageSlug(Arg.Any<string>());
-    }
-
-    [Fact]
-    public async Task Should_Retrieve_ButtonWithEntryReferences_For_Page_When_Existing()
-    {
-        GetPageQuery query = CreateGetPageQuery();
-
-        _cmsDbSubstitute.Pages.Returns(_pagesFromDb.AsQueryable());
-        _cmsDbSubstitute.GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>())
-                        .Returns(callinfo =>
-                        {
-                            var slug = callinfo.ArgAt<string>(0);
-
-                            return _cmsDbSubstitute.Pages.FirstOrDefault(page => string.Equals(page.Slug, slug));
-                        });
-
-        var result = await query.GetPageBySlug(_pageWithButton.Slug);
-
-        Assert.NotNull(result);
-        Assert.Equal(_pageWithButton.Slug, result.Slug);
-
-        await _repoSubstitute.ReceivedWithAnyArgs(0).GetEntities<Page>(Arg.Any<IGetEntitiesOptions>(), Arg.Any<CancellationToken>());
-        await _cmsDbSubstitute.ReceivedWithAnyArgs(1).GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await _cmsDbSubstitute.ReceivedWithAnyArgs(1).ToListAsync(Arg.Any<IQueryable<ButtonWithEntryReferenceDbEntity>>(), Arg.Any<CancellationToken>());
+        await _getPageChildrenQuery.ReceivedWithAnyArgs(1).TryLoadChildren(Arg.Any<PageDbEntity>(), Arg.Any<CancellationToken>());
     }
 
 
@@ -439,7 +326,7 @@ public class GetPageQueryTests
     {
         Environment.SetEnvironmentVariable("CONTENTFUL_GET_ENTITY_INT", "4");
 
-        GetPageQuery query = CreateGetPageQuery();
+        var query = CreateGetPageQuery();
 
         var emptyList = new List<PageDbEntity>(0);
         _cmsDbSubstitute.Pages.Returns(emptyList.AsQueryable());
@@ -459,7 +346,7 @@ public class GetPageQueryTests
     {
         Environment.SetEnvironmentVariable("CONTENTFUL_GET_ENTITY_INT", "4");
 
-        GetPageQuery query = CreateGetPageQuery();
+        var query = CreateGetPageQuery();
 
         _cmsDbSubstitute.GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>())
                         .Returns(callinfo =>
@@ -520,5 +407,4 @@ public class GetPageQueryTests
 
         await Assert.ThrowsAsync<FormatException>(async () => await query.GetPageBySlug(SECTION_SLUG));
     }
-
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetRichTextsQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetRichTextsQueryTests.cs
@@ -1,0 +1,94 @@
+using Dfe.PlanTech.Application.Content.Queries;
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dfe.PlanTech.Application.UnitTests.Content.Queries;
+
+public class GetRichTextsQueryTests
+{
+  private readonly ICmsDbContext _db = Substitute.For<ICmsDbContext>();
+  private readonly ILogger<GetRichTextsQuery> _logger = Substitute.For<ILogger<GetRichTextsQuery>>();
+
+  private readonly IGetPageChildrenQuery _getRichTextsQuery;
+
+  private readonly static PageDbEntity _loadedPage = new()
+  {
+    Id = "Page-id",
+    Content = new()
+    {
+
+    }
+  };
+
+  private readonly static TextBodyDbEntity _textBody = new()
+  {
+    Id = "ABCD",
+    RichTextId = 1,
+  };
+
+  private readonly static List<RichTextContentDbEntity> _richTextContents = new(){
+    new()
+    {
+      Data = new()
+      {
+        Uri = "uri"
+      },
+      Marks = new(){
+        new(){
+          Type = "Bold",
+        }
+      },
+      Content = new()
+      {
+
+      },
+      Value = "rich-text",
+      Id = 1,
+    }
+  };
+
+  private readonly List<RichTextContentDbEntity> _returnedRichTextContents = new();
+
+  public GetRichTextsQueryTests()
+  {
+    _loadedPage.Content.Clear();
+
+    _getRichTextsQuery = new GetRichTextsQuery(_db, _logger);
+
+    _db.RichTextContentsByPageSlug(Arg.Any<string>()).Returns(_richTextContents.AsQueryable());
+
+    _db.ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>())
+        .Returns(callinfo =>
+        {
+          var queryable = callinfo.ArgAt<IQueryable<RichTextContentDbEntity>>(0);
+
+          return queryable.ToList();
+        });
+  }
+
+  [Fact]
+  public async Task Should_Retrieve_ButtonWithEntryReferences_For_Page_When_Existing()
+  {
+    _loadedPage.Content.Add(new TextBodyDbEntity()
+    {
+      RichText = _richTextContents.First()
+    });
+
+    await _getRichTextsQuery.TryLoadChildren(_loadedPage, CancellationToken.None);
+
+    await _db.ReceivedWithAnyArgs(1)
+                 .ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>());
+  }
+
+  [Fact]
+  public async Task Should_Not_Retrieve_ButtonWithEntryReferences_For_Page_When_NoButtons()
+  {
+    await _getRichTextsQuery.TryLoadChildren(_loadedPage, CancellationToken.None);
+
+    await _db.ReceivedWithAnyArgs(0)
+                 .ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>());
+  }
+}

--- a/tests/Dfe.PlanTech.Web.UnitTests/Authorisation/PageModelAuthorisationPolicyTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Authorisation/PageModelAuthorisationPolicyTests.cs
@@ -1,4 +1,4 @@
-using Dfe.PlanTech.Application.Content.Queries;
+using Dfe.PlanTech.Domain.Content.Queries;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/CookieControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/CookieControllerTests.cs
@@ -2,6 +2,7 @@
 using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Cookie.Interfaces;
 using Dfe.PlanTech.Infrastructure.Application.Models;
@@ -133,7 +134,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         {
             IQuestionnaireCacher questionnaireCacherSubstitute = Substitute.For<IQuestionnaireCacher>();
             IContentRepository contentRepositorySubstitute = SetupRepositorySubstitute();
-            GetPageQuery _getPageQuerySubstitute = Substitute.For<GetPageQuery>(_db, _getPageLogger, _mapper, questionnaireCacherSubstitute, contentRepositorySubstitute);
+            GetPageQuery _getPageQuerySubstitute = Substitute.For<GetPageQuery>(_db, _getPageLogger, _mapper, questionnaireCacherSubstitute, contentRepositorySubstitute, Array.Empty<IGetPageChildrenQuery>());
 
             CookiesController cookiesController = CreateStrut();
             var result = await cookiesController.GetCookiesPage(_getPageQuerySubstitute);

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/CheckAnswersRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/CheckAnswersRouterTests.cs
@@ -1,6 +1,6 @@
-using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Exceptions;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Content.Queries;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Domain.Responses.Interfaces;

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
@@ -1,6 +1,6 @@
-using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Exceptions;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Content.Queries;
 using Dfe.PlanTech.Domain.Questionnaire.Enums;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Domain.Submissions.Enums;


### PR DESCRIPTION
Split up queries from GetPageQueries into separate classes.

Was becoming a pain trying to update and/or test them due to the size of the GetPageQuery class in the end.