### PR TITLE
fix: remove step-by-step navigation js from layout

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
@@ -52,13 +52,10 @@
 @section BodyEnd {
     <script src="~/js/app.js"></script>
     <script src="~/js/govuk-frontend.min.js" type="module"></script>
-    <script src="/js/step-by-step-navigation.js"></script>
-    <script src="/js/step-by-step-polyfills.js"></script>
+    
     <script type="module">
         import { initAll } from '/js/govuk-frontend.min.js';
 
         initAll();
-        var $element = document.querySelector('#step-by-step-navigation')
-        var stepByStepNavigation = new GOVUK.Modules.AppStepNav($element).init()
     </script>
 }


### PR DESCRIPTION
E2E tests appear to be failing due to the step-by-step navigation.

As the accordion has been removed, the script to initialise it was failing as it was unable to find the right elements.

When we have the recommendation page proper (or wherever the accordion might be used), we should add the JS back in to that page specifically.

```
    <script src="/js/step-by-step-navigation.js"></script>
    <script src="/js/step-by-step-polyfills.js"></script>
    <script type="module">
        var $element = document.querySelector('#step-by-step-navigation')
        var stepByStepNavigation = new GOVUK.Modules.AppStepNav($element).init()
</script>
```

As you can see the initialise script attempts to find the the relevant element by ID and then run some JS on it to initialise it. Given that the element doesn't exist the JS fails.

This error actually occurs locally in development; if you pull in the development branch and run it, check your dev tools; you will see the same error from the E2E tests occur.

I'm unsure of:
1. Why the E2E tests passed for the step-by-step navigation PR to begin with
2. Why the exceptions are being ignored locally, but not in the CI/CD. Assumingly there is some configuration difference we have but I haven't looked into that too much yet.

Regardless, the step-by-step navigation JS is bespoke to a specific page (currently), so it would be better to add it to the pages it is actually used on only, to reduce page sizes unless necessary.