### PR TITLE
💚 Fix SQL script to clear DB

### DIFF
--- a/.github/scripts/clear-user-data-from-db.sql
+++ b/.github/scripts/clear-user-data-from-db.sql
@@ -1,26 +1,11 @@
 BEGIN TRANSACTION;
-GO;
 
   DELETE FROM [dbo].[response];
-  GO;
-
   DELETE FROM [dbo].[submission];
-  GO;
-
   DELETE FROM [dbo].[question];
-  GO;
-
   DELETE FROM [dbo].[answer];
-  GO;
-
   DELETE FROM [dbo].[signin];
-  GO;
-
   DELETE FROM [dbo].[user];
-  GO;
-
   DELETE FROM [dbo].[establishment];
-  GO;
 
 COMMIT;
-GO;

--- a/.github/workflows/clear-user-data-from-db.yml
+++ b/.github/workflows/clear-user-data-from-db.yml
@@ -1,27 +1,20 @@
 name: Clear user data from DB
+
 on:
   workflow_dispatch:
     inputs:
       environment:
         description: "What environment to clear"
         required: true
-        type: environment
-
-env:
-  DOTNET_VERSION: ${{ vars.DOTNET_VERSION }}
+        type: choice
+        options:
+          - development
+          - tst
+          - staging
 
 jobs:
-  disallow-prod-message:
-    if: inputs.environment == 'Production'
-    name: Disallow production message
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Disallow production message
-        run: echo "This action is not allowed in production"
-
   clear-db:
-    if: inputs.environment != 'Production'
+    if: ${{ inputs.environment != 'Production' }}
     environment: ${{ inputs.environment }}
     name: Clear user data from DB
     runs-on: ubuntu-latest
@@ -35,6 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Log Environment
+        run: |
+          echo "Environment: ${{ inputs.environment }}"
 
       - name: Login with AZ
         uses: ./.github/actions/azure-login
@@ -65,7 +62,7 @@ jobs:
           az_keyvault_name: ${{ env.az_keyvault_name }}
           az_keyvault_database_connectionstring_name: ${{ env.az_keyvault_database_connectionstring_name }}
 
-      - name: Execute stored procedure
+      - name: Run clear DB SQL script
         uses: azure/sql-action@v2.2
         with:
           connection-string: ${{ steps.get-connection-string.outputs.connection_string }}


### PR DESCRIPTION
- For some reason the 'Go' commands weren't working from the workflow (although worked directly on DB). Removed.
- Tweaked CI/CD pipeline a bit to ensure safety

Should now also be able to run it from `Actions` tab as the workflow should show there.

Can also run manually using the GitHub CLI. E.g.

`gh workflow run 'Clear user data from DB' --ref development -f environment=development`