### PR TITLE
feat: Convert RichTextContents function into a view

### DIFF
--- a/src/Dfe.PlanTech.Application/Content/Queries/GetRichTextsQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetRichTextsQuery.cs
@@ -1,20 +1,18 @@
+using System.Linq;
+using System.Linq.Expressions;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Persistence.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Dfe.PlanTech.Application.Content.Queries;
 
-public class GetRichTextsQuery : IGetPageChildrenQuery
+public class GetRichTextsForPageQuery(ICmsDbContext db, ILogger<GetRichTextsForPageQuery> logger, ContentfulOptions contentfulOptions) : IGetPageChildrenQuery
 {
-    private readonly ICmsDbContext _db;
-    private readonly ILogger<GetRichTextsQuery> _logger;
-
-    public GetRichTextsQuery(ICmsDbContext db, ILogger<GetRichTextsQuery> logger)
-    {
-        _db = db;
-        _logger = logger;
-    }
+    private readonly ICmsDbContext _db = db;
+    private readonly ILogger<GetRichTextsForPageQuery> _logger = logger;
+    private readonly ContentfulOptions _contentfulOptions = contentfulOptions;
 
     /// <summary>
     /// Load RichTextContents for the given page from database 
@@ -32,12 +30,19 @@ public class GetRichTextsQuery : IGetPageChildrenQuery
 
             if (!hasTextBodyContents) return;
 
-            await _db.ToListAsync(_db.RichTextContentsByPageSlug(page.Slug), cancellationToken);
+            var richTextContentQuery = _db.RichTextContentWithSlugs.Where(PageMatchesSlugAndPublishedOrIsPreview(page));
+
+            var richTexts = await _db.ToListAsync(richTextContentQuery, cancellationToken);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error fetching rich text content from Database for {pageId}", page.Id);
             throw;
         }
+    }
+
+    private Expression<Func<RichTextContentWithSlugDbEntity, bool>> PageMatchesSlugAndPublishedOrIsPreview(PageDbEntity page)
+    {
+        return content => content.Slug == page.Slug && (!_contentfulOptions.UsePreview || content.Published);
     }
 }

--- a/src/Dfe.PlanTech.Application/Helpers/QueryServiceSetup.cs
+++ b/src/Dfe.PlanTech.Application/Helpers/QueryServiceSetup.cs
@@ -29,7 +29,7 @@ public static class QueryServiceSetup
         services.AddScoped<IGetPageQuery, GetPageQuery>();
         services.AddScoped<IGetPageChildrenQuery, GetButtonWithEntryReferencesQuery>();
         services.AddScoped<IGetPageChildrenQuery, GetCategorySectionsQuery>();
-        services.AddScoped<IGetPageChildrenQuery, GetRichTextsQuery>();
+        services.AddScoped<IGetPageChildrenQuery, GetRichTextsForPageQuery>();
 
         return services;
     }

--- a/src/Dfe.PlanTech.Application/Persistence/Interfaces/ICmsDbContext.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Interfaces/ICmsDbContext.cs
@@ -33,6 +33,7 @@ public interface ICmsDbContext
     public IQueryable<RecommendationPageDbEntity> RecommendationPages { get; }
 
     public IQueryable<RichTextContentDbEntity> RichTextContents { get; }
+    public IQueryable<RichTextContentWithSlugDbEntity> RichTextContentWithSlugs { get; }
 
     public IQueryable<RichTextDataDbEntity> RichTextDataDbEntity { get; }
 
@@ -48,8 +49,6 @@ public interface ICmsDbContext
 
 
     public Task<PageDbEntity?> GetPageBySlug(string slug, CancellationToken cancellationToken = default);
