### PR TITLE
refactor: Contentful Models

### DIFF
--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationChunk.cs
@@ -1,0 +1,15 @@
+using Dfe.PlanTech.Domain.Content.Interfaces;
+
+namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+
+public interface IRecommendationChunk<THeader, TContentComponent, TAnswer>
+where THeader : IHeader
+where TContentComponent : IContentComponent
+where TAnswer : IAnswer
+{
+    public THeader Header { get; }
+
+    public List<TContentComponent> Content { get; }
+
+    public List<TAnswer> Answers { get; }
+}

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationChunk.cs
@@ -2,7 +2,9 @@ using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
-public interface IRecommendationChunk<TTitle, THeader, TContentComponent, TAnswer>
+public interface IRecommendationChunk { }
+
+public interface IRecommendationChunk<TTitle, THeader, TContentComponent, TAnswer> : IRecommendationChunk
 where TTitle : ITitle
 where THeader : IHeader
 where TContentComponent : IContentComponent

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationChunk.cs
@@ -2,11 +2,14 @@ using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
-public interface IRecommendationChunk<THeader, TContentComponent, TAnswer>
+public interface IRecommendationChunk<TTitle, THeader, TContentComponent, TAnswer>
+where TTitle : ITitle
 where THeader : IHeader
 where TContentComponent : IContentComponent
 where TAnswer : IAnswer
 {
+    public TTitle Title { get; }
+
     public THeader Header { get; }
 
     public List<TContentComponent> Content { get; }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationChunk.cs
@@ -2,16 +2,16 @@ using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
-public interface IRecommendationChunk { }
+public interface IRecommendationChunk
+{
+    public string Title { get; }
+}
 
-public interface IRecommendationChunk<TTitle, THeader, TContentComponent, TAnswer> : IRecommendationChunk
-where TTitle : ITitle
+public interface IRecommendationChunk<THeader, TContentComponent, TAnswer> : IRecommendationChunk
 where THeader : IHeader
 where TContentComponent : IContentComponent
 where TAnswer : IAnswer
 {
-    public TTitle Title { get; }
-
     public THeader Header { get; }
 
     public List<TContentComponent> Content { get; }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
@@ -12,7 +12,7 @@ public interface IRecommendationIntro<THeader, TContentComponent> : IRecommendat
 where THeader : IHeader
 where TContentComponent : IContentComponent
 {
-    public Header Header { get; }
+    public THeader Header { get; }
 
     public List<TContentComponent> Content { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
@@ -8,11 +8,11 @@ public interface IRecommendationIntro
     public string Maturity { get; }
 }
 
-public interface IRecommendationIntro<TTitle, TContentComponent> : IRecommendationIntro
-where TTitle : ITitle
+public interface IRecommendationIntro<THeader, TContentComponent> : IRecommendationIntro
+where THeader : IHeader
 where TContentComponent : IContentComponent
 {
-    public Title Title { get; }
+    public Header Header { get; }
 
     public List<TContentComponent> Content { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
@@ -1,12 +1,11 @@
 using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
-using Dfe.PlanTech.Domain.Questionnaire.Enums;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface IRecommendationIntro
 {
-    public Maturity Maturity { get; }
+    public string Maturity { get; }
 }
 
 public interface IRecommendationIntro<TTitle, TContentComponent> : IRecommendationIntro

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
@@ -1,0 +1,17 @@
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Questionnaire.Enums;
+
+namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+
+public interface IRecommendationIntro
+{
+    public string Title { get; }
+
+    public Maturity Maturity { get; }
+}
+
+public interface IRecommendationIntro<TContentComponent> : IRecommendationIntro
+where TContentComponent : IContentComponent
+{
+    public List<TContentComponent> Content { get; }
+}

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
@@ -1,17 +1,19 @@
 using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Enums;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface IRecommendationIntro
 {
-    public string Title { get; }
-
     public Maturity Maturity { get; }
 }
 
-public interface IRecommendationIntro<TContentComponent> : IRecommendationIntro
+public interface IRecommendationIntro<TTitle, TContentComponent> : IRecommendationIntro
+where TTitle : ITitle
 where TContentComponent : IContentComponent
 {
+    public Title Title { get; }
+
     public List<TContentComponent> Content { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
@@ -9,5 +9,5 @@ where TRecommendationChunk : IRecommendationChunk<Header, ContentComponent, Answ
 {
     public List<TAnswer> Answers { get; }
 
-    public List<TRecommendationChunk> RecommendationChunks { get; }
+    public List<TRecommendationChunk> Chunks { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
@@ -5,7 +5,7 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface IRecommendationSection<TAnswer, TRecommendationChunk>
 where TAnswer : IAnswer
-where TRecommendationChunk : IRecommendationChunk<Header, ContentComponent, Answer>
+where TRecommendationChunk : IRecommendationChunk<Title, Header, ContentComponent, Answer>
 {
     public List<TAnswer> Answers { get; }
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
@@ -3,7 +3,9 @@ using Dfe.PlanTech.Domain.Questionnaire.Models;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
-public interface IRecommendationSection<TAnswer, TRecommendationChunk>
+public interface IRecommendationSection { }
+
+public interface IRecommendationSection<TAnswer, TRecommendationChunk> : IRecommendationSection
 where TAnswer : IAnswer
 where TRecommendationChunk : IRecommendationChunk<Title, Header, ContentComponent, Answer>
 {

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
@@ -1,0 +1,13 @@
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+
+namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+
+public interface IRecommendationSection<TAnswer, TRecommendationChunk>
+where TAnswer : IAnswer
+where TRecommendationChunk : IRecommendationChunk<Header, ContentComponent, Answer>
+{
+    public List<TAnswer> Answers { get; }
+
+    public List<TRecommendationChunk> RecommendationChunks { get; }
+}

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
@@ -7,7 +7,7 @@ public interface IRecommendationSection { }
 
 public interface IRecommendationSection<TAnswer, TRecommendationChunk> : IRecommendationSection
 where TAnswer : IAnswer
-where TRecommendationChunk : IRecommendationChunk<Title, Header, ContentComponent, Answer>
+where TRecommendationChunk : IRecommendationChunk<Header, ContentComponent, Answer>
 {
     public List<TAnswer> Answers { get; }
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ISubTopicRecommendation.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ISubTopicRecommendation.cs
@@ -2,7 +2,9 @@ using Dfe.PlanTech.Domain.Questionnaire.Models;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
-public interface ISubTopicRecommendation<TRecommendationIntro, TRecommendationSection>
+public interface ISubTopicRecommendation { }
+
+public interface ISubTopicRecommendation<TRecommendationIntro, TRecommendationSection> : ISubTopicRecommendation
 where TRecommendationIntro : IRecommendationIntro
 where TRecommendationSection : IRecommendationSection<Answer, RecommendationChunk>
 {

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ISubTopicRecommendation.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ISubTopicRecommendation.cs
@@ -4,11 +4,14 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface ISubTopicRecommendation { }
 
-public interface ISubTopicRecommendation<TRecommendationIntro, TRecommendationSection> : ISubTopicRecommendation
+public interface ISubTopicRecommendation<TRecommendationIntro, TRecommendationSection, TSection> : ISubTopicRecommendation
 where TRecommendationIntro : IRecommendationIntro
 where TRecommendationSection : IRecommendationSection<Answer, RecommendationChunk>
+where TSection : ISection
 {
     public List<TRecommendationIntro> Intros { get; }
 
     public TRecommendationSection Section { get; }
+
+    public TSection Subtopic { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ISubTopicRecommendation.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ISubTopicRecommendation.cs
@@ -1,0 +1,12 @@
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+
+namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+
+public interface ISubTopicRecommendation<TRecommendationIntro, TRecommendationSection>
+where TRecommendationIntro : IRecommendationIntro
+where TRecommendationSection : IRecommendationSection<Answer, RecommendationChunk>
+{
+    public List<TRecommendationIntro> RecommendationIntros { get; }
+
+    public TRecommendationSection RecommendationSection { get; }
+}

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ISubTopicRecommendation.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ISubTopicRecommendation.cs
@@ -6,7 +6,7 @@ public interface ISubTopicRecommendation<TRecommendationIntro, TRecommendationSe
 where TRecommendationIntro : IRecommendationIntro
 where TRecommendationSection : IRecommendationSection<Answer, RecommendationChunk>
 {
-    public List<TRecommendationIntro> RecommendationIntros { get; }
+    public List<TRecommendationIntro> Intros { get; }
 
-    public TRecommendationSection RecommendationSection { get; }
+    public TRecommendationSection Section { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
@@ -1,0 +1,13 @@
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+
+namespace Dfe.PlanTech.Domain.Questionnaire.Models;
+
+public class RecommendationChunk : ContentComponent, IRecommendationChunk<Header, ContentComponent, Answer>
+{
+    public Header Header { get; init; } = null!;
+
+    public List<ContentComponent> Content { get; init; } = [];
+
+    public List<Answer> Answers { get; init; } = [];
+}

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
@@ -3,9 +3,9 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class RecommendationChunk : ContentComponent, IRecommendationChunk<Title, Header, ContentComponent, Answer>
+public class RecommendationChunk : ContentComponent, IRecommendationChunk<Header, ContentComponent, Answer>
 {
-    public Title Title { get; init; } = null!;
+    public string Title { get; init; } = null!;
 
     public Header Header { get; init; } = null!;
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
@@ -3,8 +3,10 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class RecommendationChunk : ContentComponent, IRecommendationChunk<Header, ContentComponent, Answer>
+public class RecommendationChunk : ContentComponent, IRecommendationChunk<Title, Header, ContentComponent, Answer>
 {
+    public Title Title { get; init; } = null!;
+
     public Header Header { get; init; } = null!;
 
     public List<ContentComponent> Content { get; init; } = [];

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
@@ -1,0 +1,14 @@
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Enums;
+using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+
+namespace Dfe.PlanTech.Domain.Questionnaire.Models;
+
+public class RecommendationIntro : ContentComponent, IRecommendationIntro<ContentComponent>
+{
+    public string Title { get; init; } = null!;
+
+    public Maturity Maturity { get; init; }
+
+    public List<ContentComponent> Content { get; init; } = [];
+}

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
@@ -4,9 +4,9 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class RecommendationIntro : ContentComponent, IRecommendationIntro<ContentComponent>
+public class RecommendationIntro : ContentComponent, IRecommendationIntro<Title, ContentComponent>
 {
-    public string Title { get; init; } = null!;
+    public Title Title { get; init; } = null!;
 
     public Maturity Maturity { get; init; }
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
@@ -4,9 +4,9 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class RecommendationIntro : ContentComponent, IRecommendationIntro<Title, ContentComponent>
+public class RecommendationIntro : ContentComponent, IRecommendationIntro<Header, ContentComponent>
 {
-    public Title Title { get; init; } = null!;
+    public Header Header { get; init; } = null!;
 
     public string Maturity { get; init; } = null!;
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
@@ -8,7 +8,7 @@ public class RecommendationIntro : ContentComponent, IRecommendationIntro<Title,
 {
     public Title Title { get; init; } = null!;
 
-    public Maturity Maturity { get; init; }
+    public string Maturity { get; init; } = null!;
 
     public List<ContentComponent> Content { get; init; } = [];
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationSection.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationSection.cs
@@ -1,0 +1,11 @@
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+
+namespace Dfe.PlanTech.Domain.Questionnaire.Models;
+
+public class RecommendationSection : ContentComponent, IRecommendationSection<Answer, RecommendationChunk>
+{
+    public List<Answer> Answers { get; init; } = [];
+
+    public List<RecommendationChunk> RecommendationChunks { get; init; } = [];
+}

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationSection.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationSection.cs
@@ -7,5 +7,5 @@ public class RecommendationSection : ContentComponent, IRecommendationSection<An
 {
     public List<Answer> Answers { get; init; } = [];
 
-    public List<RecommendationChunk> RecommendationChunks { get; init; } = [];
+    public List<RecommendationChunk> Chunks { get; init; } = [];
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/SubTopicRecommendation.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/SubTopicRecommendation.cs
@@ -3,9 +3,11 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class SubTopicRecommendation : ContentComponent, ISubTopicRecommendation<RecommendationIntro, RecommendationSection>
+public class SubTopicRecommendation : ContentComponent, ISubTopicRecommendation<RecommendationIntro, RecommendationSection, Section>
 {
     public List<RecommendationIntro> Intros { get; init; } = [];
 
     public RecommendationSection Section { get; init; } = null!;
+
+    public Section Subtopic { get; init; } = null!;
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/SubTopicRecommendation.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/SubTopicRecommendation.cs
@@ -1,0 +1,11 @@
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+
+namespace Dfe.PlanTech.Domain.Questionnaire.Models;
+
+public class SubTopicRecommendation : ContentComponent, ISubTopicRecommendation<RecommendationIntro, RecommendationSection>
+{
+    public List<RecommendationIntro> RecommendationIntros { get; init; } = [];
+
+    public RecommendationSection RecommendationSection { get; init; } = null!;
+}

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/SubTopicRecommendation.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/SubTopicRecommendation.cs
@@ -5,7 +5,7 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class SubTopicRecommendation : ContentComponent, ISubTopicRecommendation<RecommendationIntro, RecommendationSection>
 {
-    public List<RecommendationIntro> RecommendationIntros { get; init; } = [];
+    public List<RecommendationIntro> Intros { get; init; } = [];
 
-    public RecommendationSection RecommendationSection { get; init; } = null!;
+    public RecommendationSection Section { get; init; } = null!;
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/RecommendationComponentTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/RecommendationComponentTests.cs
@@ -1,0 +1,113 @@
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+
+namespace Dfe.PlanTech.Application.UnitTests.Questionnaire.Queries;
+
+// TODO: Temporary tests to satisfy requirements of SonarCloud
+// TODO: Remove once the recommendation components are tested as part of business logic tests!
+
+public class RecommendationComponentTests
+{
+    private readonly RecommendationChunk _recommendationChunk;
+    private readonly RecommendationSection _recommendationSection;
+    private readonly RecommendationIntro _recommendationIntro;
+    private readonly SubTopicRecommendation _subTopicRecommendation;
+
+    public RecommendationComponentTests()
+    {
+        Answer answer = new()
+        {
+            Text = "Answer Text",
+            NextQuestion = null,
+            Maturity = "High"
+        };
+
+        TextBody textBody = new()
+        {
+            RichText = new()
+            {
+                Value = "Text Body"
+            }
+        };
+
+        _recommendationChunk = new()
+        {
+            Title = new() { Text = "Title Text" },
+            Header = new() { Text = "Header Chunk Text" },
+            Content = [textBody],
+            Answers = [answer]
+        };
+
+        _recommendationSection = new()
+        {
+            Answers = [answer],
+            Chunks = [_recommendationChunk]
+        };
+
+        _recommendationIntro = new RecommendationIntro()
+        {
+            Header = new() { Text = "Header Intro Text" },
+            Maturity = "High",
+            Content = [textBody]
+        };
+
+        _subTopicRecommendation = new SubTopicRecommendation()
+        {
+            Intros = [_recommendationIntro],
+            Section = _recommendationSection
+        };
+    }
+
+    [Fact]
+    public void RecommendationChunk_Contains_Elements()
+    {
+        Assert.Equal("Title Text", _recommendationChunk.Title.Text);
+
+        Assert.Equal("Header Chunk Text", _recommendationChunk.Header.Text);
+
+        Assert.NotEmpty(_recommendationChunk.Content);
+        Assert.IsType<TextBody>(_recommendationChunk.Content[0]);
+        Assert.Equal("Text Body", (_recommendationChunk.Content[0] as TextBody)?.RichText.Value);
+
+        Assert.NotEmpty(_recommendationChunk.Answers);
+        Assert.IsType<Answer>(_recommendationChunk.Answers[0]);
+        Assert.Equal("Answer Text", _recommendationChunk.Answers[0].Text);
+        Assert.Null(_recommendationChunk.Answers[0].NextQuestion);
+        Assert.Equal("High", _recommendationChunk.Answers[0].Maturity);
+    }
+
+    [Fact]
+    public void RecommendationSection_Contains_Elements()
+    {
+        Assert.NotEmpty(_recommendationSection.Answers);
+        Assert.IsType<Answer>(_recommendationSection.Answers[0]);
+        Assert.Equal("Answer Text", _recommendationSection.Answers[0].Text);
+        Assert.Null(_recommendationSection.Answers[0].NextQuestion);
+        Assert.Equal("High", _recommendationSection.Answers[0].Maturity);
+
+        Assert.NotEmpty(_recommendationSection.Chunks);
+        Assert.IsType<RecommendationChunk>(_recommendationSection.Chunks[0]);
+        Assert.Equal(_recommendationChunk, _recommendationSection.Chunks[0]);
+    }
+
+    [Fact]
+    public void RecommendationIntro_Contains_Elements()
+    {
+        Assert.Equal("Header Intro Text", _recommendationIntro.Header.Text);
+
+        Assert.Equal("High", _recommendationIntro.Maturity);
+
+        Assert.NotEmpty(_recommendationIntro.Content);
+        Assert.IsType<TextBody>(_recommendationIntro.Content[0]);
+        Assert.Equal("Text Body", (_recommendationIntro.Content[0] as TextBody)?.RichText.Value);
+    }
+
+    [Fact]
+    public void SubTopicRecommendation_Contains_Elements()
+    {
+        Assert.NotEmpty(_subTopicRecommendation.Intros);
+        Assert.Equal(_recommendationIntro, _subTopicRecommendation.Intros[0]);
+
+        Assert.Equal(_recommendationSection, _subTopicRecommendation.Section);
+    }
+}

--- a/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/RecommendationComponentTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/RecommendationComponentTests.cs
@@ -30,9 +30,14 @@ public class RecommendationComponentTests
             }
         };
 
+        Section section = new()
+        {
+            Name = "Subtopic Name"
+        };
+
         _recommendationChunk = new()
         {
-            Title = new() { Text = "Title Text" },
+            Title = "Title Text",
             Header = new() { Text = "Header Chunk Text" },
             Content = [textBody],
             Answers = [answer]
@@ -54,14 +59,15 @@ public class RecommendationComponentTests
         _subTopicRecommendation = new SubTopicRecommendation()
         {
             Intros = [_recommendationIntro],
-            Section = _recommendationSection
+            Section = _recommendationSection,
+            Subtopic = section
         };
     }
 
     [Fact]
     public void RecommendationChunk_Contains_Elements()
     {
-        Assert.Equal("Title Text", _recommendationChunk.Title.Text);
+        Assert.Equal("Title Text", _recommendationChunk.Title);
 
         Assert.Equal("Header Chunk Text", _recommendationChunk.Header.Text);
 
@@ -109,5 +115,7 @@ public class RecommendationComponentTests
         Assert.Equal(_recommendationIntro, _subTopicRecommendation.Intros[0]);
 
         Assert.Equal(_recommendationSection, _subTopicRecommendation.Section);
+
+        Assert.Equal("Subtopic Name", _subTopicRecommendation.Subtopic.Name);
     }
 }


### PR DESCRIPTION
This PR creates the C# entities for mapping the new recommendation content from Contentful

Tickets:
- [196687](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_boards/board/t/Plan%20Tech/Stories/?workitem=196687)
- [196688](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_boards/board/t/Plan%20Tech/Stories/?workitem=196688)
- [196689](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_boards/board/t/Plan%20Tech/Stories/?workitem=196689)
- [196690](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_boards/board/t/Plan%20Tech/Stories/?workitem=196690)

**TODO**
- [x] - Make the C# entities
- [x] - Make the content models