### PR TITLE
fix(recommendations): :bug: Recommendations querying

### DIFF
--- a/src/Dfe.PlanTech.Application/Content/Queries/GetSubTopicRecommendationFromContentfulQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetSubTopicRecommendationFromContentfulQuery.cs
@@ -33,7 +33,7 @@ public class GetSubtopicRecommendationFromContentfulQuery(IContentRepository rep
 
     public async Task<RecommendationsViewDto?> GetRecommendationsViewDto(string subtopicId, string maturity, CancellationToken cancellationToken = default)
     {
-        var options = CreateGetEntityOptions(subtopicId, 2, new ContentQueryEquals() { Field = "fields.intro.fields.maturity", Value = maturity });
+        var options = CreateGetEntityOptions(subtopicId, 2);
         options.Select = ["fields.intros", "sys"];
 
         var subtopicRecommendation = (await _repository.GetEntities<SubtopicRecommendation>(options, cancellationToken)).FirstOrDefault();

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240321_1003_AlterRichTextContentsWithSubtopicRecommendationIdView.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240321_1003_AlterRichTextContentsWithSubtopicRecommendationIdView.sql
@@ -1,0 +1,52 @@
+CREATE 
+OR ALTER VIEW [Contentful].[RichTextContentsBySubtopicRecommendationId] AS (
+  SELECT 
+    [ContentComponentId], 
+    [RichTextContentsWithSlug].[RichTextId] AS Id, 
+    [SubtopicRecommendationId], 
+    [Value], 
+    [NodeType], 
+    [DataId], 
+    [ParentId] 
+  FROM 
+    (
+      (
+        SELECT 
+          SRC.[Id] AS SubtopicRecommendationId, 
+          RCC.[ContentComponentId] 
+        FROM 
+          [Contentful].[SubtopicRecommendations] AS SRC 
+          JOIN [Contentful].[RecommendationSectionChunks] AS RSC ON SRC.[SectionId] = RSC.[RecommendationSectionId] 
+          JOIN [Contentful].[RecommendationChunkContents] AS RCC ON RSC.[RecommendationChunkId] = RCC.[RecommendationChunkId] 
+        UNION 
+        SELECT 
+          SRI.[Id] AS SubtopicRecommendationId, 
+          RIC.[ContentComponentId] 
+        FROM 
+          [Contentful].[SubtopicRecommendations] AS SRI 
+          JOIN [Contentful].[SubtopicRecommendationIntros] AS SRII ON SRI.[Id] = SRII.[SubtopicRecommendationId] 
+          JOIN [Contentful].[RecommendationIntros] AS RI ON SRII.[RecommendationIntroId] = RI.[Id] 
+          JOIN [Contentful].[RecommendationIntroContents] AS RIC ON RI.[Id] = RIC.[RecommendationIntroId]
+      ) AS RecContents 
+      LEFT JOIN(
+        SELECT 
+          [RichTextId], 
+          ISNULL([Warning].[Id], [TB].[Id]) AS ContentId 
+        FROM 
+          [Contentful].[TextBodies] AS TB 
+          LEFT JOIN [Contentful].[Warnings] AS Warning ON [Warning].[TextId] = [TB].[Id] 
+        WHERE 
+          [RichTextId] IS NOT NULL
+      ) AS TextContent ON RecContents.ContentComponentId = TextContent.ContentId OUTER APPLY (
+        SELECT 
+          [Id] AS [RichTextId], 
+          [Value], 
+          [NodeType], 
+          [DataId], 
+          [ParentId] 
+        FROM 
+          [Contentful].[SelectAllRichTextContentForParentId]([TextContent].[RichTextId])
+      ) AS RichTextContentsWithSlug
+    )
+)
+GO

--- a/src/Dfe.PlanTech.Infrastructure.Data/Repositories/RecommendationsRepository.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/Repositories/RecommendationsRepository.cs
@@ -85,6 +85,7 @@ public class RecommendationsRepository(ICmsDbContext db) : IRecommendationsRepos
                 Chunks = chunks.Select(chunk => new RecommendationChunkDbEntity()
                 {
                     Id = chunk.Id,
+                    Title = chunk.Title,
                     Header = chunk.Header,
                     HeaderId = chunk.HeaderId,
                     Answers = chunk.Answers,

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromContentfulQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromContentfulQueryTests.cs
@@ -250,31 +250,12 @@ public class GetSubTopicRecommendationFromContentfulQueryTests
                                                             .Select(query => query as ContentQueryEquals)
                                                             .Select(query => query!.Value).FirstOrDefault();
 
-                            var maturityFilter = options.Queries!.Where(query => query.Field == "fields.intro.fields.maturity")
-                                                        .Select(query => query as ContentQueryEquals)
-                                                        .Select(query => query!.Value).FirstOrDefault();
-
-                            var test = _subtopicRecommendations.Where(rec => rec.Subtopic.Sys.Id == idFilter)
-                                                            .Select(rec => new SubtopicRecommendation()
-                                                            {
-                                                                Intros = rec.Intros,
-                                                                Sys = rec.Sys
-                                                            }).ToList();
-
-                            var testTwo = _subtopicRecommendations.Where(rec => rec.Subtopic.Sys.Id == idFilter)
-                                                                            .Select(rec => new SubtopicRecommendation()
-                                                                            {
-                                                                                Intros = rec.Intros,
-                                                                                Sys = rec.Sys
-                                                                            }).ToList();
-
                             return _subtopicRecommendations.Where(rec => rec.Subtopic.Sys.Id == idFilter)
                                                             .Select(rec => new SubtopicRecommendation()
                                                             {
                                                                 Intros = rec.Intros,
                                                                 Sys = rec.Sys
-                                                            })
-                                                            .Where(rec => rec.Intros.Any(intro => intro.Maturity == maturityFilter));
+                                                            });
                         });
 
         var maturity = "Low";


### PR DESCRIPTION
### Fixes

- Fixes issue where query for Recommendations on the self-assessment page was failing from Contentful.  [^1]
- Retrieves `Title` for RecommendationChunk from DB
- Renames column in SQL view to ensure complete DB query works.


[^1]: This was caused by me trying to filter the request down by the intro maturity, and Contentful didn't like it. This could have been fixed, however it would never have had the intended result anyway, so I have just removed it.