-
-    public IQueryable<RichTextContentDbEntity> RichTextContentsByPageSlug(string pageSlug);
 
     public Task<T?> FirstOrDefaultAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default);
     public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default);

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240209_1647_CreateRichTextContentWithPageSlugView.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240209_1647_CreateRichTextContentWithPageSlugView.sql
@@ -1,0 +1,47 @@
+ALTER VIEW Contentful.[RichTextContentsBySlug] AS
+(
+    SELECT [Slug], [Id], [Value], [NodeType], [DataId], [ParentId], [Published], [Archived], [Deleted]
+    FROM (     
+        SELECT * 
+        FROM (
+                SELECT RichTextId, Slug, Archived, Deleted, Published
+                FROM 
+                (
+                    --- Get RichTextIds for all text bodies and warnings
+                    SELECT * 
+                    FROM 
+                    (
+                        SELECT RichTextId, Id AS ContentId 
+                        FROM [Contentful].[TextBodies] AS TB
+                        UNION
+                        SELECT RichTextId, TB.Id 
+                        FROM [Contentful].[Warnings] AS W
+                        LEFT JOIN [Contentful].[TextBodies] AS TB ON W.TextId = TB.Id
+                    ) AS RT
+                ) AS RichTexts
+
+                LEFT JOIN 
+                
+                --Get all contents for a page
+                (
+                    SELECT MAX(Slug) AS Slug, ContentId
+                    FROM 
+                    (
+                        SELECT ISNULL([BeforeContentComponentId], [ContentComponentId]) AS ContentId, P.Slug 
+                        FROM [Contentful].[PageContents] PC
+                        LEFT JOIN [Contentful].[Pages] P ON PC.PageId = P.Id
+                    ) AS PC
+                    GROUP BY PC.ContentId
+                ) AS Contents ON Contents.ContentId = RichTexts.ContentId
+
+                LEFT JOIN(
+                    SELECT Id, Archived, Published, DELETED
+                    FROM Contentful.ContentComponents
+                ) AS CC 
+                ON CC.Id = RichTexts.ContentId
+            ) AS RichTextContents
+        ) AS RichTextContentParents
+    OUTER APPLY (
+        SELECT * FROM [Contentful].[SelectAllRichTextContentForParentId](RichTextContentParents.RichTextId) 
+    ) AS RichTextContentsWithSlug
+)

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240209_1649_DeleteUnusedFunctions.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240209_1649_DeleteUnusedFunctions.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION [Contentful].[SelectAllRichTextContentForPageSlug];
+DROP FUNCTION [Contentful].[SelectAllRichTextContentForParentIds];

--- a/src/Dfe.PlanTech.Domain/Content/Models/RichTextContentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/RichTextContentDbEntity.cs
@@ -3,7 +3,6 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Dfe.PlanTech.Domain.Content.Models;
-
 /// <summary>
 /// Content for a 'RichText' field in Contentful
 /// </summary>
@@ -20,16 +19,17 @@ public class RichTextContentDbEntity : IRichTextContent<RichTextMarkDbEntity, Ri
 
     public RichTextDataDbEntity? Data { get; set; }
 
-    public List<RichTextMarkDbEntity> Marks { get; set; } = new();
+    public List<RichTextMarkDbEntity> Marks { get; set; } = [];
 
     /// <summary>
     /// Children
     /// </summary>
-    public List<RichTextContentDbEntity> Content { get; set; } = new();
+    public List<RichTextContentDbEntity> Content { get; set; } = [];
 
     public RichTextContentDbEntity? Parent { get; set; }
 
     public long? ParentId { get; set; }
 
     public ComponentDropDownDbEntity? DropDown { get; set; }
+
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/RichTextContentWithSlugDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/RichTextContentWithSlugDbEntity.cs
@@ -1,0 +1,20 @@
+namespace Dfe.PlanTech.Domain.Content.Models;
+
+
+/// <summary>
+/// Represents a rich text content entity with the corresponding slug for the page that it is loaded on
+/// </summary>
+/// <remarks>
+/// Is loaded by a view
+/// </remarks>
+public class RichTextContentWithSlugDbEntity : RichTextContentDbEntity
+{
+  //Loaded from page that the parent entity (e.g. TextBodyDbEntity) belongs to
+  public string Slug { get; set; } = null!;
+
+  //Loaded from the parent entity
+  public bool Archived { get; set; }
+  public bool Deleted { get; set; }
+  public bool Published { get; set; }
+
+}

