### PR TITLE
:ambulance:(198819): Saving pages from Contentful -> DB

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -80,7 +80,7 @@ public class QueueReceiver : BaseFunction
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex.Message);
+            Logger.LogError(ex, "Error processing message ID {message}", message.MessageId);
             await messageActions.DeadLetterMessageAsync(message, null, ex.Message, ex.StackTrace, cancellationToken);
         }
     }
@@ -177,7 +177,7 @@ public class QueueReceiver : BaseFunction
         }
         else
         {
-            Logger.LogInformation($"Updated {rowsChangedInDatabase} rows in the database");
+            Logger.LogInformation("Updated {rowsChangedInDatabase} rows in the database", rowsChangedInDatabase);
         }
     }
 }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/AnswerMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/AnswerMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class AnswerMapper : JsonToDbMapper<AnswerDbEntity>
+public class AnswerMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<JsonToDbMapper<AnswerDbEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<AnswerDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public AnswerMapper(ILogger<JsonToDbMapper<AnswerDbEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         values = MoveValueToNewKey(values, "nextQuestion", "nextQuestionId");

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonDbMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonDbMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class ButtonDbMapper : JsonToDbMapper<ButtonDbEntity>
+public class ButtonDbMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<ButtonDbMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<ButtonDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public ButtonDbMapper(ILogger<ButtonDbMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         return values;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonWithEntryReferenceMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonWithEntryReferenceMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class ButtonWithEntryReferenceMapper : JsonToDbMapper<ButtonWithEntryReferenceDbEntity>
+public class ButtonWithEntryReferenceMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<ButtonWithEntryReferenceMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<ButtonWithEntryReferenceDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public ButtonWithEntryReferenceMapper(ILogger<ButtonWithEntryReferenceMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         values = MoveValueToNewKey(values, "button", "buttonId");

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonWithLinkMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/ButtonWithLinkMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class ButtonWithLinkMapper : JsonToDbMapper<ButtonWithLinkDbEntity>
+public class ButtonWithLinkMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<ButtonWithLinkMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<ButtonWithLinkDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public ButtonWithLinkMapper(ILogger<ButtonWithLinkMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         values = MoveValueToNewKey(values, "button", "buttonId");

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/CategoryMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/CategoryMapper.cs
@@ -5,14 +5,9 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class CategoryMapper : JsonToDbMapper<CategoryDbEntity>
+public class CategoryMapper(EntityRetriever retriever, EntityUpdater updater, CmsDbContext db, ILogger<CategoryMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<CategoryDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    private readonly CmsDbContext _db;
-
-    public CategoryMapper(CmsDbContext db, ILogger<CategoryMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-        _db = db;
-    }
+    private readonly CmsDbContext _db = db;
 
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/ComponentDropDownMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/ComponentDropDownMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class ComponentDropDownMapper : JsonToDbMapper<ComponentDropDownDbEntity>
+public class ComponentDropDownMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<JsonToDbMapper<ComponentDropDownDbEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<ComponentDropDownDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public ComponentDropDownMapper(ILogger<JsonToDbMapper<ComponentDropDownDbEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         return values;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityRetriever.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityRetriever.cs
@@ -1,0 +1,40 @@
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Dfe.PlanTech.AzureFunctions.Mappings;
+
+public class EntityRetriever(CmsDbContext db)
+{
+  public readonly CmsDbContext Db = db;
+
+  /// <summary>
+  /// Gets the existing entity (if existing) from the database that matches the mapped entity
+  /// </summary>
+  /// <param name="entity"></param>
+  /// <param name="cancellationToken"></param>
+  /// <returns></returns>
+  /// <exception cref="KeyNotFoundException">Exception thrown when we do not have a matching DbSet in our DbContext for the entity type</exception>
+  public virtual Task<ContentComponentDbEntity?> GetExistingDbEntity(ContentComponentDbEntity entity, CancellationToken cancellationToken)
+  {
+    var model = Db.Model.FindEntityType(entity.GetType()) ?? throw new KeyNotFoundException($"Could not find model in database for {entity.GetType()}");
+
+    var dbSet = GetIQueryableForEntity(model);
+
+    return dbSet.IgnoreAutoIncludes()
+                .IgnoreQueryFilters()
+                .FirstOrDefaultAsync(existing => existing.Id == entity.Id, cancellationToken);
+  }
+
+  /// <summary>
+  /// Uses reflection to get the DbSet, as an IQueryable, for the provided entity 
+  /// </summary>
+  /// <param name="model">Entity type for the entity we have received</param>
+  /// <returns></returns>
+  private IQueryable<ContentComponentDbEntity> GetIQueryableForEntity(IEntityType model)
+  => (IQueryable<ContentComponentDbEntity>)Db.GetType()
+                                            .GetMethod("Set", 1, Type.EmptyTypes)!
+                                            .MakeGenericMethod(model!.ClrType)!
+                                            .Invoke(Db, null)!;
+}

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
@@ -13,9 +13,9 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
 {
   private readonly Type _dontCopyValueAttribute = typeof(DontCopyValueAttribute);
   private readonly ILogger<EntityUpdater> _logger = logger;
-  private readonly CmsDbContext _db = db;
-
   private MappedEntity? _mappedEntity;
+
+  protected readonly CmsDbContext Db = db;
 
   public MappedEntity UpdateEntity(ContentComponentDbEntity incoming, ContentComponentDbEntity? existing, CmsEvent cmsEvent)
   {
@@ -35,7 +35,7 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
 
     UpdateEntityStatusByEvent(cmsEvent);
 
-    mappedEntity.IsValidComponent(_db, _dontCopyValueAttribute, _logger);
+    mappedEntity.IsValidComponent(Db, _dontCopyValueAttribute, _logger);
 
     mappedEntity = UpdateEntityConcrete(mappedEntity);
 

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
@@ -17,6 +17,13 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
 
   protected readonly CmsDbContext Db = db;
 
+  /// <summary>
+  /// Updates properties on the existing component (if any) based on the incoming component and the CmsEvent
+  /// </summary>
+  /// <param name="incoming"></param>
+  /// <param name="existing"></param>
+  /// <param name="cmsEvent"></param>
+  /// <returns></returns>
   public MappedEntity UpdateEntity(ContentComponentDbEntity incoming, ContentComponentDbEntity? existing, CmsEvent cmsEvent)
   {
     var mappedEntity = new MappedEntity()
@@ -42,6 +49,11 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
     return mappedEntity;
   }
 
+  /// <summary>
+  /// Overridable method to allow bespoke updating by entity type if needed
+  /// </summary>
+  /// <param name="entity"></param>
+  /// <returns></returns>
   public virtual MappedEntity UpdateEntityConcrete(MappedEntity entity)
   {
     return entity;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
@@ -1,0 +1,134 @@
+using System.Reflection;
+using Dfe.PlanTech.AzureFunctions.Models;
+using Dfe.PlanTech.Domain;
+using Dfe.PlanTech.Domain.Caching.Enums;
+using Dfe.PlanTech.Domain.Caching.Exceptions;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.AzureFunctions.Mappings;
+
+public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
+{
+  private readonly Type _dontCopyValueAttribute = typeof(DontCopyValueAttribute);
+  private readonly ILogger<EntityUpdater> _logger = logger;
+  private readonly CmsDbContext _db = db;
+
+  private MappedEntity? _mappedEntity;
+
+  public MappedEntity UpdateEntity(ContentComponentDbEntity incoming, ContentComponentDbEntity? existing, CmsEvent cmsEvent)
+  {
+    var mappedEntity = new MappedEntity()
+    {
+      IncomingEntity = incoming,
+      ExistingEntity = existing
+    };
+
+    _mappedEntity = mappedEntity;
+
+    if (mappedEntity.AlreadyExistsInDatabase)
+    {
+      CopyEntityStatus();
+      UpdateProperties(incoming, existing!);
+    }
+
+    UpdateEntityStatusByEvent(cmsEvent);
+
+    mappedEntity.IsValidComponent(_db, _dontCopyValueAttribute, _logger);
+
+    return mappedEntity;
+  }
+
+  public virtual MappedEntity UpdateEntityConcrete(MappedEntity entity)
+  {
+    return entity;
+  }
+
+  private void CopyEntityStatus()
+  {
+    _mappedEntity!.IncomingEntity.Archived = _mappedEntity.ExistingEntity!.Archived;
+    _mappedEntity!.IncomingEntity.Published = _mappedEntity.ExistingEntity!.Published;
+    _mappedEntity!.IncomingEntity.Deleted = _mappedEntity.ExistingEntity!.Deleted;
+  }
+
+  /// <summary>
+  /// Updates the status of an entity based on the provided CMS event and entity information.
+  /// </summary>
+  /// <param name="cmsEvent"></param>
+  /// <param name="mapped"></param>
+  /// <param name="existing"></param>
+  /// <exception cref="CmsEventException"></exception>
+  public void UpdateEntityStatusByEvent(CmsEvent cmsEvent)
+  {
+    if (_mappedEntity == null) throw new NullReferenceException($"{nameof(_mappedEntity)} is null");
+    switch (cmsEvent)
+    {
+      case CmsEvent.SAVE:
+      case CmsEvent.AUTO_SAVE:
+        break;
+      case CmsEvent.ARCHIVE:
+        _mappedEntity.IncomingEntity.Archived = true;
+        break;
+      case CmsEvent.UNARCHIVE:
+        _mappedEntity.IncomingEntity.Archived = false;
+        break;
+      case CmsEvent.PUBLISH:
+        _mappedEntity.IncomingEntity.Published = true;
+        break;
+      case CmsEvent.UNPUBLISH:
+        if (_mappedEntity.ExistingEntity == null)
+        {
+          throw new CmsEventException(string.Format("Content with Id \"{0}\" has event 'unpublish' despite not existing in the database!", _mappedEntity.IncomingEntity.Id));
+        }
+        _mappedEntity.ExistingEntity.Published = false;
+        break;
+      case CmsEvent.DELETE:
+        if (_mappedEntity.ExistingEntity == null)
+        {
+          throw new CmsEventException(string.Format("Content with Id \"{0}\" has event 'unpublish' despite not existing in the database!", _mappedEntity.IncomingEntity.Id));
+        }
+        _mappedEntity.ExistingEntity.Deleted = true;
+        break;
+    }
+  }
+
+  private void UpdateProperties(ContentComponentDbEntity incoming, ContentComponentDbEntity existing)
+  {
+    foreach (var property in PropertiesToCopy(incoming))
+    {
+      var newValue = property.GetValue(incoming);
+      var currentValue = property.GetValue(existing);
+
+      //Don't update existing properties if they haven't changed,
+      //to minimise unnecessary update calls to DB
+      if (newValue?.Equals(currentValue) == true)
+      {
+        continue;
+      }
+      property.SetValue(existing, property.GetValue(incoming));
+    }
+  }
+
+  /// <summary>
+  /// Get properties to copy for the selected entity
+  /// </summary>
+  /// <remarks>
+  /// Returns all properties, except properties ending with "Id" (i.e. relationship fields), and properties that have
+  /// a <see cref="DontCopyValueAttribute"/> attribute.
+  /// </remarks>
+  /// <param name="entity">Entity to get copyable properties for</param>
+  /// <returns></returns>
+  private IEnumerable<PropertyInfo> PropertiesToCopy(ContentComponentDbEntity entity)
+  => entity.GetType()
+          .GetProperties()
+          .Where(property => !HasDontCopyValueAttribute(property));
+
+  /// <summary>
+  /// Does the property have a <see cref="DontCopyValueAttribute"/> property attached to it? 
+  /// </summary>
+  /// <param name="property"></param>
+  /// <returns></returns>
+  private bool HasDontCopyValueAttribute(PropertyInfo property)
+   => property.CustomAttributes.Any(attribute => attribute.AttributeType == _dontCopyValueAttribute);
+}

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
@@ -37,6 +37,8 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
 
     mappedEntity.IsValidComponent(_db, _dontCopyValueAttribute, _logger);
 
+    mappedEntity = UpdateEntityConcrete(mappedEntity);
+
     return mappedEntity;
   }
 

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
@@ -63,7 +63,8 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
   /// <exception cref="CmsEventException"></exception>
   public void UpdateEntityStatusByEvent(CmsEvent cmsEvent)
   {
-    if (_mappedEntity == null) throw new NullReferenceException($"{nameof(_mappedEntity)} is null");
+    if (_mappedEntity == null) throw new InvalidDataException($"{nameof(_mappedEntity)} is null");
+
     switch (cmsEvent)
     {
       case CmsEvent.SAVE:

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
@@ -73,6 +73,11 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
         _mappedEntity.IncomingEntity.Archived = true;
         break;
       case CmsEvent.UNARCHIVE:
+        if (_mappedEntity.ExistingEntity == null)
+        {
+          throw new CmsEventException(string.Format("Content with Id \"{0}\" has event 'unarchive' despite not existing in the database!", _mappedEntity.IncomingEntity.Id));
+        }
+
         _mappedEntity.IncomingEntity.Archived = false;
         break;
       case CmsEvent.PUBLISH:
@@ -88,7 +93,7 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
       case CmsEvent.DELETE:
         if (_mappedEntity.ExistingEntity == null)
         {
-          throw new CmsEventException(string.Format("Content with Id \"{0}\" has event 'unpublish' despite not existing in the database!", _mappedEntity.IncomingEntity.Id));
+          throw new CmsEventException(string.Format("Content with Id \"{0}\" has event 'delete' despite not existing in the database!", _mappedEntity.IncomingEntity.Id));
         }
         _mappedEntity.ExistingEntity.Deleted = true;
         break;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/HeaderMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/HeaderMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class HeaderMapper : JsonToDbMapper<HeaderDbEntity>
+public class HeaderMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<JsonToDbMapper<HeaderDbEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<HeaderDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public HeaderMapper(ILogger<JsonToDbMapper<HeaderDbEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         return values;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/InsetTextMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/InsetTextMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class InsetTextMapper : JsonToDbMapper<InsetTextDbEntity>
+public class InsetTextMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<InsetTextMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<InsetTextDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public InsetTextMapper(ILogger<InsetTextMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         return values;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
@@ -1,6 +1,10 @@
+using Dfe.PlanTech.AzureFunctions.Models;
+using Dfe.PlanTech.Domain.Caching.Enums;
 using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -16,9 +20,11 @@ where TEntity : ContentComponentDbEntity, new()
 {
     protected readonly TEntity MappedEntity = new();
     protected CmsWebHookPayload? Payload;
+    protected EntityUpdater _entityUpdater;
 
-    protected JsonToDbMapper(ILogger<JsonToDbMapper<TEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : base(typeof(TEntity), logger, jsonSerialiserOptions)
+    protected JsonToDbMapper(EntityRetriever entityRetriever, EntityUpdater entityUpdater, ILogger<JsonToDbMapper<TEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : base(entityRetriever, typeof(TEntity), logger, jsonSerialiserOptions)
     {
+        _entityUpdater = entityUpdater;
     }
 
     public virtual TEntity ToEntity(CmsWebHookPayload payload)
@@ -38,7 +44,14 @@ where TEntity : ContentComponentDbEntity, new()
         return serialised;
     }
 
-    public override ContentComponentDbEntity MapEntity(CmsWebHookPayload payload) => ToEntity(payload);
+    public override async Task<MappedEntity> MapEntity(CmsWebHookPayload payload, CmsEvent cmsEvent, CancellationToken cancellationToken)
+    {
+        var incomingEntity = ToEntity(payload);
+
+        var existingEntity = await EntityRetriever.GetExistingDbEntity(incomingEntity, cancellationToken);
+
+        return _entityUpdater.UpdateEntity(incomingEntity, existingEntity, cmsEvent);
+    }
 
     public abstract Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values);
 
@@ -82,13 +95,14 @@ where TEntity : ContentComponentDbEntity, new()
 
 public abstract class JsonToDbMapper
 {
+    protected readonly EntityRetriever EntityRetriever;
     protected readonly ILogger Logger;
     protected readonly JsonSerializerOptions JsonOptions;
-
     private readonly Type _entityType;
 
-    protected JsonToDbMapper(Type entityType, ILogger logger, JsonSerializerOptions jsonSerialiserOptions)
+    protected JsonToDbMapper(EntityRetriever entityRetriever, Type entityType, ILogger logger, JsonSerializerOptions jsonSerialiserOptions)
     {
+        EntityRetriever = entityRetriever;
         _entityType = entityType;
         Logger = logger;
         JsonOptions = jsonSerialiserOptions;
@@ -97,7 +111,7 @@ public abstract class JsonToDbMapper
     public virtual bool AcceptsContentType(string contentType)
       => _entityType.Name.Equals($"{contentType}DbEntity", StringComparison.InvariantCultureIgnoreCase);
 
-    public abstract ContentComponentDbEntity MapEntity(CmsWebHookPayload payload);
+    public abstract Task<MappedEntity> MapEntity(CmsWebHookPayload payload, CmsEvent cmsEvent, CancellationToken cancellationToken);
 
     protected Dictionary<string, object?> GetEntityValuesDictionary(CmsWebHookPayload payload)
     => GetEntityValues(payload).Where(kvp => kvp.HasValue)
@@ -224,4 +238,11 @@ public abstract class JsonToDbMapper
 
         return values;
     }
+
+    public virtual Task<ContentComponentDbEntity?> RetrieveEntityFromDatabase(ContentComponentDbEntity incomingEntity, CancellationToken cancellationToken)
+    {
+        return EntityRetriever.GetExistingDbEntity(incomingEntity, cancellationToken);
+    }
+
+
 }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToDbMapper.cs
@@ -15,17 +15,12 @@ namespace Dfe.PlanTech.AzureFunctions.Mappings;
 /// Maps a JSON payload to the given entity type
 /// </summary>
 /// <typeparam name="TEntity"></typeparam>
-public abstract class JsonToDbMapper<TEntity> : JsonToDbMapper
+public abstract class JsonToDbMapper<TEntity>(EntityRetriever entityRetriever, EntityUpdater entityUpdater, ILogger<JsonToDbMapper<TEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper(entityRetriever, typeof(TEntity), logger, jsonSerialiserOptions)
 where TEntity : ContentComponentDbEntity, new()
 {
     protected readonly TEntity MappedEntity = new();
     protected CmsWebHookPayload? Payload;
-    protected EntityUpdater _entityUpdater;
-
-    protected JsonToDbMapper(EntityRetriever entityRetriever, EntityUpdater entityUpdater, ILogger<JsonToDbMapper<TEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : base(entityRetriever, typeof(TEntity), logger, jsonSerialiserOptions)
-    {
-        _entityUpdater = entityUpdater;
-    }
+    protected EntityUpdater _entityUpdater = entityUpdater;
 
     public virtual TEntity ToEntity(CmsWebHookPayload payload)
     {

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToEntityMappers.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToEntityMappers.cs
@@ -1,3 +1,5 @@
+using Dfe.PlanTech.AzureFunctions.Models;
+using Dfe.PlanTech.Domain.Caching.Enums;
 using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Content.Models;
 using System.Text.Json;
@@ -8,6 +10,7 @@ public class JsonToEntityMappers
 {
     private readonly JsonSerializerOptions _jsonSerialiserOptions;
     private readonly HashSet<JsonToDbMapper> _mappers;
+    private JsonToDbMapper? _mapper;
 
     public JsonToEntityMappers(IEnumerable<JsonToDbMapper> mappers, JsonSerializerOptions jsonSerialiserOptions)
     {
@@ -15,13 +18,13 @@ public class JsonToEntityMappers
         _mappers = mappers.ToHashSet();
     }
 
-    public ContentComponentDbEntity ToEntity(string requestBody)
+    public Task<MappedEntity> ToEntity(string requestBody, CmsEvent cmsEvent, CancellationToken cancellationToken)
     {
         var payload = SerialiseToPayload(requestBody);
 
         JsonToDbMapper mapper = GetMapperForPayload(payload);
 
-        return mapper.MapEntity(payload);
+        return mapper.MapEntity(payload, cmsEvent, cancellationToken);
     }
 
     private JsonToDbMapper GetMapperForPayload(CmsWebHookPayload payload)

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToEntityMappers.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToEntityMappers.cs
@@ -1,7 +1,6 @@
 using Dfe.PlanTech.AzureFunctions.Models;
 using Dfe.PlanTech.Domain.Caching.Enums;
 using Dfe.PlanTech.Domain.Caching.Models;
-using Dfe.PlanTech.Domain.Content.Models;
 using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToEntityMappers.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/JsonToEntityMappers.cs
@@ -6,17 +6,10 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class JsonToEntityMappers
+public class JsonToEntityMappers(IEnumerable<JsonToDbMapper> mappers, JsonSerializerOptions jsonSerialiserOptions)
 {
-    private readonly JsonSerializerOptions _jsonSerialiserOptions;
-    private readonly HashSet<JsonToDbMapper> _mappers;
-    private JsonToDbMapper? _mapper;
-
-    public JsonToEntityMappers(IEnumerable<JsonToDbMapper> mappers, JsonSerializerOptions jsonSerialiserOptions)
-    {
-        _jsonSerialiserOptions = jsonSerialiserOptions;
-        _mappers = mappers.ToHashSet();
-    }
+    private readonly JsonSerializerOptions _jsonSerialiserOptions = jsonSerialiserOptions;
+    private readonly HashSet<JsonToDbMapper> _mappers = mappers.ToHashSet();
 
     public Task<MappedEntity> ToEntity(string requestBody, CmsEvent cmsEvent, CancellationToken cancellationToken)
     {

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/NavigationLinkMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/NavigationLinkMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class NavigationLinkMapper : JsonToDbMapper<NavigationLinkDbEntity>
+public class NavigationLinkMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<NavigationLinkMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<NavigationLinkDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public NavigationLinkMapper(ILogger<NavigationLinkMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         return values;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityRetriever.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityRetriever.cs
@@ -1,0 +1,15 @@
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dfe.PlanTech.AzureFunctions.Mappings;
+
+public class PageEntityRetriever(CmsDbContext db) : EntityRetriever(db)
+{
+  public override async Task<ContentComponentDbEntity?> GetExistingDbEntity(ContentComponentDbEntity entity, CancellationToken cancellationToken)
+  {
+    var page = await Db.Pages.Include(page => page.AllPageContents).FirstOrDefaultAsync(page => page.Id == entity.Id, cancellationToken);
+
+    return page;
+  }
+}

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityRetriever.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityRetriever.cs
@@ -8,7 +8,17 @@ public class PageEntityRetriever(CmsDbContext db) : EntityRetriever(db)
 {
   public override async Task<ContentComponentDbEntity?> GetExistingDbEntity(ContentComponentDbEntity entity, CancellationToken cancellationToken)
   {
-    var page = await Db.Pages.Include(page => page.AllPageContents).FirstOrDefaultAsync(page => page.Id == entity.Id, cancellationToken);
+    var page = await Db.Pages.IgnoreQueryFilters()
+                            .Include(page => page.AllPageContents)
+                            .Include(page => page.BeforeTitleContent)
+                            .Include(page => page.Content)
+                            .Include(page => page.Title)
+                            .FirstOrDefaultAsync(page => page.Id == entity.Id, cancellationToken);
+
+    if (page == null)
+    {
+      return null;
+    }
 
     return page;
   }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
@@ -1,4 +1,5 @@
 using Dfe.PlanTech.AzureFunctions.Models;
+using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.Extensions.Logging;
 
@@ -8,7 +9,30 @@ public class PageEntityUpdater(ILogger<PageEntityUpdater> logger, CmsDbContext d
 {
   public override MappedEntity UpdateEntityConcrete(MappedEntity entity)
   {
+    if (!entity.AlreadyExistsInDatabase)
+    {
+      return entity;
+    }
 
+    if (entity.IncomingEntity is not PageDbEntity incomingPage || entity.ExistingEntity is not PageDbEntity existingPage)
+    {
+      throw new InvalidCastException($"Entities are not expected page types. Received {entity.IncomingEntity.GetType()} and {entity.ExistingEntity!.GetType()}");
+    }
+
+    var pageContentsJoined = incomingPage.AllPageContents.GroupJoin(existingPage.AllPageContents, KeySelector, KeySelector,
+    (pageContent, inner) =>
+    {
+      return new
+      {
+        pageContent,
+        existing = inner
+      };
+    });
   }
 
+  private static readonly Func<PageContentDbEntity, CompositeKey> KeySelector = pageContent => new CompositeKey(pageContent.BeforeContentComponentId, pageContent.ContentComponentId);
+}
+
+public record CompositeKey(string? BeforeContentComponentId, string? ContentComponentId)
+{
 }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
@@ -50,7 +50,7 @@ public class PageEntityUpdater(ILogger<PageEntityUpdater> logger, CmsDbContext d
         Db.PageContents.RemoveRange(matchingContents[1..]);
       }
 
-      var remainingMatchingContent = matchingContents.First();
+      var remainingMatchingContent = matchingContents[0];
       if (remainingMatchingContent.Order != pageContent.Order)
       {
         remainingMatchingContent.Order = pageContent.Order;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
@@ -1,0 +1,14 @@
+using Dfe.PlanTech.AzureFunctions.Models;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.AzureFunctions.Mappings;
+
+public class PageEntityUpdater(ILogger<PageEntityUpdater> logger, CmsDbContext db) : EntityUpdater(logger, db)
+{
+  public override MappedEntity UpdateEntityConcrete(MappedEntity entity)
+  {
+
+  }
+
+}

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageMapper.cs
@@ -10,12 +10,14 @@ public class PageMapper(PageEntityRetriever retriever, PageEntityUpdater updater
     private const string BeforeTitleContentKey = "beforeTitleContent";
     private const string ContentKey = "content";
 
-    public List<PageContentDbEntity> PageContents = [];
+    private readonly List<PageContentDbEntity> _pageContents = [];
+
+    public List<PageContentDbEntity> PageContents => _pageContents;
 
     public override PageDbEntity ToEntity(CmsWebHookPayload payload)
     {
         var mappedPage = base.ToEntity(payload);
-        mappedPage.AllPageContents = PageContents;
+        mappedPage.AllPageContents = _pageContents;
 
         return mappedPage;
     }
@@ -83,6 +85,6 @@ public class PageMapper(PageEntityRetriever retriever, PageEntityUpdater updater
             pageContent.ContentComponentId = contentId;
         }
 
-        PageContents.Add(pageContent);
+        _pageContents.Add(pageContent);
     }
 }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageMapper.cs
@@ -1,15 +1,24 @@
+using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Content.Models;
-using Dfe.PlanTech.Infrastructure.Data;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class PageMapper(EntityUpdater updater, PageEntityRetriever retriever, ILogger<PageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<PageDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
+public class PageMapper(PageEntityUpdater updater, PageEntityRetriever retriever, ILogger<PageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<PageDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
     private const string BeforeTitleContentKey = "beforeTitleContent";
     private const string ContentKey = "content";
+
+    public List<PageContentDbEntity> PageContents = [];
+
+    public override PageDbEntity ToEntity(CmsWebHookPayload payload)
+    {
+        var mappedPage = base.ToEntity(payload);
+        mappedPage.AllPageContents = PageContents;
+
+        return mappedPage;
+    }
 
     /// <summary>
     /// Create joins for content, and before title content, and map the title ID to the correct expected name.
@@ -73,5 +82,7 @@ public class PageMapper(EntityUpdater updater, PageEntityRetriever retriever, IL
         {
             pageContent.ContentComponentId = contentId;
         }
+
+        PageContents.Add(pageContent);
     }
 }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageMapper.cs
@@ -6,14 +6,10 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class PageMapper : JsonToDbMapper<PageDbEntity>
+public class PageMapper(EntityUpdater updater, PageEntityRetriever retriever, ILogger<PageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<PageDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
     private const string BeforeTitleContentKey = "beforeTitleContent";
     private const string ContentKey = "content";
-
-    public PageMapper(EntityUpdater updater, PageEntityRetriever retriever, ILogger<PageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(retriever, updater, logger, jsonSerialiserOptions)
-    {
-    }
 
     /// <summary>
     /// Create joins for content, and before title content, and map the title ID to the correct expected name.

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageMapper.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class PageMapper(PageEntityUpdater updater, PageEntityRetriever retriever, ILogger<PageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<PageDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
+public class PageMapper(PageEntityRetriever retriever, PageEntityUpdater updater, ILogger<PageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<PageDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
     private const string BeforeTitleContentKey = "beforeTitleContent";
     private const string ContentKey = "content";

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageMapper.cs
@@ -1,5 +1,6 @@
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
@@ -9,11 +10,9 @@ public class PageMapper : JsonToDbMapper<PageDbEntity>
 {
     private const string BeforeTitleContentKey = "beforeTitleContent";
     private const string ContentKey = "content";
-    private readonly CmsDbContext _db;
 
-    public PageMapper(CmsDbContext db, ILogger<PageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
+    public PageMapper(EntityUpdater updater, PageEntityRetriever retriever, ILogger<PageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(retriever, updater, logger, jsonSerialiserOptions)
     {
-        _db = db;
     }
 
     /// <summary>
@@ -78,7 +77,5 @@ public class PageMapper : JsonToDbMapper<PageDbEntity>
         {
             pageContent.ContentComponentId = contentId;
         }
-
-        _db.PageContents.Attach(pageContent);
     }
 }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/QuestionMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/QuestionMapper.cs
@@ -5,14 +5,9 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class QuestionMapper : JsonToDbMapper<QuestionDbEntity>
+public class QuestionMapper(EntityRetriever retriever, EntityUpdater updater, CmsDbContext db, ILogger<JsonToDbMapper<QuestionDbEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<QuestionDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    private readonly CmsDbContext _db;
-
-    public QuestionMapper(CmsDbContext db, ILogger<JsonToDbMapper<QuestionDbEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-        _db = db;
-    }
+    private readonly CmsDbContext _db = db;
 
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/RecommendationPageMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/RecommendationPageMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class RecommendationPageMapper : JsonToDbMapper<RecommendationPageDbEntity>
+public class RecommendationPageMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<RecommendationPageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<RecommendationPageDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public RecommendationPageMapper(ILogger<RecommendationPageMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         values = MoveValueToNewKey(values, "page", "pageId");

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/SectionMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/SectionMapper.cs
@@ -5,14 +5,9 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class SectionMapper : JsonToDbMapper<SectionDbEntity>
+public class SectionMapper(EntityRetriever retriever, EntityUpdater updater, CmsDbContext db, ILogger<SectionMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<SectionDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    private readonly CmsDbContext _db;
-
-    public SectionMapper(CmsDbContext db, ILogger<SectionMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-        _db = db;
-    }
+    private readonly CmsDbContext _db = db;
 
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/TextBodyMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/TextBodyMapper.cs
@@ -5,14 +5,9 @@ using System.Text.Json.Nodes;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class TextBodyMapper : JsonToDbMapper<TextBodyDbEntity>
+public class TextBodyMapper(EntityRetriever retriever, EntityUpdater updater, RichTextContentMapper richTextMapper, ILogger<TextBodyMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<TextBodyDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    private readonly RichTextContentMapper _richTextMapper;
-
-    public TextBodyMapper(RichTextContentMapper richTextMapper, ILogger<TextBodyMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-        _richTextMapper = richTextMapper;
-    }
+    private readonly RichTextContentMapper _richTextMapper = richTextMapper;
 
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/TitleMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/TitleMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class TitleMapper : JsonToDbMapper<TitleDbEntity>
+public class TitleMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<TitleMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<TitleDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public TitleMapper(ILogger<TitleMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         return values;

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/WarningComponentMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/WarningComponentMapper.cs
@@ -4,12 +4,8 @@ using System.Text.Json;
 
 namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
-public class WarningComponentMapper : JsonToDbMapper<WarningComponentDbEntity>
+public class WarningComponentMapper(EntityRetriever retriever, EntityUpdater updater, ILogger<WarningComponentMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<WarningComponentDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    public WarningComponentMapper(ILogger<WarningComponentMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : base(logger, jsonSerialiserOptions)
-    {
-    }
-
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
         values = MoveValueToNewKey(values, "text", "textId");

--- a/src/Dfe.PlanTech.AzureFunctions/Models/MappedEntity.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Models/MappedEntity.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.Extensions.Logging;
+
+namespace Dfe.PlanTech.AzureFunctions.Models;
+
+public class MappedEntity
+{
+  public required ContentComponentDbEntity IncomingEntity { get; init; }
+
+  public ContentComponentDbEntity? ExistingEntity { get; init; }
+
+  public bool IsValid { get; set; }
+
+  public bool AlreadyExistsInDatabase => ExistingEntity != null;
+
+  public bool IsValidComponent(CmsDbContext db, Type dontCopyAttribute, ILogger logger)
+  {
+    string? nullProperties = string.Join(", ", AnyRequiredPropertyIsNull(db, dontCopyAttribute));
+
+    IsValid = !string.IsNullOrEmpty(nullProperties);
+
+    if (!IsValid)
+    {
+      logger.LogInformation("Content Component with ID {id} is missing the following required properties: {nullProperties}", IncomingEntity.Id, nullProperties);
+    }
+
+    return IsValid;
+  }
+
+  private IEnumerable<PropertyInfo?> AnyRequiredPropertyIsNull(CmsDbContext db, Type dontCopyAttribute)
+      => db.Model.FindEntityType(IncomingEntity.GetType())!
+      .GetProperties()
+      .Where(prop => !prop.IsNullable)
+      .Select(prop => prop.PropertyInfo)
+      .Where(prop => !prop!.CustomAttributes.Any(atr => atr.GetType() == dontCopyAttribute))
+      .Where(prop => prop!.GetValue(IncomingEntity) == null);
+}

--- a/src/Dfe.PlanTech.AzureFunctions/Models/MappedEntity.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Models/MappedEntity.cs
@@ -19,7 +19,7 @@ public class MappedEntity
   {
     string? nullProperties = string.Join(", ", AnyRequiredPropertyIsNull(db, dontCopyAttribute));
 
-    IsValid = !string.IsNullOrEmpty(nullProperties);
+    IsValid = string.IsNullOrEmpty(nullProperties);
 
     if (!IsValid)
     {

--- a/src/Dfe.PlanTech.AzureFunctions/Startup.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Startup.cs
@@ -59,8 +59,12 @@ namespace Dfe.PlanTech.AzureFunctions
             }
 
             services.AddScoped<RichTextContentMapper>();
-
             services.AddScoped<JsonToEntityMappers>();
+
+            services.AddTransient<PageEntityUpdater>();
+            services.AddTransient<PageEntityRetriever>();
+            services.AddTransient<EntityRetriever>();
+            services.AddTransient<EntityUpdater>();
         }
 
         /// <summary>

--- a/src/Dfe.PlanTech.Domain/Content/Models/ContentComponentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/ContentComponentDbEntity.cs
@@ -2,7 +2,7 @@ using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Content.Models;
 
-public abstract class ContentComponentDbEntity : IContentComponentDbEntity
+public class ContentComponentDbEntity : IContentComponentDbEntity
 {
     public string Id { get; set; } = null!;
 

--- a/src/Dfe.PlanTech.Domain/Content/Models/PageContentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/PageContentDbEntity.cs
@@ -22,4 +22,11 @@ public class PageContentDbEntity
     /// What order the component should be in in its respective section (e.g. before/after)
     /// </summary>
     public int Order { get; set; }
+
+    public bool Matches(PageContentDbEntity other)
+    {
+        return other.PageId == PageId &&
+                other.ContentComponentId == ContentComponentId &&
+                other.BeforeContentComponentId == BeforeContentComponentId;
+    }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/PageDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/PageDbEntity.cs
@@ -20,21 +20,27 @@ public class PageDbEntity : ContentComponentDbEntity, IPage<ContentComponentDbEn
 
     public bool RequiresAuthorisation { get; set; } = true;
 
+    [DontCopyValue]
     public List<ContentComponentDbEntity> BeforeTitleContent { get; set; } = [];
 
+    [DontCopyValue]
     public TitleDbEntity? Title { get; set; }
 
     public string? TitleId { get; set; }
 
+    [DontCopyValue]
     public List<ContentComponentDbEntity> Content { get; set; } = [];
 
+    [DontCopyValue]
     public RecommendationPageDbEntity? RecommendationPage { get; set; }
 
+    [DontCopyValue]
     public SectionDbEntity? Section { get; set; }
 
     /// <summary>
     /// Combined joins for <see cref="Content"/> and <see cref="BeforeTitleContent"/> 
     /// </summary>
+    [DontCopyValue]
     public List<PageContentDbEntity> AllPageContents { get; set; } = [];
 
     public void OrderContents()

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -101,7 +101,7 @@ public class QueueReceiverTests
                         var answer = callinfo.ArgAt<AnswerDbEntity>(0);
                     });
 
-        _jsonToEntityMappers = Substitute.For<JsonToEntityMappers>(new JsonToDbMapper[] { new QuestionMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _cmsDbContextMock, Substitute.For<ILogger<QuestionMapper>>(), jsonOptions) }, jsonOptions);
+        _jsonToEntityMappers = Substitute.For<JsonToEntityMappers>(new JsonToDbMapper[] { new QuestionMapper(new EntityRetriever(_cmsDbContextMock), new EntityUpdater(Substitute.For<ILogger<EntityUpdater>>(), _cmsDbContextMock), _cmsDbContextMock, Substitute.For<ILogger<QuestionMapper>>(), jsonOptions) }, jsonOptions);
 
         _queueReceiver = new QueueReceiver(new ContentfulOptions(true), _loggerFactoryMock, _cmsDbContextMock, _jsonToEntityMappers);
 

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -101,7 +101,7 @@ public class QueueReceiverTests
                         var answer = callinfo.ArgAt<AnswerDbEntity>(0);
                     });
 
-        _jsonToEntityMappers = Substitute.For<JsonToEntityMappers>(new JsonToDbMapper[] { new QuestionMapper(_cmsDbContextMock, Substitute.For<ILogger<QuestionMapper>>(), jsonOptions) }, jsonOptions);
+        _jsonToEntityMappers = Substitute.For<JsonToEntityMappers>(new JsonToDbMapper[] { new QuestionMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _cmsDbContextMock, Substitute.For<ILogger<QuestionMapper>>(), jsonOptions) }, jsonOptions);
 
         _queueReceiver = new QueueReceiver(new ContentfulOptions(true), _loggerFactoryMock, _cmsDbContextMock, _jsonToEntityMappers);
 

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Helpers/MapperHelpers.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Helpers/MapperHelpers.cs
@@ -1,0 +1,16 @@
+using Dfe.PlanTech.AzureFunctions.Mappings;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dfe.PlanTech.AzureFunctions.UnitTests;
+
+public static class MapperHelpers
+{
+  private static readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
+  private static readonly ILogger<EntityUpdater> _logger = Substitute.For<ILogger<EntityUpdater>>();
+
+  public static EntityUpdater CreateMockEntityUpdater() => new(_logger, _db);
+
+  public static EntityRetriever CreateMockEntityRetriever() => new(_db);
+}

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/AnswerMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/AnswerMapperTests.cs
@@ -2,6 +2,7 @@ using Dfe.PlanTech.AzureFunctions.Mappings;
 using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Enums;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
@@ -16,10 +17,13 @@ public class AnswerMapperTests : BaseMapperTests
 
     private readonly AnswerMapper _mapper;
     private readonly ILogger<JsonToDbMapper<AnswerDbEntity>> _logger;
+    private readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
+    private readonly ILogger<EntityUpdater> _entityUpdaterLogger = Substitute.For<ILogger<EntityUpdater>>();
+
     public AnswerMapperTests()
     {
         _logger = Substitute.For<ILogger<JsonToDbMapper<AnswerDbEntity>>>();
-        _mapper = new AnswerMapper(_logger, JsonOptions);
+        _mapper = new AnswerMapper(new EntityRetriever(_db), new EntityUpdater(_entityUpdaterLogger, _db), _logger, JsonOptions);
     }
 
     [Fact]
@@ -34,11 +38,11 @@ public class AnswerMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, AnswerId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as AnswerDbEntity;
+        var concrete = mapped;
         Assert.NotNull(concrete);
 
         Assert.Equal(AnswerId, concrete.Id);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonMapperTests.cs
@@ -15,7 +15,7 @@ public class ButtonMapperTests : BaseMapperTests
     public ButtonMapperTests()
     {
         _logger = Substitute.For<ILogger<ButtonDbMapper>>();
-        _mapper = new ButtonDbMapper(_logger, JsonOptions);
+        _mapper = new ButtonDbMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _logger, JsonOptions);
     }
 
     [Theory]
@@ -33,11 +33,11 @@ public class ButtonMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, ButtonId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as ButtonDbEntity;
+        var concrete = mapped;
         Assert.NotNull(concrete);
 
         Assert.Equal(ButtonId, concrete.Id);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonWithEntryReferenceMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonWithEntryReferenceMapperTests.cs
@@ -30,7 +30,7 @@ public class ButtonWithEntryReferenceMapperTests : BaseMapperTests
     public ButtonWithEntryReferenceMapperTests()
     {
         _logger = Substitute.For<ILogger<ButtonWithEntryReferenceMapper>>();
-        _mapper = new ButtonWithEntryReferenceMapper(_logger, JsonOptions);
+        _mapper = new ButtonWithEntryReferenceMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _logger, JsonOptions);
     }
 
     [Fact]
@@ -44,11 +44,11 @@ public class ButtonWithEntryReferenceMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, ButtonWithEntryReferenceId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as ButtonWithEntryReferenceDbEntity;
+        var concrete = mapped;
         Assert.NotNull(concrete);
 
         Assert.Equal(ButtonWithEntryReferenceId, concrete.Id);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonWithLinkMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ButtonWithLinkMapperTests.cs
@@ -24,7 +24,7 @@ public class ButtonWithLinkMapperTests : BaseMapperTests
     public ButtonWithLinkMapperTests()
     {
         _logger = Substitute.For<ILogger<ButtonWithLinkMapper>>();
-        _mapper = new ButtonWithLinkMapper(_logger, JsonOptions);
+        _mapper = new ButtonWithLinkMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _logger, JsonOptions);
     }
 
     [Fact]
@@ -38,11 +38,11 @@ public class ButtonWithLinkMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, ButtonWithLinkId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as ButtonWithLinkDbEntity;
+        var concrete = mapped;
         Assert.NotNull(concrete);
 
         Assert.Equal(ButtonWithLinkId, concrete.Id);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/CategoryMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/CategoryMapperTests.cs
@@ -34,7 +34,7 @@ public class CategoryMapperTests : BaseMapperTests
     public CategoryMapperTests()
     {
         _logger = Substitute.For<ILogger<CategoryMapper>>();
-        _mapper = new CategoryMapper(_db, _logger, JsonOptions);
+        _mapper = new CategoryMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _db, _logger, JsonOptions);
 
         _db.Sections = _sectionsDbSet;
 
@@ -57,11 +57,11 @@ public class CategoryMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, CategoryId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as CategoryDbEntity;
+        var concrete = mapped;
         Assert.NotNull(concrete);
 
         Assert.Equal(CategoryId, concrete.Id);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ComponentDropDownMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/ComponentDropDownMapperTests.cs
@@ -7,20 +7,20 @@ namespace Dfe.PlanTech.AzureFunctions.UnitTests;
 
 public class ComponentDropDownMapperTests : BaseMapperTests
 {
-    private const string DropdownTitle = "Dropdown title test";
-    private const string DropdownId = "Dropdown Id";
-    private readonly RichTextContent DropdownContent = new()
+  private const string DropdownTitle = "Dropdown title test";
+  private const string DropdownId = "Dropdown Id";
+  private readonly RichTextContent DropdownContent = new()
+  {
+    Data = new RichTextData()
     {
-        Data = new RichTextData()
-        {
-            Uri = "Test URI"
-        },
-        Marks = new(){
+      Uri = "Test URI"
+    },
+    Marks = new(){
       new(){
         Type = "Bold"
       }
     },
-        Content = new(){
+    Content = new(){
       new(){
         Data = new(),
         Marks = new(),
@@ -40,37 +40,37 @@ public class ComponentDropDownMapperTests : BaseMapperTests
         }
       }
     },
-        NodeType = "document"
+    NodeType = "document"
+  };
+
+  private readonly ComponentDropDownMapper _mapper;
+  private readonly ILogger<JsonToDbMapper<ComponentDropDownDbEntity>> _logger;
+
+  public ComponentDropDownMapperTests()
+  {
+    _logger = Substitute.For<ILogger<JsonToDbMapper<ComponentDropDownDbEntity>>>();
+    _mapper = new ComponentDropDownMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _logger, JsonOptions);
+  }
+
+  [Fact]
+  public void Mapper_Should_Map_Relationship()
+  {
+    var fields = new Dictionary<string, object?>()
+    {
+      ["title"] = WrapWithLocalisation(DropdownTitle),
+      ["content"] = WrapWithLocalisation(DropdownContent),
     };
 
-    private readonly ComponentDropDownMapper _mapper;
-    private readonly ILogger<JsonToDbMapper<ComponentDropDownDbEntity>> _logger;
+    var payload = CreatePayload(fields, DropdownId);
 
-    public ComponentDropDownMapperTests()
-    {
-        _logger = Substitute.For<ILogger<JsonToDbMapper<ComponentDropDownDbEntity>>>();
-        _mapper = new ComponentDropDownMapper(_logger, JsonOptions);
-    }
+    var mapped = _mapper.ToEntity(payload);
 
-    [Fact]
-    public void Mapper_Should_Map_Relationship()
-    {
-        var fields = new Dictionary<string, object?>()
-        {
-            ["title"] = WrapWithLocalisation(DropdownTitle),
-            ["content"] = WrapWithLocalisation(DropdownContent),
-        };
+    Assert.NotNull(mapped);
 
-        var payload = CreatePayload(fields, DropdownId);
+    var concrete = mapped;
+    Assert.NotNull(concrete);
 
-        var mapped = _mapper.MapEntity(payload);
-
-        Assert.NotNull(mapped);
-
-        var concrete = mapped as ComponentDropDownDbEntity;
-        Assert.NotNull(concrete);
-
-        Assert.Equal(DropdownId, concrete.Id);
-        Assert.Equal(DropdownTitle, concrete.Title);
-    }
+    Assert.Equal(DropdownId, concrete.Id);
+    Assert.Equal(DropdownTitle, concrete.Title);
+  }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/HeaderMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/HeaderMapperTests.cs
@@ -18,7 +18,7 @@ public class HeaderMapperTests : BaseMapperTests
     public HeaderMapperTests()
     {
         _logger = Substitute.For<ILogger<JsonToDbMapper<HeaderDbEntity>>>();
-        _mapper = new HeaderMapper(_logger, JsonOptions);
+        _mapper = new HeaderMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _logger, JsonOptions);
     }
 
     [Fact]
@@ -33,11 +33,11 @@ public class HeaderMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, HeaderId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as HeaderDbEntity;
+        var concrete = mapped;
         Assert.NotNull(concrete);
 
         Assert.Equal(HeaderId, concrete.Id);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/InsetTextMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/InsetTextMapperTests.cs
@@ -16,7 +16,7 @@ public class InsetTextMapperTests : BaseMapperTests
     public InsetTextMapperTests()
     {
         _logger = Substitute.For<ILogger<InsetTextMapper>>();
-        _mapper = new InsetTextMapper(_logger, JsonOptions);
+        _mapper = new InsetTextMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _logger, JsonOptions);
     }
 
     [Fact]
@@ -29,11 +29,11 @@ public class InsetTextMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, InsetTextId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as InsetTextDbEntity;
+        var concrete = mapped;
         Assert.NotNull(concrete);
 
         Assert.Equal(InsetTextId, concrete.Id);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/JsonToDbMapperUnitTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/JsonToDbMapperUnitTests.cs
@@ -13,11 +13,11 @@ namespace Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
 public class JsonToDbMapperUnitTests : BaseMapperTests
 {
   private const string StringValueTest = "string test";
-  private readonly string[] ArrayValueTest = new[] { "one", "two", "three" };
+  private readonly string[] ArrayValueTest = ["one", "two", "three"];
   private const int NumberValueTest = 10000;
   private const string EntityId = "Testing Id";
 
-  private readonly CmsWebHookSystemDetailsInnerContainer[] ReferencesValueTest = new[] {
+  private readonly CmsWebHookSystemDetailsInnerContainer[] ReferencesValueTest = [
         new CmsWebHookSystemDetailsInnerContainer(){
           Sys = new(){
             Id = "First reference"
@@ -27,13 +27,11 @@ public class JsonToDbMapperUnitTests : BaseMapperTests
             Id = "Second reference"
           }
         }
-      };
+      ];
 
   private readonly JsonToDbMapperImplementation _mapper;
 
-  private readonly Type _type = typeof(ButtonWithLinkDbEntity);
-
-  private readonly ILogger<JsonToDbMapper<ContentComponentDbEntityImplementation>> _logger = Substitute.For<ILogger<JsonToDbMapper<ContentComponentDbEntityImplementation>>>();
+  private readonly ILogger<JsonToDbMapper<ContentComponentImplementationDbEntity>> _logger = Substitute.For<ILogger<JsonToDbMapper<ContentComponentImplementationDbEntity>>>();
 
   public JsonToDbMapperUnitTests()
   {
@@ -41,7 +39,7 @@ public class JsonToDbMapperUnitTests : BaseMapperTests
   }
 
   [Theory]
-  [InlineData("ButtonWithLink", true)]
+  [InlineData("ContentComponentImplementation", true)]
   [InlineData("Button", false)]
   [InlineData("ButtonWithEntryReference", false)]
   public void AcceptsContentType_Should_Return_Correct_Output(string typeName, bool expectedResult)
@@ -83,9 +81,9 @@ public class JsonToDbMapperUnitTests : BaseMapperTests
   }
 }
 
-public class JsonToDbMapperImplementation : JsonToDbMapper<ContentComponentDbEntityImplementation>
+public class JsonToDbMapperImplementation : JsonToDbMapper<ContentComponentImplementationDbEntity>
 {
-  public JsonToDbMapperImplementation(ILogger<JsonToDbMapper<ContentComponentDbEntityImplementation>> logger, JsonSerializerOptions jsonSerialiserOptions) : base(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), logger, jsonSerialiserOptions)
+  public JsonToDbMapperImplementation(ILogger<JsonToDbMapper<ContentComponentImplementationDbEntity>> logger, JsonSerializerOptions jsonSerialiserOptions) : base(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), logger, jsonSerialiserOptions)
   {
   }
 
@@ -95,7 +93,7 @@ public class JsonToDbMapperImplementation : JsonToDbMapper<ContentComponentDbEnt
   }
 }
 
-public class ContentComponentDbEntityImplementation : ContentComponentDbEntity
+public class ContentComponentImplementationDbEntity : ContentComponentDbEntity
 {
   public string StringValue { get; init; } = null!;
   public int NumberValue { get; init; }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/JsonToDbMapperUnitTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/JsonToDbMapperUnitTests.cs
@@ -1,4 +1,6 @@
 using Dfe.PlanTech.AzureFunctions.Mappings;
+using Dfe.PlanTech.AzureFunctions.Models;
+using Dfe.PlanTech.Domain.Caching.Enums;
 using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Content.Models.Buttons;
@@ -10,12 +12,12 @@ namespace Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
 
 public class JsonToDbMapperUnitTests : BaseMapperTests
 {
-    private const string StringValueTest = "string test";
-    private readonly string[] ArrayValueTest = new[] { "one", "two", "three" };
-    private const int NumberValueTest = 10000;
-    private const string EntityId = "Testing Id";
+  private const string StringValueTest = "string test";
+  private readonly string[] ArrayValueTest = new[] { "one", "two", "three" };
+  private const int NumberValueTest = 10000;
+  private const string EntityId = "Testing Id";
 
-    private readonly CmsWebHookSystemDetailsInnerContainer[] ReferencesValueTest = new[] {
+  private readonly CmsWebHookSystemDetailsInnerContainer[] ReferencesValueTest = new[] {
         new CmsWebHookSystemDetailsInnerContainer(){
           Sys = new(){
             Id = "First reference"
@@ -27,80 +29,76 @@ public class JsonToDbMapperUnitTests : BaseMapperTests
         }
       };
 
-    private readonly JsonToDbMapperImplementation _mapper;
+  private readonly JsonToDbMapperImplementation _mapper;
 
-    private readonly Type _type = typeof(ButtonWithLinkDbEntity);
+  private readonly Type _type = typeof(ButtonWithLinkDbEntity);
 
-    private readonly ILogger _logger = Substitute.For<ILogger>();
+  private readonly ILogger<JsonToDbMapper<ContentComponentDbEntityImplementation>> _logger = Substitute.For<ILogger<JsonToDbMapper<ContentComponentDbEntityImplementation>>>();
 
-    public JsonToDbMapperUnitTests()
+  public JsonToDbMapperUnitTests()
+  {
+    _mapper = new JsonToDbMapperImplementation(_logger, JsonOptions);
+  }
+
+  [Theory]
+  [InlineData("ButtonWithLink", true)]
+  [InlineData("Button", false)]
+  [InlineData("ButtonWithEntryReference", false)]
+  public void AcceptsContentType_Should_Return_Correct_Output(string typeName, bool expectedResult)
+  {
+    var acceptsContentType = _mapper.AcceptsContentType(typeName);
+
+    Assert.Equal(expectedResult, acceptsContentType);
+  }
+
+  [Fact]
+  public void Should_Flatten_Payload_And_Return_ContentComponentDbEntity_When_Valid_Payload()
+  {
+    var fields = new Dictionary<string, object?>()
     {
-        _mapper = new JsonToDbMapperImplementation(_type, _logger, JsonOptions);
-    }
+      ["stringValue"] = WrapWithLocalisation(StringValueTest),
+      ["numberValue"] = WrapWithLocalisation(NumberValueTest),
+      ["arrayValue"] = WrapWithLocalisation(ArrayValueTest),
+      ["referenceIds"] = WrapWithLocalisation(ReferencesValueTest)
+    };
+    CmsWebHookPayload payload = CreatePayload(fields, EntityId);
 
-    [Theory]
-    [InlineData("ButtonWithLink", true)]
-    [InlineData("Button", false)]
-    [InlineData("ButtonWithEntryReference", false)]
-    public void AcceptsContentType_Should_Return_Correct_Output(string typeName, bool expectedResult)
+    var mapped = _mapper.ToEntity(payload);
+
+    Assert.NotNull(mapped);
+
+    var concrete = mapped;
+    Assert.NotNull(concrete);
+
+    Assert.Equal(EntityId, concrete.Id);
+
+    Assert.Equal(StringValueTest, concrete.StringValue);
+    Assert.Equal(NumberValueTest, concrete.NumberValue);
+    Assert.Equal(ArrayValueTest, concrete.ArrayValue);
+
+    foreach (var reference in ReferencesValueTest)
     {
-        var acceptsContentType = _mapper.AcceptsContentType(typeName);
-
-        Assert.Equal(expectedResult, acceptsContentType);
+      Assert.Contains(reference.Sys.Id, concrete.ReferenceIds);
     }
-
-    [Fact]
-    public void Should_Flatten_Payload_And_Return_ContentComponentDbEntity_When_Valid_Payload()
-    {
-        var fields = new Dictionary<string, object?>()
-        {
-            ["stringValue"] = WrapWithLocalisation(StringValueTest),
-            ["numberValue"] = WrapWithLocalisation(NumberValueTest),
-            ["arrayValue"] = WrapWithLocalisation(ArrayValueTest),
-            ["referenceIds"] = WrapWithLocalisation(ReferencesValueTest)
-        };
-        CmsWebHookPayload payload = CreatePayload(fields, EntityId);
-
-        var mapped = _mapper.MapEntity(payload);
-
-        Assert.NotNull(mapped);
-
-        var concrete = mapped as ContentComponentDbEntityImplementation;
-        Assert.NotNull(concrete);
-
-        Assert.Equal(EntityId, concrete.Id);
-
-        Assert.Equal(StringValueTest, concrete.StringValue);
-        Assert.Equal(NumberValueTest, concrete.NumberValue);
-        Assert.Equal(ArrayValueTest, concrete.ArrayValue);
-
-        foreach (var reference in ReferencesValueTest)
-        {
-            Assert.Contains(reference.Sys.Id, concrete.ReferenceIds);
-        }
-    }
+  }
 }
-public class JsonToDbMapperImplementation : JsonToDbMapper
+
+public class JsonToDbMapperImplementation : JsonToDbMapper<ContentComponentDbEntityImplementation>
 {
-    public JsonToDbMapperImplementation(Type entityType, ILogger logger, JsonSerializerOptions jsonSerialiserOptions) : base(entityType, logger, jsonSerialiserOptions)
-    {
-    }
+  public JsonToDbMapperImplementation(ILogger<JsonToDbMapper<ContentComponentDbEntityImplementation>> logger, JsonSerializerOptions jsonSerialiserOptions) : base(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), logger, jsonSerialiserOptions)
+  {
+  }
 
-    public override ContentComponentDbEntity MapEntity(CmsWebHookPayload payload)
-    {
-        var values = GetEntityValuesDictionary(payload);
-
-        var asJson = JsonSerializer.Serialize(values, JsonOptions);
-        var serialised = JsonSerializer.Deserialize<ContentComponentDbEntityImplementation>(asJson, JsonOptions) ?? throw new ArgumentNullException("Null returned");
-
-        return serialised;
-    }
+  public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
+  {
+    return values;
+  }
 }
 
 public class ContentComponentDbEntityImplementation : ContentComponentDbEntity
 {
-    public string StringValue { get; init; } = null!;
-    public int NumberValue { get; init; }
-    public string[] ArrayValue { get; init; } = null!;
-    public string[] ReferenceIds { get; init; } = null!;
+  public string StringValue { get; init; } = null!;
+  public int NumberValue { get; init; }
+  public string[] ArrayValue { get; init; } = null!;
+  public string[] ReferenceIds { get; init; } = null!;
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/JsonToDbMapperUnitTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/JsonToDbMapperUnitTests.cs
@@ -1,9 +1,6 @@
 using Dfe.PlanTech.AzureFunctions.Mappings;
-using Dfe.PlanTech.AzureFunctions.Models;
-using Dfe.PlanTech.Domain.Caching.Enums;
 using Dfe.PlanTech.Domain.Caching.Models;
 using Dfe.PlanTech.Domain.Content.Models;
-using Dfe.PlanTech.Domain.Content.Models.Buttons;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using System.Text.Json;

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/NavigationLinkMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/NavigationLinkMapperTests.cs
@@ -17,7 +17,7 @@ public class NavigationLinkMapperTests : BaseMapperTests
     public NavigationLinkMapperTests()
     {
         _logger = Substitute.For<ILogger<NavigationLinkMapper>>();
-        _mapper = new NavigationLinkMapper(_logger, JsonOptions);
+        _mapper = new NavigationLinkMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _logger, JsonOptions);
     }
 
     [Theory]
@@ -34,11 +34,11 @@ public class NavigationLinkMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, NavigationLinkId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as NavigationLinkDbEntity;
+        var concrete = mapped;
         Assert.NotNull(concrete);
 
         Assert.Equal(NavigationLinkId, concrete.Id);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityRetrieverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityRetrieverTests.cs
@@ -1,0 +1,51 @@
+using System.Linq.Expressions;
+using Dfe.PlanTech.AzureFunctions.Mappings;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
+
+public class PageEntityRetrieverTests
+{
+  private const string ExistingPageId = "existing-page";
+  private readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
+  private readonly PageEntityRetriever _retriever;
+
+  private readonly List<PageDbEntity> _pages = [];
+
+  private readonly PageDbEntity _existingPage = new() { Id = ExistingPageId, };
+
+  public PageEntityRetrieverTests()
+  {
+    _retriever = new PageEntityRetriever(_db);
+
+    _pages.Add(_existingPage);
+
+    _db.Pages.FirstOrDefaultAsync(Arg.Any<Expression<Func<PageDbEntity, bool>>>(), Arg.Any<CancellationToken>())
+            .Returns(callinfo =>
+            {
+              var expression = callinfo.ArgAt<Expression<Func<PageDbEntity, bool>>>(0);
+
+              var compiled = expression.Compile();
+
+              var results = _pages.FirstOrDefault(compiled);
+
+              return results;
+            });
+  }
+
+  [Theory]
+  [InlineData(ExistingPageId, true)]
+  [InlineData("not-existing-entity-id", false)]
+  public async Task Should_Find_Existing_Entity_If_Any(string pageId, bool shouldBeFound)
+  {
+    var incomingPage = new PageDbEntity() { Id = pageId };
+    var result = await _retriever.GetExistingDbEntity(incomingPage, CancellationToken.None);
+
+    var isNull = result == null;
+
+    Assert.Equal(shouldBeFound, isNull);
+  }
+}

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityRetrieverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityRetrieverTests.cs
@@ -24,7 +24,6 @@ public class PageEntityRetrieverTests
     _pages.Add(_existingPage);
 
     MockPageDbSet();
-
   }
 
   private void MockPageDbSet()

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityUpdaterTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityUpdaterTests.cs
@@ -1,0 +1,62 @@
+using System.Linq.Expressions;
+using Dfe.PlanTech.AzureFunctions.Mappings;
+using Dfe.PlanTech.AzureFunctions.Models;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Content.Models.Buttons;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Dfe.PlanTech.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
+
+public class PageEntityUpdaterTests
+{
+  private const string ExistingPageId = "existing-page";
+  private readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
+  private readonly ILogger<PageEntityUpdater> _logger = Substitute.For<ILogger<PageEntityUpdater>>();
+  private readonly PageEntityUpdater _updater;
+
+  private readonly List<PageDbEntity> _pages = [];
+  private readonly PageDbEntity _existingPage = new() { Id = ExistingPageId, };
+
+  public PageEntityUpdaterTests()
+  {
+    _updater = new PageEntityUpdater(_logger, _db);
+  }
+
+  [Fact]
+  public void Should_Error_If_Incorrect_ContentComponent_Types()
+  {
+    MappedEntity[] shouldErrorEntities = [new MappedEntity()
+    {
+      IncomingEntity = new ButtonDbEntity(),
+      ExistingEntity = new PageDbEntity()
+    },
+      new MappedEntity()  {
+      IncomingEntity = new PageDbEntity(),
+      ExistingEntity = new QuestionDbEntity()
+    },
+      new MappedEntity()  {
+      IncomingEntity = new SectionDbEntity(),
+      ExistingEntity = new AnswerDbEntity()
+    }];
+
+    foreach (var errorableEntity in shouldErrorEntities)
+    {
+      Assert.ThrowsAny<InvalidCastException>(() => _updater.UpdateEntityConcrete(errorableEntity));
+    }
+  }
+
+  public void Should_AddOrUpdate_NewAndExistingPageComponents()
+  {
+
+  }
+
+  public void Should_Delete_Removed_Entities()
+  {
+
+  }
+}

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityUpdaterTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityUpdaterTests.cs
@@ -8,23 +8,60 @@ using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 
 namespace Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
 
 public class PageEntityUpdaterTests
 {
-  private const string ExistingPageId = "existing-page";
+  private const string PageId = "page-id";
+
   private readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
   private readonly ILogger<PageEntityUpdater> _logger = Substitute.For<ILogger<PageEntityUpdater>>();
   private readonly PageEntityUpdater _updater;
 
-  private readonly List<PageDbEntity> _pages = [];
-  private readonly PageDbEntity _existingPage = new() { Id = ExistingPageId, };
+  private readonly List<PageContentDbEntity> _pageContents = [
+    new PageContentDbEntity(){
+        ContentComponentId = "A",
+        Order = 2,
+        PageId = PageId
+      },
+      new PageContentDbEntity(){
+        ContentComponentId = "B",
+        Order = 1,
+        PageId = PageId
+      },
+      new PageContentDbEntity(){
+        BeforeContentComponentId = "D",
+        Order = 2,
+        PageId = PageId
+      },
+      new PageContentDbEntity(){
+        BeforeContentComponentId = "E",
+        Order = 1,
+        PageId = PageId
+      }
+  ];
 
   public PageEntityUpdaterTests()
   {
     _updater = new PageEntityUpdater(_logger, _db);
+    IQueryable<PageContentDbEntity> queryable = _pageContents.AsQueryable();
+
+    var asyncProvider = new AsyncQueryProvider<PageContentDbEntity>(queryable.Provider);
+
+    var mockPageDataSet = Substitute.For<DbSet<PageContentDbEntity>, IQueryable<PageContentDbEntity>>();
+    ((IQueryable<PageContentDbEntity>)mockPageDataSet).Provider.Returns(asyncProvider);
+    ((IQueryable<PageContentDbEntity>)mockPageDataSet).Expression.Returns(queryable.Expression);
+    ((IQueryable<PageContentDbEntity>)mockPageDataSet).ElementType.Returns(queryable.ElementType);
+    ((IQueryable<PageContentDbEntity>)mockPageDataSet).GetEnumerator().Returns(queryable.GetEnumerator());
+    _db.PageContents = mockPageDataSet;
+
+    _db.PageContents.When(pc => pc.RemoveRange(Arg.Any<IEnumerable<PageContentDbEntity>>()))
+                    .Do((callinfo) =>
+                    {
+                      var pageContentsToRemove = callinfo.ArgAt<IEnumerable<PageContentDbEntity>>(0);
+                      _pageContents.RemoveAll(pc => pageContentsToRemove.Contains(pc));
+                    });
   }
 
   [Fact]
@@ -50,13 +87,74 @@ public class PageEntityUpdaterTests
     }
   }
 
-  public void Should_AddOrUpdate_NewAndExistingPageComponents()
+  [Fact]
+  public void Should_AddOrUpddotnetate_NewAndExistingPageComponents()
   {
+    var addedEntity = new PageContentDbEntity()
+    {
+      ContentComponentId = "C",
+      Order = 3
+    };
 
+    var mappedEntity = new MappedEntity()
+    {
+      IncomingEntity = new PageDbEntity()
+      {
+        AllPageContents = [.. _pageContents.Select(InverseOrder), addedEntity],
+        Id = "page-id"
+      },
+      ExistingEntity = new PageDbEntity()
+      {
+        AllPageContents = [.. _pageContents]
+      }
+    };
+
+    var result = _updater.UpdateEntityConcrete(mappedEntity);
+
+    var unboxedExistingEntity = (PageDbEntity)mappedEntity.ExistingEntity!;
+
+    Assert.Contains(addedEntity, unboxedExistingEntity.AllPageContents);
+
+    var aContent = unboxedExistingEntity.AllPageContents.FirstOrDefault(pc => pc.ContentComponentId == "A");
+    var bContent = unboxedExistingEntity.AllPageContents.FirstOrDefault(pc => pc.ContentComponentId == "B");
+    var dContent = unboxedExistingEntity.AllPageContents.FirstOrDefault(pc => pc.BeforeContentComponentId == "D");
+    var eContent = unboxedExistingEntity.AllPageContents.FirstOrDefault(pc => pc.BeforeContentComponentId == "E");
+
+    Assert.Equivalent(1, aContent!.Order);
+    Assert.Equivalent(2, bContent!.Order);
+    Assert.Equivalent(1, dContent!.Order);
+    Assert.Equivalent(2, eContent!.Order);
   }
 
+  private static readonly Func<PageContentDbEntity, PageContentDbEntity> InverseOrder
+    = pc => new PageContentDbEntity()
+    {
+      BeforeContentComponentId = pc.BeforeContentComponentId,
+      ContentComponentId = pc.ContentComponentId,
+      PageId = pc.PageId,
+      Order = pc.Order == 1 ? 2 : 1
+    };
+
+  [Fact]
   public void Should_Delete_Removed_Entities()
   {
+    var removedEntity = _pageContents.First();
 
+    var mappedEntity = new MappedEntity()
+    {
+      IncomingEntity = new PageDbEntity()
+      {
+        AllPageContents = [.. _pageContents.Skip(1)],
+        Id = "page-id"
+      },
+      ExistingEntity = new PageDbEntity()
+      {
+        AllPageContents = [.. _pageContents]
+      }
+    };
+
+    var result = _updater.UpdateEntityConcrete(mappedEntity);
+
+    Assert.DoesNotContain(removedEntity, _pageContents);
   }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageMapperTests.cs
@@ -16,6 +16,7 @@ public class PageMapperTests : BaseMapperTests
     private readonly PageMapper _mapper;
     private readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
     private readonly ILogger<PageMapper> _logger;
+    private readonly ILogger<PageEntityUpdater> _entityUpdaterLogger = Substitute.For<ILogger<PageEntityUpdater>>();
     private readonly DbSet<PageContentDbEntity> _pageContentsDbSet = Substitute.For<DbSet<PageContentDbEntity>>();
     private readonly List<PageContentDbEntity> _attachedPageContents = new(10);
 
@@ -24,7 +25,7 @@ public class PageMapperTests : BaseMapperTests
     public PageMapperTests()
     {
         _logger = Substitute.For<ILogger<PageMapper>>();
-        _mapper = new PageMapper(_db, _logger, JsonOptions);
+        _mapper = new PageMapper(new PageEntityRetriever(_db), new PageEntityUpdater(_entityUpdaterLogger, _db), _logger, JsonOptions);
 
         _db.PageContents = _pageContentsDbSet;
 
@@ -50,11 +51,11 @@ public class PageMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, PageId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as PageDbEntity;
+        var concrete = mapped;
         Assert.NotNull(concrete);
 
         Assert.Equal(PageId, concrete.Id);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageMapperTests.cs
@@ -69,7 +69,7 @@ public class PageMapperTests : BaseMapperTests
         for (var index = 0; index < content.Length; index++)
         {
             var beforeTitle = content[index];
-            var matching = _attachedPageContents.FirstOrDefault(pc => idSelector(pc) == beforeTitle.Sys.Id);
+            var matching = _mapper.PageContents.FirstOrDefault(pc => idSelector(pc) == beforeTitle.Sys.Id);
             Assert.NotNull(matching);
             Assert.Equal(index, matching.Order);
         }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/QuestionMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/QuestionMapperTests.cs
@@ -30,7 +30,7 @@ public class QuestionMapperTests : BaseMapperTests
     public QuestionMapperTests()
     {
         _logger = Substitute.For<ILogger<JsonToDbMapper<QuestionDbEntity>>>();
-        _mapper = new QuestionMapper(_db, _logger, JsonOptions);
+        _mapper = new QuestionMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _db, _logger, JsonOptions);
     }
 
     [Fact]
@@ -55,11 +55,11 @@ public class QuestionMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, QuestionId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as QuestionDbEntity;
+        var concrete = mapped;
         Assert.NotNull(concrete);
 
         Assert.Equal(QuestionId, concrete.Id);

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationPageMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationPageMapperTests.cs
@@ -27,7 +27,7 @@ public class RecommendationPageMapperTests : BaseMapperTests
     public RecommendationPageMapperTests()
     {
         _logger = Substitute.For<ILogger<RecommendationPageMapper>>();
-        _mapper = new RecommendationPageMapper(_logger, JsonOptions);
+        _mapper = new RecommendationPageMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _logger, JsonOptions);
     }
 
     [Fact]
@@ -43,16 +43,14 @@ public class RecommendationPageMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, RecommendationId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
+        Assert.NotNull(mapped);
 
-        var concrete = mapped as RecommendationPageDbEntity;
-        Assert.NotNull(concrete);
-
-        Assert.Equal(RecommendationId, concrete.Id);
-        Assert.Equal(DisplayName, concrete.DisplayName);
-        Assert.Equal(InternalName, concrete.InternalName);
-        Assert.Equal(Page.Sys.Id, concrete.PageId);
+        Assert.Equal(RecommendationId, mapped.Id);
+        Assert.Equal(DisplayName, mapped.DisplayName);
+        Assert.Equal(InternalName, mapped.InternalName);
+        Assert.Equal(Page.Sys.Id, mapped.PageId);
     }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/SectionMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/SectionMapperTests.cs
@@ -53,7 +53,7 @@ public class SectionMapperTests : BaseMapperTests
         ((IQueryable<PageDbEntity>)mockPageDataSet).GetEnumerator().Returns(queryable.GetEnumerator());
 
         _logger = Substitute.For<ILogger<SectionMapper>>();
-        _mapper = new SectionMapper(_db, _logger, JsonOptions);
+        _mapper = new SectionMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _db, _logger, JsonOptions);
 
         _db.Questions = _questionsDbSet;
 
@@ -79,16 +79,13 @@ public class SectionMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, SectionId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as SectionDbEntity;
-        Assert.NotNull(concrete);
-
-        Assert.Equal(SectionId, concrete.Id);
-        Assert.Equal(SectionName, concrete.Name);
-        Assert.Equal(InterstitialPage.Sys.Id, concrete.InterstitialPageId);
+        Assert.Equal(SectionId, mapped.Id);
+        Assert.Equal(SectionName, mapped.Name);
+        Assert.Equal(InterstitialPage.Sys.Id, mapped.InterstitialPageId);
 
         Assert.Equal(Questions.Length, _attachedQuestions.Count);
 

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/TextBodyMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/TextBodyMapperTests.cs
@@ -15,7 +15,7 @@ public class TextBodyMapperTests : BaseMapperTests
     public TextBodyMapperTests()
     {
         _logger = Substitute.For<ILogger<TextBodyMapper>>();
-        _mapper = new TextBodyMapper(_richTextMapper, _logger, JsonOptions);
+        _mapper = new TextBodyMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _richTextMapper, _logger, JsonOptions);
     }
 
     [Fact]
@@ -29,13 +29,9 @@ public class TextBodyMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, TextBodyId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
-
-        var concrete = mapped as TextBodyDbEntity;
-        Assert.NotNull(concrete);
-
-        Assert.True(RichTextContentMapperTests.ContentMatches<RichTextContent, RichTextData, RichTextMark, RichTextContentDbEntity, RichTextDataDbEntity, RichTextMarkDbEntity>(richText, concrete.RichText));
+        Assert.True(RichTextContentMapperTests.ContentMatches<RichTextContent, RichTextData, RichTextMark, RichTextContentDbEntity, RichTextDataDbEntity, RichTextMarkDbEntity>(richText, mapped.RichText));
     }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/TitleMapperUnitTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/TitleMapperUnitTests.cs
@@ -16,7 +16,7 @@ public class TitleMapperUnitTests : BaseMapperTests
     public TitleMapperUnitTests()
     {
         _logger = Substitute.For<ILogger<TitleMapper>>();
-        _mapper = new TitleMapper(_logger, JsonOptions);
+        _mapper = new TitleMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _logger, JsonOptions);
     }
 
     [Fact]
@@ -29,14 +29,11 @@ public class TitleMapperUnitTests : BaseMapperTests
 
         var payload = CreatePayload(fields, TitleId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as TitleDbEntity;
-        Assert.NotNull(concrete);
-
-        Assert.Equal(TitleId, concrete.Id);
-        Assert.Equal(TitleText, concrete.Text);
+        Assert.Equal(TitleId, mapped.Id);
+        Assert.Equal(TitleText, mapped.Text);
     }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/WarningComponentMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/WarningComponentMapperTests.cs
@@ -17,7 +17,7 @@ public class WarningComponentMapperTests : BaseMapperTests
     public WarningComponentMapperTests()
     {
         _logger = Substitute.For<ILogger<WarningComponentMapper>>();
-        _mapper = new WarningComponentMapper(_logger, JsonOptions);
+        _mapper = new WarningComponentMapper(MapperHelpers.CreateMockEntityRetriever(), MapperHelpers.CreateMockEntityUpdater(), _logger, JsonOptions);
     }
 
     [Fact]
@@ -30,14 +30,11 @@ public class WarningComponentMapperTests : BaseMapperTests
 
         var payload = CreatePayload(fields, WarningComponentId);
 
-        var mapped = _mapper.MapEntity(payload);
+        var mapped = _mapper.ToEntity(payload);
 
         Assert.NotNull(mapped);
 
-        var concrete = mapped as WarningComponentDbEntity;
-        Assert.NotNull(concrete);
-
-        Assert.Equal(WarningComponentId, concrete.Id);
-        Assert.Equal(WarningComponentText.Sys.Id, concrete.TextId);
+        Assert.Equal(WarningComponentId, mapped.Id);
+        Assert.Equal(WarningComponentText.Sys.Id, mapped.TextId);
     }
 }


### PR DESCRIPTION
## Features

- Slightly refactor some code so that the responsibilities of certain classes is clearer and well defined
- This also allows me to make some slight changes to how an entity is updated and/or retrieved, depending on the mapper
- For unarchive and delete events, ensure that an existing entity exists in database. Otherwise error + deadletter message.
   - This matches the existing unpublish event behaviour.

## Fixes

- Fixes a bug (198819) where pages were no longer saving to the DB from Contentful

## TODO

- [x] Fix bug
- [x]  Update unit tests to match changes
- [x] Add unit tests for the new classes:
   - [x] PageRetriever
   - [x] PageUpdater
- [x] Add unit tests to get match code coverage requirements (if not already done)
- [x] Comment changes
