### PR TITLE
feat: Support preview mode in Content db

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -22,9 +22,9 @@ public class QueueReceiver : BaseFunction
     private readonly JsonToEntityMappers _mappers;
     private readonly Type _dontCopyValueAttribute = typeof(DontCopyValueAttribute);
 
-    public QueueReceiver(ILoggerFactory loggerFactory, CmsDbContext db, JsonToEntityMappers mappers) : base(loggerFactory.CreateLogger<QueueReceiver>())
+    public QueueReceiver(ContentfulOptions contentfulOptions, ILoggerFactory loggerFactory, CmsDbContext db, JsonToEntityMappers mappers) : base(loggerFactory.CreateLogger<QueueReceiver>())
     {
-        //_contentfulOptions = contentfulOptions;
+        _contentfulOptions = contentfulOptions;
         _db = db;
         _mappers = mappers;
     }
@@ -89,9 +89,7 @@ public class QueueReceiver : BaseFunction
 
         Logger.LogInformation("Processing = {messageBody}", messageBody);
 
-        var entity = _mappers.ToEntity(messageBody);
-
-        return cmsEvent != CmsEvent.CREATE ? entity : new ContentComponentDbEntity() { Id = entity.Id };
+        return _mappers.ToEntity(messageBody);
     }
 
     private async Task<ContentComponentDbEntity?> GetExisting(ContentComponentDbEntity mapped, CancellationToken cancellationToken)

--- a/src/Dfe.PlanTech.AzureFunctions/Startup.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Startup.cs
@@ -42,7 +42,7 @@ namespace Dfe.PlanTech.AzureFunctions
                 Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
             });
 
-            //services.Configure<ContentfulOptions>(configuration.GetSection("Contentful"));
+            services.AddSingleton(new ContentfulOptions(configuration.GetValue<bool>("Contentful:UsePreview")));
 
             AddMappers(services);
         }

--- a/src/Dfe.PlanTech.AzureFunctions/Startup.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Startup.cs
@@ -42,7 +42,11 @@ namespace Dfe.PlanTech.AzureFunctions
                 Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
             });
 
-            services.AddSingleton(new ContentfulOptions(configuration.GetValue<bool>("Contentful:UsePreview")));
+            services.AddSingleton(() =>
+            {
+                var usePreview = bool.Parse(configuration["Contentful:UsePreview"] ?? "false");
+                return new ContentfulOptions(usePreview);
+            });
 
             AddMappers(services);
         }

--- a/src/Dfe.PlanTech.AzureFunctions/Startup.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Startup.cs
@@ -1,6 +1,7 @@
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
 using Dfe.PlanTech.AzureFunctions.Mappings;
+using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Azure;
@@ -40,6 +41,8 @@ namespace Dfe.PlanTech.AzureFunctions
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
             });
+
+            //services.Configure<ContentfulOptions>(configuration.GetSection("Contentful"));
 
             AddMappers(services);
         }

--- a/src/Dfe.PlanTech.Domain/Content/Models/ContentComponentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/ContentComponentDbEntity.cs
@@ -2,7 +2,7 @@ using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Content.Models;
 
