### PR TITLE
fix: SonarCloud Coverage

### DIFF
--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -95,7 +95,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Install dotnet coverage
-        run: dotnet tool install --global dotnet-coverage --version 17.9.6
+        run: dotnet tool install --global dotnet-coverage --version 17.9.3
 
       - name: Install SonarCloud scanners
         run: dotnet tool install --global dotnet-sonarscanner


### PR DESCRIPTION
SonarCloud has some hard dependencies with `dotnet-coverage 17.9.3`, updating it caused the coverage to always report as 0%, this PR rolls back the update to fix it.