### PR TITLE
:zap:: Update Category + Recommendation View Components

### DIFF
--- a/src/Dfe.PlanTech.Application/Submissions/Queries/GetSubmissionStatusesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Queries/GetSubmissionStatusesQuery.cs
@@ -19,7 +19,7 @@ public class GetSubmissionStatusesQuery : IGetSubmissionStatusesQuery
 
     }
 
-    public IList<SectionStatusDto> GetSectionSubmissionStatuses(IEnumerable<ISectionComponent> sections)
+    public List<SectionStatusDto> GetSectionSubmissionStatuses(IEnumerable<ISectionComponent> sections)
     {
         int establishmentId = _userHelper.GetEstablishmentId().Result;
 

--- a/src/Dfe.PlanTech.Application/Submissions/Queries/GetSubmissionStatusesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Queries/GetSubmissionStatusesQuery.cs
@@ -19,13 +19,13 @@ public class GetSubmissionStatusesQuery : IGetSubmissionStatusesQuery
 
     }
 
-    public List<SectionStatusDto> GetSectionSubmissionStatuses(IEnumerable<ISectionComponent> sections)
+    public Task<List<SectionStatusDto>> GetSectionSubmissionStatuses(IEnumerable<ISectionComponent> sections)
     {
         int establishmentId = _userHelper.GetEstablishmentId().Result;
 
         string sectionStringify = string.Join(',', sections.Select(x => x.Sys.Id));
 
-        return _db.GetSectionStatuses(sectionStringify, establishmentId).ToList();
+        return _db.ToListAsync(_db.GetSectionStatuses(sectionStringify, establishmentId));
     }
 
     public async Task<SectionStatusNew> GetSectionSubmissionStatusAsync(int establishmentId,

--- a/src/Dfe.PlanTech.Domain/Interfaces/IGetSubmissionStatusesQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Interfaces/IGetSubmissionStatusesQuery.cs
@@ -5,7 +5,7 @@ namespace Dfe.PlanTech.Domain.Interfaces;
 
 public interface IGetSubmissionStatusesQuery
 {
-    IList<SectionStatusDto> GetSectionSubmissionStatuses(IEnumerable<ISectionComponent> sections);
+    List<SectionStatusDto> GetSectionSubmissionStatuses(IEnumerable<ISectionComponent> sections);
 
     Task<SectionStatusNew> GetSectionSubmissionStatusAsync(int establishmentId,
                                                            ISectionComponent section,

--- a/src/Dfe.PlanTech.Domain/Interfaces/IGetSubmissionStatusesQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Interfaces/IGetSubmissionStatusesQuery.cs
@@ -5,7 +5,7 @@ namespace Dfe.PlanTech.Domain.Interfaces;
 
 public interface IGetSubmissionStatusesQuery
 {
-    List<SectionStatusDto> GetSectionSubmissionStatuses(IEnumerable<ISectionComponent> sections);
+    Task<List<SectionStatusDto>> GetSectionSubmissionStatuses(IEnumerable<ISectionComponent> sections);
 
     Task<SectionStatusNew> GetSectionSubmissionStatusAsync(int establishmentId,
                                                            ISectionComponent section,

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/Category.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/Category.cs
@@ -8,7 +8,7 @@ public class Category : ContentComponent, ICategoryComponent
 {
     public Header Header { get; set; } = null!;
     public List<Section> Sections { get; set; } = new();
-    public IList<SectionStatusDto> SectionStatuses { get; set; } = new List<SectionStatusDto>();
+    public IList<SectionStatusDto> SectionStatuses { get; set; } = [];
     public int Completed { get; set; }
     public bool RetrievalError { get; set; }
 }

--- a/src/Dfe.PlanTech.Web/TagHelpers/TaskList/TagColour.cs
+++ b/src/Dfe.PlanTech.Web/TagHelpers/TaskList/TagColour.cs
@@ -10,5 +10,8 @@ public static class TagColour
 
     private readonly static string[] _colours = [Blue, Grey, LightBlue, Red];
 
-    public static string GetMatchingColour(string? toMatch) => string.IsNullOrEmpty(toMatch) ? Default : _colours.FirstOrDefault(colour => colour == toMatch, Default);
+    public static string GetMatchingColour(string? toMatch)
+    => string.IsNullOrEmpty(toMatch) ?
+        Default :
+        _colours.FirstOrDefault(colour => string.Equals(colour, toMatch, StringComparison.InvariantCultureIgnoreCase), Default);
 }

--- a/src/Dfe.PlanTech.Web/TagHelpers/TaskList/TagColour.cs
+++ b/src/Dfe.PlanTech.Web/TagHelpers/TaskList/TagColour.cs
@@ -1,10 +1,14 @@
 namespace Dfe.PlanTech.Web.TagHelpers.TaskList;
 
-public enum TagColour
+public static class TagColour
 {
-    Default,
-    Blue,
-    Grey,
-    Red,
-    DarkBlue,
+    public readonly static string Default = "blue";
+    public readonly static string Blue = "blue";
+    public readonly static string Grey = "grey";
+    public readonly static string LightBlue = "light-blue";
+    public readonly static string Red = "red";
+
+    private readonly static string[] _colours = [Blue, Grey, LightBlue, Red];
+
+    public static string GetMatchingColour(string? toMatch) => string.IsNullOrEmpty(toMatch) ? Default : _colours.FirstOrDefault(colour => colour == toMatch, Default);
 }

--- a/src/Dfe.PlanTech.Web/TagHelpers/TaskList/TaskListTagTagHelper.cs
+++ b/src/Dfe.PlanTech.Web/TagHelpers/TaskList/TaskListTagTagHelper.cs
@@ -16,7 +16,7 @@ public class TaskListTagTagHelper : BaseTaskListTagHelper
         TagName = "strong";
     }
 
-    protected TagColour TagColour => Enum.TryParse(Colour, true, out TagColour colour) ? colour : TagColour.Default;
+    protected string TagClassColour => TagColour.GetMatchingColour(Colour);
 
     protected override string CreateClassesAttribute()
     {
@@ -40,13 +40,12 @@ public class TaskListTagTagHelper : BaseTaskListTagHelper
 
     private void AppendTagColour(StringBuilder stringBuilder)
     {
-        var tagColour = TagColour;
-        if (tagColour != TagColour.Default)
+        if (TagClassColour != TagColour.Default)
         {
             stringBuilder.Append(' ');
             stringBuilder.Append(_class);
             stringBuilder.Append("--");
-            stringBuilder.Append(tagColour.ToString().ToLower());
+            stringBuilder.Append(TagClassColour);
         }
     }
 

--- a/src/Dfe.PlanTech.Web/ViewComponents/CategorySectionViewComponent.cs
+++ b/src/Dfe.PlanTech.Web/ViewComponents/CategorySectionViewComponent.cs
@@ -7,26 +7,19 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.PlanTech.Web.ViewComponents;
 
-public class CategorySectionViewComponent : ViewComponent
+public class CategorySectionViewComponent(ILogger<CategorySectionViewComponent> logger, IGetSubmissionStatusesQuery query) : ViewComponent
 {
-    private readonly ILogger<CategorySectionViewComponent> _logger;
-    private readonly IGetSubmissionStatusesQuery _query;
+    private readonly ILogger<CategorySectionViewComponent> _logger = logger;
+    private readonly IGetSubmissionStatusesQuery _query = query;
 
-
-    public CategorySectionViewComponent(ILogger<CategorySectionViewComponent> logger, IGetSubmissionStatusesQuery query)
+    public async Task<IViewComponentResult> InvokeAsync(Category category)
     {
-        _logger = logger;
-        _query = query;
-    }
-
-    public IViewComponentResult Invoke(Category category)
-    {
-        var viewModel = GenerateViewModel(category);
+        var viewModel = await GenerateViewModel(category);
 
         return View(viewModel);
     }
 
-    private CategorySectionViewComponentViewModel GenerateViewModel(Category category)
+    private async Task<CategorySectionViewComponentViewModel> GenerateViewModel(Category category)
     {
         bool sectionsExist = category.Sections?.Count > 0;
 
@@ -40,7 +33,7 @@ public class CategorySectionViewComponent : ViewComponent
             };
         }
 
-        category = RetrieveSectionStatuses(category);
+        category = await RetrieveSectionStatuses(category);
 
         return new CategorySectionViewComponentViewModel()
         {
@@ -98,11 +91,11 @@ public class CategorySectionViewComponent : ViewComponent
         }
     }
 
-    public Category RetrieveSectionStatuses(Category category)
+    public async Task<Category> RetrieveSectionStatuses(Category category)
     {
         try
         {
-            category.SectionStatuses = _query.GetSectionSubmissionStatuses(category.Sections);
+            category.SectionStatuses = await _query.GetSectionSubmissionStatuses(category.Sections);
             category.Completed = category.SectionStatuses.Count(x => x.Completed == 1);
             category.RetrievalError = false;
             return category;

--- a/src/Dfe.PlanTech.Web/ViewComponents/CategorySectionViewComponent.cs
+++ b/src/Dfe.PlanTech.Web/ViewComponents/CategorySectionViewComponent.cs
@@ -70,7 +70,7 @@ public class CategorySectionViewComponent : ViewComponent
 
         if (sectionStatusCompleted != null)
         {
-            categorySectionDto.TagColour = sectionStatusCompleted == 1 ? TagColour.DarkBlue.ToString() : TagColour.Blue.ToString();
+            categorySectionDto.TagColour = sectionStatusCompleted == 1 ? TagColour.Blue : TagColour.LightBlue;
             categorySectionDto.TagText = sectionStatusCompleted == 1 ? "COMPLETE" : "IN PROGRESS";
         }
         else
@@ -102,7 +102,7 @@ public class CategorySectionViewComponent : ViewComponent
     {
         try
         {
-            category.SectionStatuses = _query.GetSectionSubmissionStatuses(category.Sections).ToList();
+            category.SectionStatuses = _query.GetSectionSubmissionStatuses(category.Sections);
             category.Completed = category.SectionStatuses.Count(x => x.Completed == 1);
             category.RetrievalError = false;
             return category;

--- a/src/Dfe.PlanTech.Web/ViewComponents/RecommendationsViewComponent.cs
+++ b/src/Dfe.PlanTech.Web/ViewComponents/RecommendationsViewComponent.cs
@@ -6,19 +6,13 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.PlanTech.Web.ViewComponents;
 
-public class RecommendationsViewComponent : ViewComponent
+public class RecommendationsViewComponent(ILogger<RecommendationsViewComponent> logger,
+    IGetSubmissionStatusesQuery query) : ViewComponent
 {
-    private readonly ILogger<RecommendationsViewComponent> _logger;
-    private readonly IGetSubmissionStatusesQuery _query;
+    private readonly ILogger<RecommendationsViewComponent> _logger = logger;
+    private readonly IGetSubmissionStatusesQuery _query = query;
 
-    public RecommendationsViewComponent(ILogger<RecommendationsViewComponent> logger,
-        IGetSubmissionStatusesQuery query)
-    {
-        _logger = logger;
-        _query = query;
-    }
-
-    public IViewComponentResult Invoke(IEnumerable<ICategoryComponent> categories)
+    public async Task<IViewComponentResult> InvokeAsync(IEnumerable<ICategoryComponent> categories)
     {
         var allSectionsOfCombinedCategories = new List<ISectionComponent>();
         var allSectionStatusesOfCombinedCategories = new List<SectionStatusDto>();
@@ -31,7 +25,7 @@ public class RecommendationsViewComponent : ViewComponent
                 recommendationsAvailable = true;
             }
 
-            var categoryElement = RetrieveSectionStatuses(category);
+            var categoryElement = await RetrieveSectionStatuses(category);
             allSectionsOfCombinedCategories.AddRange(categoryElement.Sections);
             allSectionStatusesOfCombinedCategories.AddRange(categoryElement.SectionStatuses);
         }
@@ -75,11 +69,11 @@ public class RecommendationsViewComponent : ViewComponent
         }
     }
 
-    public ICategoryComponent RetrieveSectionStatuses(ICategoryComponent category)
+    public async Task<ICategoryComponent> RetrieveSectionStatuses(ICategoryComponent category)
     {
         try
         {
-            category.SectionStatuses = _query.GetSectionSubmissionStatuses(category.Sections);
+            category.SectionStatuses = await _query.GetSectionSubmissionStatuses(category.Sections);
             category.Completed = category.SectionStatuses.Count(x => x.Completed == 1);
             category.RetrievalError = false;
 

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
@@ -111,15 +111,22 @@ public class GetSubmissionStatusesQueryTests
                 return queryable.FirstOrDefault();
             });
 
+        Db.ToListAsync(Arg.Any<IQueryable<SectionStatusDto>>(), Arg.Any<CancellationToken>()).Returns((callinfo) =>
+        {
+            var query = callinfo.ArgAt<IQueryable<SectionStatusDto>>(0);
+
+            return query.ToList();
+        });
+
         user.GetEstablishmentId().Returns(establishmentId);
     }
 
     [Fact]
-    public void GetSectionSubmissionStatuses_ReturnsListOfStatuses()
+    public async Task GetSectionSubmissionStatuses_ReturnsListOfStatuses()
     {
         var sections = new Section[2] { new() { Sys = new SystemDetails { Id = "1" } }, new() { Sys = new SystemDetails { Id = "3" } } };
 
-        var result = CreateStrut().GetSectionSubmissionStatuses(sections);
+        var result = await CreateStrut().GetSectionSubmissionStatuses(sections);
 
         Assert.Equal(result.Count, sections.Length);
 

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
@@ -15,12 +15,12 @@ public class GetSubmissionStatusesQueryTests
     private readonly IPlanTechDbContext Db = Substitute.For<IPlanTechDbContext>();
     private readonly IUser user = Substitute.For<IUser>();
 
-    private readonly List<SectionStatusDto> SectionStatuses = new() {
+    private readonly List<SectionStatusDto> SectionStatuses = [
             new SectionStatusDto { Completed = 1, SectionId = "1", Maturity = "Low", DateCreated = DateTime.UtcNow },
             new SectionStatusDto { Completed = 1, SectionId = "2", Maturity = "High", DateCreated = DateTime.UtcNow },
             new SectionStatusDto { Completed = 0, SectionId = "3", DateCreated = DateTime.UtcNow },
             new SectionStatusDto { Completed = 0, SectionId = "4",  DateCreated = DateTime.UtcNow },
-        };
+        ];
 
     private const int establishmentId = 1;
     private const string maturity = "High";

--- a/tests/Dfe.PlanTech.Web.UnitTests/TagHelpers/TaskListTagTagHelperTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/TagHelpers/TaskListTagTagHelperTests.cs
@@ -18,7 +18,7 @@ namespace Dfe.PlanTech.Web.UnitTests.TagHelpers
         [Fact]
         public void Should_Create_CorrectColour_When_ValidColour()
         {
-            var colour = "Grey";
+            var colour = "grey";
 
             var tagHelper = new TaskListTagTagHelper
             {
@@ -49,7 +49,7 @@ namespace Dfe.PlanTech.Web.UnitTests.TagHelpers
         [Fact]
         public void Should_Float_To_Right()
         {
-            var colour = "Grey";
+            var colour = "grey";
 
             var tagHelper = new TaskListTagTagHelper
             {
@@ -113,7 +113,7 @@ namespace Dfe.PlanTech.Web.UnitTests.TagHelpers
         {
             var tagHelper = new TaskListTagTagHelper
             {
-                Colour = "Grey"
+                Colour = "grey"
             };
 
             var context = new TagHelperContext(tagName: "task-list-tag",

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/RecommendationsViewComponentTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/RecommendationsViewComponentTests.cs
@@ -30,13 +30,13 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             _category = new Category()
             {
                 Completed = 1,
-                Sections = new()
-                {
+                Sections =
+                [
                     new()
                     {
                         Sys = new SystemDetails() { Id = "Section1" },
                         Name = "Test Section 1",
-                        Recommendations = new(){
+                        Recommendations = [
                             new RecommendationPage()
                             {
                                 InternalName = "High-Maturity-Recommendation-Page-InternalName",
@@ -44,24 +44,24 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                                 Maturity = Maturity.High,
                                 Page = new Page() { Slug = "High-Maturity-Recommendation-Page-Slug" }
                             }
-                        },
+                        ],
                         InterstitialPage = new Page
                         {
                             Slug = "test-slug"
                         }
                     }
-                }
+                ]
             };
 
             _categoryTwo = new Category()
             {
                 Completed = 1,
-                Sections = new(){
+                Sections = [
                     new()
                     {
                         Sys = new SystemDetails() { Id = "Section1" },
                         Name = "Test Section 1",
-                        Recommendations =new(){
+                        Recommendations = [
                             new()
                             {
                                 InternalName = "High-Maturity-Recommendation-Page-InternalName-Two",
@@ -69,18 +69,18 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                                 Maturity = Maturity.High,
                                 Page = new Page() { Slug = "High-Maturity-Recommendation-Page-Slug-Two" }
                             }
-                        },
+                        ],
                         InterstitialPage = new Page
                         {
                             Slug = "test-slug"
                         }
                     }
-                }
+                ]
             };
         }
 
         [Fact]
-        public void Returns_RecommendationInfo_If_It_Exists_ForMaturity()
+        public async Task Returns_RecommendationInfo_If_It_Exists_ForMaturity()
         {
             _category.SectionStatuses.Add(new Domain.Submissions.Models.SectionStatusDto()
             {
@@ -91,9 +91,9 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
 
             Category[] categories = new Category[] { _category };
 
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses);
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses.ToList());
 
-            var result = _recommendationsComponent.Invoke(categories) as ViewViewComponentResult;
+            var result = await _recommendationsComponent.InvokeAsync(categories) as ViewViewComponentResult;
 
             Assert.NotNull(result);
             Assert.NotNull(result.ViewData);
@@ -113,7 +113,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
         }
 
         [Fact]
-        public void Returns_RecommendationInfo_For_Multiple_Categories_If_It_Exists_ForMaturity()
+        public async Task Returns_RecommendationInfo_For_Multiple_Categories_If_It_Exists_ForMaturity()
         {
             _category.SectionStatuses.Add(new Domain.Submissions.Models.SectionStatusDto()
             {
@@ -128,11 +128,12 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                 Maturity = "High"
             });
 
-            Category[] categories = new Category[] { _category, _categoryTwo };
+            Category[] categories = [_category, _categoryTwo];
 
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses);
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_categoryTwo.Sections).Returns([.. _categoryTwo.SectionStatuses]);
 
-            var result = _recommendationsComponent.Invoke(categories) as ViewViewComponentResult;
+            var result = await _recommendationsComponent.InvokeAsync(categories) as ViewViewComponentResult;
 
             Assert.NotNull(result);
             Assert.NotNull(result.ViewData);
@@ -152,12 +153,10 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             Assert.Equal(_categoryTwo.Sections[0].Recommendations[0].DisplayName, unboxed.Skip(1).First().RecommendationDisplayName);
             Assert.Null(unboxed.First().NoRecommendationFoundErrorMessage);
             Assert.Null(unboxed.Skip(1).First().NoRecommendationFoundErrorMessage);
-
-
         }
 
         [Fact]
-        public void Returns_RecommendationInfo_And_Logs_Error_If_Exception_Thrown_By_Get_Category()
+        public async Task Returns_RecommendationInfo_And_Logs_Error_If_Exception_Thrown_By_Get_Category()
         {
             _category.SectionStatuses.Add(new Domain.Submissions.Models.SectionStatusDto()
             {
@@ -166,12 +165,11 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                 Maturity = "High"
             });
 
-            Category[] categories = new Category[] { _category };
-
+            Category[] categories = [_category];
 
             _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Throws(new Exception("test"));
 
-            var result = _recommendationsComponent.Invoke(categories) as ViewViewComponentResult;
+            var result = await _recommendationsComponent.InvokeAsync(categories) as ViewViewComponentResult;
 
             Assert.NotNull(result);
             Assert.NotNull(result.ViewData);
@@ -192,7 +190,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
         }
 
         [Fact]
-        public void Returns_NullRecommendationInfo_If_No_RecommendationPage_Exists_ForMaturity()
+        public async Task Returns_NullRecommendationInfo_If_No_RecommendationPage_Exists_ForMaturity()
         {
             _category.SectionStatuses.Add(new Domain.Submissions.Models.SectionStatusDto()
             {
@@ -203,9 +201,9 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
 
             Category[] categories = new Category[] { _category };
 
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses);
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses.ToList());
 
-            var result = _recommendationsComponent.Invoke(categories) as ViewViewComponentResult;
+            var result = await _recommendationsComponent.InvokeAsync(categories) as ViewViewComponentResult;
 
             Assert.NotNull(result);
             Assert.NotNull(result.ViewData);
@@ -225,7 +223,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
         }
 
         [Fact]
-        public void DoesNotReturn_RecommendationInfo_If_Section_IsNot_Completed()
+        public async Task DoesNotReturn_RecommendationInfo_If_Section_IsNot_Completed()
         {
             _category.Completed = 0;
             _category.SectionStatuses.Add(new Domain.Submissions.Models.SectionStatusDto()
@@ -235,11 +233,11 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                 Maturity = null
             });
 
-            Category[] categories = new Category[] { _category };
+            Category[] categories = [_category];
 
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses);
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses.ToList());
 
-            var result = _recommendationsComponent.Invoke(categories) as ViewViewComponentResult;
+            var result = await _recommendationsComponent.InvokeAsync(categories) as ViewViewComponentResult;
 
             Assert.NotNull(result);
             Assert.NotNull(result.ViewData);
@@ -249,13 +247,14 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
         }
 
         [Fact]
-        public void Returns_Null_If_Category_IsNot_Completed()
+        public async Task Returns_Null_If_Category_IsNot_Completed()
         {
             _category.Completed = 0;
 
-            Category[] categories = new Category[] { _category };
+            Category[] categories = [_category];
 
-            var result = _recommendationsComponent.Invoke(categories) as ViewViewComponentResult;
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
+            var result = await _recommendationsComponent.InvokeAsync(categories) as ViewViewComponentResult;
 
             Assert.NotNull(result);
             Assert.NotNull(result.ViewData);


### PR DESCRIPTION
 ### 💄Update tag colours to match GDS changes

- In [version 5](https://github.com/alphagov/govuk-design-system-backlog/issues/62#issuecomment-1888918535) of the GDS front-end packages, they have changed the tag colours. As a result, our "dark blue" tag no longer existed, so all of our tags were using the default colours.
- Changed tag colours to match changes.

### :zap: Improve Category + Recommendation view components

- Change return type to list; improves performance by not having to call `.ToList` on an object that is already a List
- Make async