### PR TITLE
tests: Improve QueueReceiver tests

### DIFF
--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -1,6 +1,7 @@
 using Azure.Messaging.ServiceBus;
 using Dfe.PlanTech.AzureFunctions.Mappings;
 using Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
+using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.Azure.Functions.Worker;
@@ -9,7 +10,6 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
-using System.Linq.Expressions;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -19,13 +19,24 @@ namespace Dfe.PlanTech.AzureFunctions.UnitTests;
 public class QueueReceiverTests
 {
     private const string bodyJsonStr = "{\"metadata\":{\"tags\":[]},\"fields\":{\"internalName\":{\"en-US\":\"TestingQuestion\"},\"text\":{\"en-US\":\"TestingQuestion\"},\"helpText\":{\"en-US\":\"HelpText\"},\"answers\":{\"en-US\":[{\"sys\":{\"type\":\"Link\",\"linkType\":\"Entry\",\"id\":\"4QscetbCYG4MUsGdoDU0C3\"}}]},\"slug\":{\"en-US\":\"testing-slug\"}},\"sys\":{\"type\":\"Entry\",\"id\":\"2VSR0emw0SPy8dlR9XlgfF\",\"space\":{\"sys\":{\"type\":\"Link\",\"linkType\":\"Space\",\"id\":\"py5afvqdlxgo\"}},\"environment\":{\"sys\":{\"id\":\"dev\",\"type\":\"Link\",\"linkType\":\"Environment\"}},\"contentType\":{\"sys\":{\"type\":\"Link\",\"linkType\":\"ContentType\",\"id\":\"question\"}},\"createdBy\":{\"sys\":{\"type\":\"Link\",\"linkType\":\"User\",\"id\":\"5yhMQOCN9P2vGpfjyZKiey\"}},\"updatedBy\":{\"sys\":{\"type\":\"Link\",\"linkType\":\"User\",\"id\":\"4hiJvkyVWdhTt6c4ZoDkMf\"}},\"revision\":13,\"createdAt\":\"2023-12-04T14:36:46.614Z\",\"updatedAt\":\"2023-12-15T16:16:45.034Z\"}}";
-
+    private const string _contentId = "2VSR0emw0SPy8dlR9XlgfF";
     private readonly QueueReceiver _queueReceiver;
 
     private readonly ILoggerFactory _loggerFactoryMock;
     private readonly ILogger _loggerMock;
     private readonly CmsDbContext _cmsDbContextMock;
     private readonly JsonToEntityMappers _jsonToEntityMappers;
+
+    private object? _addedObject = null;
+
+    private readonly static ContentComponentDbEntityImplementation _contentComponent = new() { Archived = true, Published = true, Deleted = true, Id = _contentId };
+    private readonly static ContentComponentDbEntityImplementation _otherContentComponent = new() { Archived = true, Published = true, Deleted = true, Id = "other-content-component" };
+
+    private readonly List<ContentComponentDbEntityImplementation> _existing = new()
+    {
+        _otherContentComponent
+    };
+
 
     public QueueReceiverTests()
     {
@@ -38,10 +49,7 @@ public class QueueReceiverTests
         });
 
         _cmsDbContextMock = Substitute.For<CmsDbContext>();
-        ContentComponentDbEntityImplementation contentComponent = new() { Archived = true, Published = true, Deleted = true, Id = "Testing" };
-
-        var list = new List<ContentComponentDbEntityImplementation>() { contentComponent };
-        IQueryable<ContentComponentDbEntityImplementation> queryable = list.AsQueryable();
+        IQueryable<ContentComponentDbEntityImplementation> queryable = _existing.AsQueryable();
         _cmsDbContextMock.SaveChangesAsync().Returns(1);
 
         var asyncProvider = new AsyncQueryProvider<ContentComponentDbEntityImplementation>(queryable.Provider);
@@ -73,13 +81,19 @@ public class QueueReceiverTests
         _jsonToEntityMappers = Substitute.For<JsonToEntityMappers>(new JsonToDbMapper[] { new JsonToDbMapperImplementation(questionDbEntityType, _loggerMock, jsonOptions) }, jsonOptions);
 
         _queueReceiver = new QueueReceiver(_loggerFactoryMock, _cmsDbContextMock, _jsonToEntityMappers);