-public abstract class ContentComponentDbEntity : IContentComponentDbEntity
+public class ContentComponentDbEntity : IContentComponentDbEntity
 {
     public string Id { get; set; } = null!;
 

--- a/src/Dfe.PlanTech.Domain/Content/Models/ContentComponentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/ContentComponentDbEntity.cs
@@ -2,7 +2,7 @@ using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Content.Models;
 
-public class ContentComponentDbEntity : IContentComponentDbEntity
+public abstract class ContentComponentDbEntity : IContentComponentDbEntity
 {
     public string Id { get; set; } = null!;
 

--- a/src/Dfe.PlanTech.Domain/Persistence/Models/ContentfulOptions.cs
+++ b/src/Dfe.PlanTech.Domain/Persistence/Models/ContentfulOptions.cs
@@ -1,0 +1,3 @@
+namespace Dfe.PlanTech.Domain.Persistence.Models;
+
+public record ContentfulOptions(bool UsePreview);

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -1,9 +1,11 @@
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 
 namespace Dfe.PlanTech.Infrastructure.Data;
 
@@ -72,11 +74,21 @@ public class CmsDbContext : DbContext, ICmsDbContext
     IQueryable<WarningComponentDbEntity> ICmsDbContext.Warnings => Warnings;
 
 
-    public CmsDbContext() { }
+    private readonly ContentfulOptions _contentfulOptions;
 
-    public CmsDbContext(DbContextOptions<CmsDbContext> options) : base(options)
+    public CmsDbContext()
     {
+        _contentfulOptions = new ContentfulOptions(false);
+    }
 
+    public CmsDbContext(ContentfulOptions contentfulOptions)
+    {
+        _contentfulOptions = contentfulOptions;
+    }
+
+    public CmsDbContext(DbContextOptions<CmsDbContext> options, ContentfulOptions contentfulOptions) : base(options)
+    {
+        _contentfulOptions = contentfulOptions;
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -192,7 +204,15 @@ public class CmsDbContext : DbContext, ICmsDbContext
             entity.Navigation(warningComponent => warningComponent.Text).AutoInclude();
         });
 
-        modelBuilder.Entity<ContentComponentDbEntity>().HasQueryFilter(entity => entity.Published && !entity.Archived && !entity.Deleted);
+        modelBuilder.Entity<ContentComponentDbEntity>().HasQueryFilter(ShouldShowEntity());
+    }
+
+    /// <summary>
+    /// Should the given entity be displayed? I.e. is it not archived, not deleted, and either published or use preview mode is enabled
+    /// </summary>
+    private Expression<Func<ContentComponentDbEntity, bool>> ShouldShowEntity()
+    {
+        return entity => (_contentfulOptions.UsePreview || entity.Published) && !entity.Archived && !entity.Deleted;
     }
 
     public Task<PageDbEntity?> GetPageBySlug(string slug, CancellationToken cancellationToken = default)

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -4,6 +4,7 @@ using Dfe.PlanTech.Domain.Content.Models.Buttons;
 using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
@@ -73,22 +74,11 @@ public class CmsDbContext : DbContext, ICmsDbContext
     IQueryable<TitleDbEntity> ICmsDbContext.Titles => Titles;
     IQueryable<WarningComponentDbEntity> ICmsDbContext.Warnings => Warnings;
 
-
     private readonly ContentfulOptions _contentfulOptions;
 
-    public CmsDbContext()
+    public CmsDbContext(DbContextOptions<CmsDbContext> options) : base(options)
     {
-        _contentfulOptions = new ContentfulOptions(false);
-    }
-
-    public CmsDbContext(ContentfulOptions contentfulOptions)
-    {
-        _contentfulOptions = contentfulOptions;
-    }
-
-    public CmsDbContext(DbContextOptions<CmsDbContext> options, ContentfulOptions contentfulOptions) : base(options)
-    {
-        _contentfulOptions = contentfulOptions;
+        _contentfulOptions = this.GetService<ContentfulOptions>();
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/Dfe.PlanTech.Web/ProgramExtensions.cs
+++ b/src/Dfe.PlanTech.Web/ProgramExtensions.cs
@@ -80,7 +80,7 @@ public static class ProgramExtensions
         });
 
         services.AddTransient<GetPageFromContentfulQuery>();
-        services.AddSingleton(() => new ContentfulOptions(configuration.GetValue<bool>("Contentful:UseePreview")));
+        services.AddSingleton(new ContentfulOptions(configuration.GetValue<bool>("Contentful:UsePreview")));
         return services;
     }
 
