### PR TITLE
feat/190555 - Process Published/Archived/Deleted Flags For Content From DB

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -124,7 +124,7 @@ public class QueueReceiver : BaseFunction
                                     .MakeGenericMethod(model!.ClrType)!
                                     .Invoke(_db, null)!;
 
-    private static void ProcessCmsEvent(string cmsEvent, ref ContentComponentDbEntity mapped)
+    private void ProcessCmsEvent(string cmsEvent, ref ContentComponentDbEntity mapped)
     {
         switch (cmsEvent)
         {
@@ -142,6 +142,7 @@ public class QueueReceiver : BaseFunction
                 mapped.Published = true;
                 break;
             case "unpublish":
+                Logger.LogWarning("Content with Id {id} has event 'unpublish' despite not existing in the database!", mapped.Id);
                 mapped.Published = false;
                 break;
             case "delete":

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -11,13 +11,6 @@ using Microsoft.Extensions.Logging;
 using System.Reflection;
 using System.Text;
 
-// TODO: Notes for today!!!
-// 1. Rejig all this so mapping, updating, adding is all separate methods
-// 2. To deal with unpublished, essentially do 'if existing entity exists && not unpublished (do value copy)'
-// 3. And changed mapped.Published = False to existing.Published = False
-// 4. Because EF Core tracks 'existing' and understands that only that property has changed
-// 5. So the section will be unmodified, but the ContentComponent will get changed
-
 namespace Dfe.PlanTech.AzureFunctions;
 
 public class QueueReceiver : BaseFunction

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -46,7 +46,7 @@ public class QueueReceiver : BaseFunction
                 throw new CmsEventException(string.Format("Cannot parse header \"{0}\" into a valid CMS event", message.Subject));
             }
 
-            Logger.LogInformation("CMS Event: {cmsEvent}", cmsEvent.ToString());
+            Logger.LogInformation("CMS Event: {cmsEvent}", cmsEvent);
 
             ContentComponentDbEntity mapped = GetMapped(message);
             ContentComponentDbEntity? existing = await GetExisting(mapped, cancellationToken);

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -42,6 +42,8 @@ public class QueueReceiver : BaseFunction
         {
             string cmsEvent = GetCmsEvent(message.Subject);
 
+            Logger.LogInformation("CMS Event: {cmsEvent}", cmsEvent);
+
             ContentComponentDbEntity mapped = GetMapped(message);
             ContentComponentDbEntity? existing = await GetExisting(mapped, cancellationToken);
 

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -111,6 +111,7 @@ public class QueueReceiver : BaseFunction
         var dbSet = GetIQueryableForEntity(model);
 
         var found = await dbSet.IgnoreAutoIncludes()
+                                .IgnoreQueryFilters()
                                 .FirstOrDefaultAsync(existing => existing.Id == entity.Id, cancellationToken);
 
         return found ?? null;

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -11,162 +11,202 @@ using Microsoft.Extensions.Logging;
 using System.Reflection;
 using System.Text;
 
-namespace Dfe.PlanTech.AzureFunctions
+// TODO: Notes for today!!!
+// 1. Rejig all this so mapping, updating, adding is all separate methods
+// 2. To deal with unpublished, essentially do 'if existing entity exists && not unpublished (do value copy)'
+// 3. And changed mapped.Published = False to existing.Published = False
+// 4. Because EF Core tracks 'existing' and understands that only that property has changed
+// 5. So the section will be unmodified, but the ContentComponent will get changed
+
+namespace Dfe.PlanTech.AzureFunctions;
+
+public class QueueReceiver : BaseFunction
 {
-    public class QueueReceiver : BaseFunction
+    private readonly CmsDbContext _db;
+    private readonly JsonToEntityMappers _mappers;
+    private readonly Type _dontCopyValueAttribute = typeof(DontCopyValueAttribute);
+
+    public QueueReceiver(ILoggerFactory loggerFactory, CmsDbContext db, JsonToEntityMappers mappers) : base(loggerFactory.CreateLogger<QueueReceiver>())
     {
-        private readonly CmsDbContext _db;
-        private readonly JsonToEntityMappers _mappers;
-        private readonly Type _dontCopyValueAttribute = typeof(DontCopyValueAttribute);
+        _db = db;
+        _mappers = mappers;
+    }
 
-        public QueueReceiver(ILoggerFactory loggerFactory, CmsDbContext db, JsonToEntityMappers mappers) : base(loggerFactory.CreateLogger<QueueReceiver>())
+    [Function("QueueReceiver")]
+    public async Task QueueReceiverDbWriter([ServiceBusTrigger("contentful", IsBatched = true)] ServiceBusReceivedMessage[] messages, ServiceBusMessageActions messageActions)
+    {
+        Logger.LogInformation("Queue Receiver -> Db Writer started. Processing {msgCount} messages", messages.Length);
+
+        foreach (ServiceBusReceivedMessage message in messages)
         {
-            _db = db;
-            _mappers = mappers;
+            await ProcessMessage(message, messageActions);
         }
+    }
 
-        [Function("QueueReceiver")]
-        public async Task QueueReceiverDbWriter([ServiceBusTrigger("contentful", IsBatched = true)] ServiceBusReceivedMessage[] messages, ServiceBusMessageActions messageActions)
+    private async Task ProcessMessage(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions)
+    {
+        try
         {
-            Logger.LogInformation("Queue Receiver -> Db Writer started. Processing {msgCount} messages", messages.Length);
+            string cmsEvent = GetCmsEvent(message.Subject);
 
-            foreach (ServiceBusReceivedMessage message in messages)
+            ContentComponentDbEntity mapped = GetMapped(message);
+            ContentComponentDbEntity? existing = await GetExisting(mapped);
+
+            if (cmsEvent.Equals("unpublish") && existing != null)
             {
-                await ProcessMessage(message, messageActions);
-            }
-        }
-
-        private async Task ProcessMessage(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions)
-        {
-            try
-            {
-                string cmsEvent = GetCmsEvent(message.Subject);
-                var text = Encoding.UTF8.GetString(message.Body);
-
-                Logger.LogInformation("Performing Action: {action}", cmsEvent);
-                Logger.LogInformation("Processing {text}", text);
-
-                ContentComponentDbEntity mapped = _mappers.ToEntity(text);
-                ContentComponentDbEntity? existing = await GetExistingDbEntity(mapped);
-
-                if (existing != null)
-                {
-                    mapped.Archived = existing.Archived;
-                    mapped.Published = existing.Published;
-                    mapped.Deleted = existing.Deleted;
-                }
-
-                switch (cmsEvent)
-                {
-                    case "create":
-                    case "save":
-                    case "auto_save":
-                        break;
-                    case "archive":
-                        mapped.Archived = true;
-                        break;
-                    case "unarchive":
-                        mapped.Archived = false;
-                        break;
-                    case "publish":
-                        mapped.Published = true;
-                        break;
-                    case "unpublish":
-                        mapped.Published = false;
-                        break;
-                    case "delete":
-                        mapped.Deleted = true;
-                        break;
-                    default:
-                        throw new CmsEventException(string.Format("CMS Event \"{0}\" not implemented", cmsEvent));
-                }
-
-                long rowsChanged = await UpsertEntityInDatabase(mapped, existing);
-
-                if (rowsChanged == 0L)
-                {
-                    Logger.LogError("Changed no rows in database");
-                }
-                else
-                {
-                    Logger.LogInformation($"Updated {rowsChanged} rows in the database");
-                }
-
-                await messageActions.CompleteMessageAsync(message);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex.Message);
-                await messageActions.DeadLetterMessageAsync(message);
-            }
-        }
-
-        private async Task<ContentComponentDbEntity?> GetExistingDbEntity(ContentComponentDbEntity entity)
-        {
-            var model = _db.Model.FindEntityType(entity.GetType()) ?? throw new Exception($"Could not find model in database for {entity.GetType()}");
-
-            var dbSet = GetIQueryableForEntity(model);
-
-            var found = await dbSet.IgnoreAutoIncludes()
-                                    .FirstOrDefaultAsync(existing => existing.Id == entity.Id);
-
-            return found ?? null;
-        }
-
-        private IQueryable<ContentComponentDbEntity> GetIQueryableForEntity(IEntityType model)
-        => (IQueryable<ContentComponentDbEntity>)_db
-                                                .GetType()
-                                                .GetMethod("Set", 1, Type.EmptyTypes)!
-                                                .MakeGenericMethod(model!.ClrType)!
-                                                .Invoke(_db, null)!;
-
-        private static string GetCmsEvent(string subject)
-        {
-            return subject.AsSpan()[(subject.LastIndexOf('.') + 1)..].ToString();
-        }
-
-        private async Task<long> UpsertEntityInDatabase(ContentComponentDbEntity entity, ContentComponentDbEntity? existing)
-        {
-            if (existing == null)
-            {
-                _db.Add(entity);
+                existing.Published = false;
             }
             else
             {
-                UpdateProperties(entity, existing);
+                ProcessCmsEvent(cmsEvent, ref mapped);
+
+                if (existing == null)
+                {
+                    DbAdd(mapped);
+                }
+                else
+                {
+                    DbUpdate(mapped, existing);
+                }
             }
 
-            return await _db.SaveChangesAsync();
-        }
+            await DbSaveChanges();
 
-        private void UpdateProperties(ContentComponentDbEntity entity, ContentComponentDbEntity existing)
+            await messageActions.CompleteMessageAsync(message);
+        }
+        catch (Exception ex)
         {
-            foreach (var property in PropertiesToCopy(entity))
-            {
-                property.SetValue(existing, property.GetValue(entity));
-            }
+            Logger.LogError(ex.Message);
+            await messageActions.DeadLetterMessageAsync(message);
+        }
+    }
+
+    private static string GetCmsEvent(string subject)
+    {
+        return subject.AsSpan()[(subject.LastIndexOf('.') + 1)..].ToString();
+    }
+
+    private ContentComponentDbEntity GetMapped(ServiceBusReceivedMessage message)
+    {
+        string messageBody = Encoding.UTF8.GetString(message.Body);
+
+        Logger.LogInformation("Processing = {messageBody}", messageBody);
+
+        return _mappers.ToEntity(messageBody);
+    }
+
+    private async Task<ContentComponentDbEntity?> GetExisting(ContentComponentDbEntity mapped)
+    {
+        ContentComponentDbEntity? existing = await GetExistingDbEntity(mapped);
+
+        if (existing != null)
+        {
+            mapped.Archived = existing.Archived;
+            mapped.Published = existing.Published;
+            mapped.Deleted = existing.Deleted;
         }
 
-        /// <summary>
-        /// Get properties to copy for the selected entity
-        /// </summary>
-        /// <remarks>
-        /// Returns all properties, except properties ending with "Id" (i.e. relationship fields), and properties that have
-        /// a <see cref="DontCopyValueAttribute"/> attribute.
-        /// </remarks>
-        /// <param name="entity">Entity to get copyable properties for</param>
-        /// <returns></returns>
-        private IEnumerable<PropertyInfo> PropertiesToCopy(ContentComponentDbEntity entity)
-        => entity.GetType()
-                .GetProperties()
-                .Where(property => !property.Name.EndsWith("Id") && !HasDontCopyValueAttribute(property));
+        return existing;
+    }
 
-        /// <summary>
-        /// Does the property have a <see cref="DontCopyValueAttribute"/> property attached to it? 
-        /// </summary>
-        /// <param name="property"></param>
-        /// <returns></returns>
-        private bool HasDontCopyValueAttribute(PropertyInfo property)
-         => property.CustomAttributes.Any(attribute => attribute.AttributeType == _dontCopyValueAttribute);
+    private async Task<ContentComponentDbEntity?> GetExistingDbEntity(ContentComponentDbEntity entity)
+    {
+        var model = _db.Model.FindEntityType(entity.GetType()) ?? throw new Exception($"Could not find model in database for {entity.GetType()}");
+
+        var dbSet = GetIQueryableForEntity(model);
+
+        var found = await dbSet.IgnoreAutoIncludes()
+                                .FirstOrDefaultAsync(existing => existing.Id == entity.Id);
+
+        return found ?? null;
+    }
+
+    private IQueryable<ContentComponentDbEntity> GetIQueryableForEntity(IEntityType model)
+    => (IQueryable<ContentComponentDbEntity>)_db
+                                    .GetType()
+                                    .GetMethod("Set", 1, Type.EmptyTypes)!
+                                    .MakeGenericMethod(model!.ClrType)!
+                                    .Invoke(_db, null)!;
+
+    private static void ProcessCmsEvent(string cmsEvent, ref ContentComponentDbEntity mapped)
+    {
+        switch (cmsEvent)
+        {
+            case "create":
+            case "save":
+            case "auto_save":
+                break;
+            case "archive":
+                mapped.Archived = true;
+                break;
+            case "unarchive":
+                mapped.Archived = false;
+                break;
+            case "publish":
+                mapped.Published = true;
+                break;
+            case "unpublish":
+                mapped.Published = false;
+                break;
+            case "delete":
+                mapped.Deleted = true;
+                break;
+            default:
+                throw new CmsEventException(string.Format("CMS Event \"{0}\" not implemented", cmsEvent));
+        }
+    }
+
+    private void DbAdd(ContentComponentDbEntity mapped)
+    {
+        _db.Add(mapped);
+    }
+
+    private void DbUpdate(ContentComponentDbEntity mapped, ContentComponentDbEntity existing)
+    {
+        UpdateProperties(mapped, existing);
+    }
+
+    private void UpdateProperties(ContentComponentDbEntity entity, ContentComponentDbEntity existing)
+    {
+        foreach (var property in PropertiesToCopy(entity))
+        {
+            property.SetValue(existing, property.GetValue(entity));
+        }
+    }
+
+    /// <summary>
+    /// Get properties to copy for the selected entity
+    /// </summary>
+    /// <remarks>
+    /// Returns all properties, except properties ending with "Id" (i.e. relationship fields), and properties that have
+    /// a <see cref="DontCopyValueAttribute"/> attribute.
+    /// </remarks>
+    /// <param name="entity">Entity to get copyable properties for</param>
+    /// <returns></returns>
+    private IEnumerable<PropertyInfo> PropertiesToCopy(ContentComponentDbEntity entity)
+    => entity.GetType()
+            .GetProperties()
+            .Where(property => !property.Name.EndsWith("Id") && !HasDontCopyValueAttribute(property));
+
+    /// <summary>
+    /// Does the property have a <see cref="DontCopyValueAttribute"/> property attached to it? 
+    /// </summary>
+    /// <param name="property"></param>
+    /// <returns></returns>
+    private bool HasDontCopyValueAttribute(PropertyInfo property)
+     => property.CustomAttributes.Any(attribute => attribute.AttributeType == _dontCopyValueAttribute);
+
+    private async Task DbSaveChanges()
+    {
+        long rowsChangedInDatabase = await _db.SaveChangesAsync();
+
+        if (rowsChangedInDatabase == 0L)
+        {
+            Logger.LogError("No rows changed in the database!");
+        }
+        else
+        {
+            Logger.LogInformation($"Updated {rowsChangedInDatabase} rows in the database");
+        }
     }
 }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
