### PR TITLE
refactor/195442 - PR #491 Tech Debt

### DIFF
--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -95,7 +95,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Install dotnet coverage
-        run: dotnet tool install --global dotnet-coverage --version 17.10.2
+        run: dotnet tool install --global dotnet-coverage --version 17.9.3
 
       - name: Install SonarCloud scanners
         run: dotnet tool install --global dotnet-sonarscanner

--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -95,7 +95,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Install dotnet coverage
-        run: dotnet tool install --global dotnet-coverage --version 17.9.6
+        run: dotnet tool install --global dotnet-coverage --version 17.10.2
 
       - name: Install SonarCloud scanners
         run: dotnet tool install --global dotnet-sonarscanner

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -71,7 +71,7 @@ public class QueueReceiver : BaseFunction
             ContentComponentDbEntity mapped = MapMessageToEntity(message);
             ContentComponentDbEntity? existing = await TryGetExistingEntity(mapped, cancellationToken);
 
-            if (!IsValidComponent(mapped, existing))
+            if (!IsValidComponent(mapped))
             {
                 await messageActions.CompleteMessageAsync(message, cancellationToken);
                 return;

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -92,7 +92,7 @@ public class QueueReceiver : BaseFunction
         }
     }
 
-    private bool IsValidComponent(ContentComponentDbEntity mapped, ContentComponentDbEntity? existing)
+    private bool IsValidComponent(ContentComponentDbEntity mapped)
     {
         if (AnyRequiredPropertyIsNull(mapped, out List<PropertyInfo?> nullProperties))
         {

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -71,7 +71,7 @@ public class QueueReceiver : BaseFunction
             ContentComponentDbEntity mapped = MapMessageToEntity(message);
             ContentComponentDbEntity? existing = await TryGetExistingEntity(mapped, cancellationToken);
 
-            if (!IsNewAndValidComponent(mapped, existing))
+            if (!IsValidComponent(mapped, existing))
             {
                 await messageActions.CompleteMessageAsync(message, cancellationToken);
                 return;
@@ -92,10 +92,8 @@ public class QueueReceiver : BaseFunction
         }
     }
 
-    private bool IsNewAndValidComponent(ContentComponentDbEntity mapped, ContentComponentDbEntity? existing)
+    private bool IsValidComponent(ContentComponentDbEntity mapped, ContentComponentDbEntity? existing)
     {
-        if (existing != null) return true;
-
         if (AnyRequiredPropertyIsNull(mapped, out List<PropertyInfo?> nullProperties))
         {
             Logger.LogInformation("Content Component with ID {id} is missing the following required properties: {nullProperties}", mapped.Id, string.Join(", ", nullProperties));

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -118,15 +118,6 @@ public class QueueReceiver : BaseFunction
         return nullProperties.Count > 0;
     }
 
-    // private bool AnyRequiredPropertyIsNull(ContentComponentDbEntity entity)
-    // => _db.Model.FindEntityType(entity.GetType())!
-    //     .GetProperties()
-    //     .Where(prop => !prop.IsNullable)
-    //     .Select(prop => prop.PropertyInfo)
-    //     .Where(prop => !prop!.CustomAttributes.Any(atr => atr.GetType() == typeof(DontCopyValueAttribute)))
-    //     .Where(prop => prop!.GetValue(entity) == null)
-    //     .Any();
-
     /// <summary>
     /// Checks if the message with the given CmsEvent should be ignored based on certain conditions.
     /// </summary>


### PR DESCRIPTION
Ticket: [195442](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_boards/board/t/Plan%20Tech/Stories/?workitem=195442)

This PR addresses the comments left in https://github.com/DFE-Digital/plan-technology-for-your-school/pull/491

References to commit hashes in this PR have been left in the comments in #491

Specifically it:

- Merges ShouldDropMessage and ShouldIgnoreMessage into one function for less confusion.

- In the event of an invalid component, logs out exactly which properties are invalid.

- Checks to see if the incoming entity is valid regardless of whether a version exists or not in the Db already, as anything missing means it was a required field in Contentful that was deleted.