### PR TITLE
tests: Minor test changes

### DIFF
--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetNavigationQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetNavigationQueryTests.cs
@@ -4,6 +4,7 @@ using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Dfe.PlanTech.Application.UnitTests.Content.Queries;
 
@@ -80,13 +81,9 @@ public class GetNavigationQueryTests
     var emptyNavLinksList = new List<NavigationLinkDbEntity>();
     _db.NavigationLink.Returns(emptyNavLinksList.AsQueryable());
 
-    _db.ToListAsync(Arg.Any<IQueryable<NavigationLinkDbEntity>>()).Returns(callInfo =>
+    _db.ToListAsync(Arg.Any<IQueryable<NavigationLinkDbEntity>>()).Throws(callInfo =>
     {
       throw new Exception("Error occurred");
-
-      var queryable = callInfo.ArgAt<IQueryable<NavigationLinkDbEntity>>(0);
-
-      return queryable.ToList();
     });
 
     IGetNavigationQuery navQuery = new GetNavigationQuery(_db, _logger, _contentRepository);
@@ -110,10 +107,9 @@ public class GetNavigationQueryTests
       return queryable.ToList();
     });
 
-    _contentRepository.GetEntities<NavigationLink>(CancellationToken.None).Returns(callinfo =>
+    _contentRepository.GetEntities<NavigationLink>(CancellationToken.None).Throws(callinfo =>
     {
       throw new Exception("Contentful error");
-      return _contentfulLinks;
     });
 
 

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncQueryProvider.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncQueryProvider.cs
@@ -23,7 +23,7 @@ public class AsyncQueryProvider<TEntity> : IAsyncQueryProvider
 
   public object Execute(Expression expression)
   {
-    return _inner.Execute(expression);
+    return _inner.Execute(expression)!;
   }
 
   public TResult Execute<TResult>(Expression expression)
@@ -43,12 +43,12 @@ public class AsyncQueryProvider<TEntity> : IAsyncQueryProvider
                          .GetMethod(
                               name: nameof(IQueryProvider.Execute),
                               genericParameterCount: 1,
-                              types: new[] { typeof(Expression) })
+                              types: new[] { typeof(Expression) })!
                          .MakeGenericMethod(expectedResultType)
                          .Invoke(this, new[] { expression });
 
     return (TResult)typeof(Task).GetMethod(nameof(Task.FromResult))
                                 ?.MakeGenericMethod(expectedResultType)
-                                 .Invoke(null, new[] { executionResult });
+                                 .Invoke(null, new[] { executionResult })!;
   }
 }


### PR DESCRIPTION
- Reenables a unit test in `DfeOpenIdConnectEventTests`
  - This was already running technically but no functionality tested. 
  - Functionality is independent of whether we actually use this logic in web app or not; should be tested.

- Changes methods in `GetNavigationQueryTests` to use correct method (`Throws` instead of `Returns`) to remove warnings

- Ignore nullability warnings in `AsyncQueryProvider` to remove warnings