@@ -109,9 +109,12 @@ public abstract class JsonToDbMapper
     {
         yield return new KeyValuePair<string, object?>("id", payload.Sys.Id);
 
-        foreach (var field in payload.Fields.SelectMany(GetValuesFromFields))
+        if (!payload.Sys.Type.Equals("DeletedEntry"))
         {
-            yield return field;
+            foreach (var field in payload.Fields.SelectMany(GetValuesFromFields))
+            {
+                yield return field;
+            }
         }
     }
 

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
@@ -26,7 +26,11 @@ where TEntity : ContentComponentDbEntity, new()
         Payload = payload;
 
         var values = GetEntityValuesDictionary(payload);
-        values = PerformAdditionalMapping(values);
+
+        if (!payload.Sys.Type.Equals("DeletedEntry"))
+        {
+            values = PerformAdditionalMapping(values);
+        }
 
         var asJson = JsonSerializer.Serialize(values, JsonOptions);
         var serialised = JsonSerializer.Deserialize<TEntity>(asJson, JsonOptions) ?? throw new NullReferenceException("Null returned");

--- a/src/Dfe.PlanTech.Domain/Caching/Enums/CmsEvent.cs
+++ b/src/Dfe.PlanTech.Domain/Caching/Enums/CmsEvent.cs
@@ -1,0 +1,13 @@
+namespace Dfe.PlanTech.Domain.Caching.Enums;
+
+public enum CmsEvent
+{
+    CREATE,
+    SAVE,
+    AUTO_SAVE,
+    ARCHIVE,
+    UNARCHIVE,
+    PUBLISH,
+    UNPUBLISH,
+    DELETE
+}

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -194,6 +194,8 @@ public class CmsDbContext : DbContext, ICmsDbContext
             entity.Navigation(warningComponent => warningComponent.Text).AutoInclude();
         });
 
