### PR TITLE
chore: Add GovUK body class script in

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
@@ -31,14 +31,19 @@
         await Html.RenderPartialAsync("_Header");
     }
 
-@RenderSection("Header", false)
+    @RenderSection("Header", false)
 }
 
 @section BeforeContent {
     @{
         await Html.RenderPartialAsync("BetaHeader");
     }
-@RenderSection("BeforeContent", required: false)
+    @RenderSection("BeforeContent", required: false)
+
+    @{
+        //Add relevant tags for GovUK front-end CSS to body
+    }
+        <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
 }
 
 
@@ -52,7 +57,7 @@
 @section BodyEnd {
     <script src="~/js/app.js"></script>
     <script src="~/js/govuk-frontend.min.js" type="module"></script>
-    
+
     <script type="module">
         import { initAll } from '/js/govuk-frontend.min.js';
 


### PR DESCRIPTION
Removed this yesterday in an erroneous attempt to fix the E2E tests. It's necessary for the GOV UK front-end initialisation script though so I've added back in.