--- a/src/Dfe.PlanTech.Domain/Content/Models/WarningComponentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/WarningComponentDbEntity.cs
@@ -21,3 +21,8 @@ public class WarningComponentDbEntity : ContentComponentDbEntity, IWarningCompon
     [DontCopyValue]
     public long RichTextId => Text.RichTextId;
 }
+
+public class RichTextContentWithPageSlug
+{
+
+}

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageFromDbQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageFromDbQueryTests.cs
@@ -271,7 +271,6 @@ public class GetPageFromDbQueryTests
         await _cmsDbSubstitute.ReceivedWithAnyArgs(1).GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await _cmsDbSubstitute.ReceivedWithAnyArgs(0).ToListAsync(Arg.Any<IQueryable<SectionDbEntity>>(), Arg.Any<CancellationToken>());
         await _cmsDbSubstitute.ReceivedWithAnyArgs(0).ToListAsync(Arg.Any<IQueryable<ButtonWithEntryReferenceDbEntity>>(), Arg.Any<CancellationToken>());
-        _cmsDbSubstitute.ReceivedWithAnyArgs(0).RichTextContentsByPageSlug(Arg.Any<string>());
         await _getPageChildrenQuery.ReceivedWithAnyArgs(1).TryLoadChildren(Arg.Any<PageDbEntity>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetRichTextsQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetRichTextsQueryTests.cs
@@ -90,7 +90,7 @@ public class GetRichTextsQueryTests
     await _getRichTextsQuery.TryLoadChildren(_loadedPage, CancellationToken.None);
 
     await _db.ReceivedWithAnyArgs(1)
-                 .ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>());
+                 .ToListAsync(Arg.Any<IQueryable<RichTextContentWithSlugDbEntity>>(), Arg.Any<CancellationToken>());
   }
 
   [Fact]
@@ -99,6 +99,6 @@ public class GetRichTextsQueryTests
     await _getRichTextsQuery.TryLoadChildren(_loadedPage, CancellationToken.None);
 
     await _db.ReceivedWithAnyArgs(0)
-                 .ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>());
+                 .ToListAsync(Arg.Any<IQueryable<RichTextContentWithSlugDbEntity>>(), Arg.Any<CancellationToken>());
   }
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetRichTextsQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetRichTextsQueryTests.cs
@@ -1,6 +1,7 @@
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Persistence.Models;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
@@ -8,27 +9,21 @@ namespace Dfe.PlanTech.Application.UnitTests.Content.Queries;
 
 public class GetRichTextsQueryTests
 {
-    private readonly ICmsDbContext _db = Substitute.For<ICmsDbContext>();
-    private readonly ILogger<GetRichTextsQuery> _logger = Substitute.For<ILogger<GetRichTextsQuery>>();
+  private readonly ICmsDbContext _db = Substitute.For<ICmsDbContext>();
+  private readonly ILogger<GetRichTextsForPageQuery> _logger = Substitute.For<ILogger<GetRichTextsForPageQuery>>();
 
-    private readonly GetRichTextsQuery _getRichTextsQuery;
+  private readonly GetRichTextsForPageQuery _getRichTextsQuery;
 
-    private readonly static PageDbEntity _loadedPage = new()
+  private readonly static PageDbEntity _loadedPage = new()
+  {
+    Id = "Page-id",
+    Content = new()
     {
-        Id = "Page-id",
-        Content = new()
-        {
 
-        }
-    };
+    }
+  };
 