+        modelBuilder.Entity<ContentComponentDbEntity>().HasQueryFilter(entity => entity.Published && !entity.Archived && !entity.Deleted);
+
     }
 
     public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -195,7 +195,6 @@ public class CmsDbContext : DbContext, ICmsDbContext
         });
 
         modelBuilder.Entity<ContentComponentDbEntity>().HasQueryFilter(entity => entity.Published && !entity.Archived && !entity.Deleted);
-
     }
 
     public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -228,7 +228,7 @@ public class QueueReceiverTests
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
 
-        var subject = "ContentManagement.Entry.publish";
+        var subject = "ContentManagement.Entry.unpublish";
         var serviceBusMessage = new ServiceBusMessage(bodyJsonStr) { Subject = subject };
 
         ServiceBusReceivedMessage serviceBusReceivedMessage = ServiceBusReceivedMessage.FromAmqpMessage(serviceBusMessage.GetRawAmqpMessage(), BinaryData.FromBytes(Encoding.UTF8.GetBytes(serviceBusReceivedMessageMock.LockToken)));
@@ -239,7 +239,7 @@ public class QueueReceiverTests
 
         var added = _addedObject as ContentComponentDbEntity;
         Assert.NotNull(added);
-        Assert.True(added.Published);
+        Assert.False(added.Published);
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -221,7 +221,7 @@ public class QueueReceiverTests
     }
 
     [Fact]