@@ -112,16 +112,17 @@ public static class ProgramExtensions
         void databaseOptionsAction(DbContextOptionsBuilder options) => options.UseSqlServer(configuration.GetConnectionString("Database"));
 
         services.AddDbContextPool<ICmsDbContext, CmsDbContext>((serviceProvider, optionsBuilder) =>
-                optionsBuilder
-                    .UseSqlServer(
-                        configuration.GetConnectionString("Database"),
-                        sqlServerOptionsBuilder =>
-                        {
-                            sqlServerOptionsBuilder
-                                .CommandTimeout((int)TimeSpan.FromSeconds(30).TotalSeconds)
-                                .EnableRetryOnFailure();
-                        })
-                    .AddInterceptors(serviceProvider.GetRequiredService<SecondLevelCacheInterceptor>()));
+            optionsBuilder
+                .UseSqlServer(
+                    configuration.GetConnectionString("Database"),
+                    sqlServerOptionsBuilder =>
+                    {
+                        sqlServerOptionsBuilder
+                            .CommandTimeout((int)TimeSpan.FromSeconds(30).TotalSeconds)
+                            .EnableRetryOnFailure();
+                    })
+                .AddInterceptors(serviceProvider.GetRequiredService<SecondLevelCacheInterceptor>())
+        );
 
         services.AddEFSecondLevelCache(options =>
         {

--- a/src/Dfe.PlanTech.Web/ProgramExtensions.cs
+++ b/src/Dfe.PlanTech.Web/ProgramExtensions.cs
@@ -17,6 +17,7 @@ using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models.Options;
 using Dfe.PlanTech.Domain.Cookie.Interfaces;
 using Dfe.PlanTech.Domain.Interfaces;
+using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Responses.Interfaces;
 using Dfe.PlanTech.Domain.Submissions.Interfaces;
@@ -79,7 +80,7 @@ public static class ProgramExtensions
         });
 
         services.AddTransient<GetPageFromContentfulQuery>();
-
+        services.AddSingleton(() => new ContentfulOptions(configuration.GetValue<bool>("Contentful:UseePreview")));
         return services;
     }
 

--- a/src/Dfe.PlanTech.Web/appsettings.json
+++ b/src/Dfe.PlanTech.Web/appsettings.json
@@ -25,5 +25,8 @@
         "Url": "http://*:8080"
       }
     }
+  },
+  "Contentful": {
+    "UsePreview": false
   }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -2,6 +2,7 @@ using Azure.Messaging.ServiceBus;
 using Dfe.PlanTech.AzureFunctions.Mappings;
 using Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.Azure.Functions.Worker;
@@ -80,7 +81,7 @@ public class QueueReceiverTests
 
         _jsonToEntityMappers = Substitute.For<JsonToEntityMappers>(new JsonToDbMapper[] { new JsonToDbMapperImplementation(questionDbEntityType, _loggerMock, jsonOptions) }, jsonOptions);
 
-        _queueReceiver = new QueueReceiver(_loggerFactoryMock, _cmsDbContextMock, _jsonToEntityMappers);
+        _queueReceiver = new QueueReceiver(new ContentfulOptions(true), _loggerFactoryMock, _cmsDbContextMock, _jsonToEntityMappers);
 
         _cmsDbContextMock.Add(Arg.Any<ContentComponentDbEntity>()).Returns(callinfo =>
         {
@@ -130,7 +131,7 @@ public class QueueReceiverTests
 
         ServiceBusReceivedMessage serviceBusReceivedMessage = ServiceBusReceivedMessage.FromAmqpMessage(serviceBusMessage.GetRawAmqpMessage(), BinaryData.FromBytes(Encoding.UTF8.GetBytes(serviceBusReceivedMessageMock.LockToken)));
 
-        await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock, CancellationToken.None);
+        await _queueReceiver.QueueReceiverDbWriter([serviceBusReceivedMessage], serviceBusMessageActionsMock, CancellationToken.None);
 
         await serviceBusMessageActionsMock.Received().DeadLetterMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), null, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -167,7 +168,7 @@ public class QueueReceiverTests
 
         ServiceBusReceivedMessage serviceBusReceivedMessage = ServiceBusReceivedMessage.FromAmqpMessage(serviceBusMessage.GetRawAmqpMessage(), BinaryData.FromBytes(Encoding.UTF8.GetBytes(serviceBusReceivedMessageMock.LockToken)));
 
-        await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock, CancellationToken.None);
+        await _queueReceiver.QueueReceiverDbWriter([serviceBusReceivedMessage], serviceBusMessageActionsMock, CancellationToken.None);
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
 
