### PR TITLE
fix: add KV reference identity id

### DIFF
--- a/terraform/container-app/functions.tf
+++ b/terraform/container-app/functions.tf
@@ -35,6 +35,8 @@ resource "azurerm_linux_function_app" "contentful_function" {
   storage_account_access_key = azurerm_storage_account.function_storage.primary_access_key
   storage_account_name       = azurerm_storage_account.function_storage.name
 
+  key_vault_reference_identity_id = azurerm_user_assigned_identity.user_assigned_identity.client_id
+
   site_config {
     application_insights_key = azurerm_application_insights.functional_insights.instrumentation_key
     application_stack {

--- a/terraform/container-app/functions.tf
+++ b/terraform/container-app/functions.tf
@@ -35,7 +35,7 @@ resource "azurerm_linux_function_app" "contentful_function" {
   storage_account_access_key = azurerm_storage_account.function_storage.primary_access_key
   storage_account_name       = azurerm_storage_account.function_storage.name
 
-  key_vault_reference_identity_id = azurerm_user_assigned_identity.user_assigned_identity.client_id
+  key_vault_reference_identity_id = azurerm_user_assigned_identity.user_assigned_identity.id
 
   site_config {
     application_insights_key = azurerm_application_insights.functional_insights.instrumentation_key

--- a/terraform/container-app/terraform-configuration.md
+++ b/terraform/container-app/terraform-configuration.md
@@ -30,7 +30,7 @@ We use two external modules to create the majority of the resources required:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.6.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.56.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.82.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 

--- a/terraform/container-app/versions.tf
+++ b/terraform/container-app/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.56.0"
+      version = ">= 3.82.0"
     }
     azapi = {
       source  = "Azure/azapi"


### PR DESCRIPTION
- Adds the KV reference identity ID to function app in Terraform
- Updates `azurerm` provider version to earliest one that supports .NET 8 in function apps.