-    public async Task QueueRecieverDbWriter_Should_CompleteSuccessfully_After_New_Unpublish()
+    public async Task QueueRecieverDbWriter_Should_DeadLetterQueue_After_New_Unpublish()
     {
         _contentComponent.Published = false;
 
@@ -235,11 +235,7 @@ public class QueueReceiverTests
 
         await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock, CancellationToken.None);
 
-        await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
-
-        var added = _addedObject as ContentComponentDbEntity;
-        Assert.NotNull(added);
-        Assert.False(added.Published);
+        await serviceBusMessageActionsMock.Received().DeadLetterMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), null, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -223,6 +223,8 @@ public class QueueReceiverTests
     [Fact]
     public async Task QueueRecieverDbWriter_Should_CompleteSuccessfully_After_Unpublish()
     {
+        _existing.Add(_contentComponent);
+
         _contentComponent.Published = false;
 
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
@@ -236,10 +238,8 @@ public class QueueReceiverTests
         await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock, CancellationToken.None);
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
-
-        var added = _addedObject as ContentComponentDbEntity;
-        Assert.NotNull(added);
-        Assert.False(added.Published);
+        _cmsDbContextMock.ReceivedWithAnyArgs(0).Add(Arg.Any<ContentComponentDbEntity>());
+        await _cmsDbContextMock.ReceivedWithAnyArgs(1).SaveChangesAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/BaseMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/BaseMapperTests.cs
@@ -28,7 +28,8 @@ public abstract class BaseMapperTests
         {
             Sys = new CmsWebHookSystemDetails()
             {
-                Id = entityId
+                Id = entityId,
+                Type = "Entry"
             },
             Fields = asJsonNode!
         };


### PR DESCRIPTION
Ticket: [190555](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_boards/board/t/Plan%20Tech/Stories/?workitem=190555)

This ticket adds a global filter to all queries from the CMS DB that only allows content that is published, not archived and not deleted to be pulled in when using the service.

It also fixes a special case regarding unpublishing content where a special "DeletedEntry" JSON needs to be parsed, which includes a rejigging of QueueReceiver to make it more maintainable.