@@ -189,7 +190,7 @@ public class QueueReceiverTests
 
         ServiceBusReceivedMessage serviceBusReceivedMessage = ServiceBusReceivedMessage.FromAmqpMessage(serviceBusMessage.GetRawAmqpMessage(), BinaryData.FromBytes(Encoding.UTF8.GetBytes(serviceBusReceivedMessageMock.LockToken)));
 
-        await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock, CancellationToken.None);
+        await _queueReceiver.QueueReceiverDbWriter([serviceBusReceivedMessage], serviceBusMessageActionsMock, CancellationToken.None);
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
 
@@ -283,6 +284,50 @@ public class QueueReceiverTests
     }
 
     [Fact]
+    public async Task QueueRecieverDbWriter_Should_ExitEarly_When_Event_Is_Save_And_UsePreview_Is_False()
+    {
+        var queueReceiver = new QueueReceiver(new ContentfulOptions(false), _loggerFactoryMock, _cmsDbContextMock, _jsonToEntityMappers);
+
+        ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
+        ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
+
+        var subject = "ContentManagement.Entry.save";
+        var serviceBusMessage = new ServiceBusMessage(bodyJsonStr) { Subject = subject };
+
+        ServiceBusReceivedMessage serviceBusReceivedMessage = ServiceBusReceivedMessage.FromAmqpMessage(serviceBusMessage.GetRawAmqpMessage(), BinaryData.FromBytes(Encoding.UTF8.GetBytes(serviceBusReceivedMessageMock.LockToken)));
+
+        await queueReceiver.QueueReceiverDbWriter([serviceBusReceivedMessage], serviceBusMessageActionsMock, CancellationToken.None);
+
+        await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
+
+        var added = _addedObject as ContentComponentDbEntity;
+        Assert.Null(added);
+    }
+
+
+    [Fact]
+    public async Task QueueRecieverDbWriter_Should_ExitEarly_When_Event_Is_AutoSave_And_UsePreview_Is_False()
+    {
+        var queueReceiver = new QueueReceiver(new ContentfulOptions(false), _loggerFactoryMock, _cmsDbContextMock, _jsonToEntityMappers);
+
+        ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
+        ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
+
+        var subject = "ContentManagement.Entry.auto_save";
+        var serviceBusMessage = new ServiceBusMessage(bodyJsonStr) { Subject = subject };
+
+        ServiceBusReceivedMessage serviceBusReceivedMessage = ServiceBusReceivedMessage.FromAmqpMessage(serviceBusMessage.GetRawAmqpMessage(), BinaryData.FromBytes(Encoding.UTF8.GetBytes(serviceBusReceivedMessageMock.LockToken)));
+
+        await queueReceiver.QueueReceiverDbWriter([serviceBusReceivedMessage], serviceBusMessageActionsMock, CancellationToken.None);
+
+        await serviceBusMessageActionsMock.Received()
+                                          .CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
+
+        var added = _addedObject as ContentComponentDbEntity;
+        Assert.Null(added);
+    }
+
+    [Fact]
     public async Task QueueRecieverDbWriter_Should_DeadLetterQueue_If_ActionIsInvalid()
     {
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
@@ -293,7 +338,7 @@ public class QueueReceiverTests
 
         ServiceBusReceivedMessage serviceBusReceivedMessage = ServiceBusReceivedMessage.FromAmqpMessage(serviceBusMessage.GetRawAmqpMessage(), BinaryData.FromBytes(Encoding.UTF8.GetBytes(serviceBusReceivedMessageMock.LockToken)));
 
-        await _queueReceiver.QueueReceiverDbWriter(new ServiceBusReceivedMessage[] { serviceBusReceivedMessage }, serviceBusMessageActionsMock, CancellationToken.None);
+        await _queueReceiver.QueueReceiverDbWriter([serviceBusReceivedMessage], serviceBusMessageActionsMock, CancellationToken.None);
 
         await serviceBusMessageActionsMock.Received().DeadLetterMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), null, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
- Adds ContentfulOptions class to get "UsePreview" variable in Azure Function, Web Project, and DB project

- If "UsePreview" is true:
   - In Azure functions: Ignore "Save" and "Auto save" events
   - In DB: allow "unpublished" content to be retrieved