+
+        _cmsDbContextMock.Add(Arg.Any<ContentComponentDbEntity>()).Returns(callinfo =>
+        {
+            var added = callinfo.ArgAt<ContentComponentDbEntity>(0);
+            _addedObject = added;
+
+            return null!;
+        });
     }
 
     [Fact]
     public async Task QueueReceiverDbWriter_Should_Execute_Successfully()
     {
-        _cmsDbContextMock.SaveChangesAsync().Returns(1);
-
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
 
@@ -91,6 +105,16 @@ public class QueueReceiverTests
         await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock);
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>());
+        await _cmsDbContextMock.ReceivedWithAnyArgs(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+        _cmsDbContextMock.ReceivedWithAnyArgs(1).Add(Arg.Any<ContentComponentDbEntity>());
+
+        Assert.NotNull(_addedObject);
+
+        var asContentComponentDbEntity = _addedObject as ContentComponentDbEntity;
+
+        Assert.NotNull(asContentComponentDbEntity);
+
+        Assert.Equal(_contentId, asContentComponentDbEntity.Id);
     }
 
     [Fact]
@@ -114,6 +138,7 @@ public class QueueReceiverTests
     [Fact]
     public async Task QueueReceiverDbWriter_Should_MapExistingDbEntity_To_Message()
     {
+        _existing.Add(_contentComponent);
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
 
@@ -125,12 +150,13 @@ public class QueueReceiverTests
         await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock);
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>());
+        _cmsDbContextMock.ReceivedWithAnyArgs(0).Add(Arg.Any<ContentComponentDbEntity>());
     }
 
     [Fact]
     public async Task QueueRecieverDbWriter_Should_CompleteSuccessfully_After_Archive()
     {
-        _cmsDbContextMock.SaveChangesAsync().Returns(1);
+        _contentComponent.Archived = false;
 
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
@@ -143,12 +169,16 @@ public class QueueReceiverTests
         await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock);
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>());
+
+        var added = _addedObject as ContentComponentDbEntity;
+        Assert.NotNull(added);
+        Assert.True(added.Archived);
     }
 
     [Fact]
     public async Task QueueRecieverDbWriter_Should_CompleteSuccessfully_After_Unarchive()
     {
-        _cmsDbContextMock.SaveChangesAsync().Returns(1);
+        _contentComponent.Archived = true;
 
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
@@ -161,12 +191,16 @@ public class QueueReceiverTests
         await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock);
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>());
+
+        var added = _addedObject as ContentComponentDbEntity;
+        Assert.NotNull(added);
+        Assert.False(added.Archived);
     }
 
     [Fact]
     public async Task QueueRecieverDbWriter_Should_CompleteSuccessfully_After_Publish()
     {
-        _cmsDbContextMock.SaveChangesAsync().Returns(1);
+        _contentComponent.Published = false;
 
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
@@ -179,12 +213,16 @@ public class QueueReceiverTests
         await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock);
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>());
+
+        var added = _addedObject as ContentComponentDbEntity;
+        Assert.NotNull(added);
+        Assert.True(added.Published);
     }
 
     [Fact]
     public async Task QueueRecieverDbWriter_Should_CompleteSuccessfully_After_Unpublish()
     {
-        _cmsDbContextMock.SaveChangesAsync().Returns(1);
+        _contentComponent.Published = false;
 
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
@@ -197,12 +235,16 @@ public class QueueReceiverTests
         await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock);
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>());
+
+        var added = _addedObject as ContentComponentDbEntity;
+        Assert.NotNull(added);
+        Assert.False(added.Published);
     }
 
     [Fact]
     public async Task QueueRecieverDbWriter_Should_CompleteSuccessfully_After_Delete()
     {
-        _cmsDbContextMock.SaveChangesAsync().Returns(1);
+        _contentComponent.Deleted = false;
 
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
@@ -215,6 +257,10 @@ public class QueueReceiverTests
         await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock);
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>());
+
+        var added = _addedObject as ContentComponentDbEntity;
+        Assert.NotNull(added);
+        Assert.True(added.Deleted);
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -111,14 +111,6 @@ public class QueueReceiverTests
         await serviceBusMessageActionsMock.Received().DeadLetterMessageAsync(Arg.Any<ServiceBusReceivedMessage>());
     }
 
-    static async IAsyncEnumerable<CategoryDbEntity> RangeAsync(int start, int count)
-    {
-        CategoryDbEntity contentComponent = new() { Archived = true, Published = true, Deleted = true };
-
-        yield return contentComponent;
-    }
-
-
     [Fact]
     public async Task QueueReceiverDbWriter_Should_MapExistingDbEntity_To_Message()
     {


### PR DESCRIPTION
Adds some small improvements to QueueReceiver tests to ensure certain things work as expected.

1. Ensures that the archive/unarchive/delete/etc. logic works and sets the relevant field to the expected value.
2. Ensures that the logic to find an existing entity from the DB works as expected
3. Ensures that the `Add` method is called if an entity is a new entity
4. Ensures that the new entity has the Id field set.

There's probably more tests/changes to come around this to make it more robust, but for now I believe this covers the important things.