-    private readonly static TextBodyDbEntity _textBody = new()
-    {
-        Id = "ABCD",
-        RichTextId = 1,
-    };
-
-    private readonly static List<RichTextContentDbEntity> _richTextContents = new(){
+  private readonly static List<RichTextContentDbEntity> _richTextContents = new(){
     new()
     {
       Data = new()
@@ -46,48 +41,64 @@ public class GetRichTextsQueryTests
       },
       Value = "rich-text",
       Id = 1,
-    }
+          },new()
+    {
+      Data = new()
+      {
+        Uri = "uri"
+      },
+      Marks = [
+        new(){
+          Type = "Bold",
+        }
+      ],
+      Content = [],
+      Value = "rich-text",
+      Id = 2
+          }
   };
 
-    private readonly List<RichTextContentDbEntity> _returnedRichTextContents = new();
+  private readonly List<RichTextContentDbEntity> _returnedRichTextContents = new();
 
-    public GetRichTextsQueryTests()
-    {
-        _loadedPage.Content.Clear();
+  private readonly ContentfulOptions _contentfulOptions = new(false);
 
-        _getRichTextsQuery = new GetRichTextsQuery(_db, _logger);
+  public GetRichTextsQueryTests()
+  {
+    _loadedPage.Content.Clear();
 
-        _db.RichTextContentsByPageSlug(Arg.Any<string>()).Returns(_richTextContents.AsQueryable());
+    _getRichTextsQuery = new GetRichTextsForPageQuery(_db, _logger, _contentfulOptions);
 
-        _db.ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>())
-            .Returns(callinfo =>
-            {
-                var queryable = callinfo.ArgAt<IQueryable<RichTextContentDbEntity>>(0);
+    _db.RichTextContents.Returns(_richTextContents.AsQueryable());
 
-                return queryable.ToList();
-            });
-    }
-
-    [Fact]
-    public async Task Should_Retrieve_ButtonWithEntryReferences_For_Page_When_Existing()
-    {
-        _loadedPage.Content.Add(new TextBodyDbEntity()
+    _db.ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>())
+        .Returns(callinfo =>
         {
-            RichText = _richTextContents.First()
+          var queryable = callinfo.ArgAt<IQueryable<RichTextContentDbEntity>>(0);
+
+          return queryable.ToList();
         });
+  }
 
-        await _getRichTextsQuery.TryLoadChildren(_loadedPage, CancellationToken.None);
-
-        await _db.ReceivedWithAnyArgs(1)
-                     .ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task Should_Not_Retrieve_ButtonWithEntryReferences_For_Page_When_NoButtons()
+  [Fact]
+  public async Task Should_Retrieve_RichTextContents_When_Matching()
+  {
+    _loadedPage.Content.Add(new TextBodyDbEntity()
     {
-        await _getRichTextsQuery.TryLoadChildren(_loadedPage, CancellationToken.None);
+      RichText = _richTextContents.First()
+    });
 
-        await _db.ReceivedWithAnyArgs(0)
-                     .ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>());
-    }
+    await _getRichTextsQuery.TryLoadChildren(_loadedPage, CancellationToken.None);
+
+    await _db.ReceivedWithAnyArgs(1)
+                 .ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>());
+  }
+
+  [Fact]
+  public async Task Should_Retrieve_RichTextContents_When_Not_Matching()
+  {
+    await _getRichTextsQuery.TryLoadChildren(_loadedPage, CancellationToken.None);
+
+    await _db.ReceivedWithAnyArgs(0)
+                 .ToListAsync(Arg.Any<IQueryable<RichTextContentDbEntity>>(), Arg.Any<CancellationToken>());
+  }
 }


### PR DESCRIPTION
- Creates a view to replace the SQL function `[Contentful].[SelectAllRichTextContentForPageSlug]`
   - View:
      - is more performant: 10-30% faster
      - doesn't involve temporary tables, table variables, loops etc.
      - cleaner
      - easier to debug (as you do not get a plan generate for table-valued functions)