### PR TITLE
fix(functions): :bug: Truncate deadletter description length

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -81,7 +81,7 @@ public class QueueReceiver : BaseFunction
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error processing message ID {message}", message.MessageId);
-            await messageActions.DeadLetterMessageAsync(message, null, ex.Message, ex.StackTrace?[..4000], cancellationToken);
+            await messageActions.DeadLetterMessageAsync(message, null, ex.Message, ex.StackTrace?.TruncateIfOverLength(4000), cancellationToken);
         }
     }
 

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -81,7 +81,7 @@ public class QueueReceiver : BaseFunction
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error processing message ID {message}", message.MessageId);
-            await messageActions.DeadLetterMessageAsync(message, null, ex.Message, ex.StackTrace, cancellationToken);
+            await messageActions.DeadLetterMessageAsync(message, null, ex.Message, ex.StackTrace?[..4000], cancellationToken);
         }
     }
 

--- a/src/Dfe.PlanTech.Domain/Extensions/StringHelpers.cs
+++ b/src/Dfe.PlanTech.Domain/Extensions/StringHelpers.cs
@@ -10,6 +10,8 @@ public static partial class StringHelpers
     public static string Slugify(this string text)
     => RemoveNonAlphaNumericCharactersPattern().Replace(text, "").Replace(" ", "-").ToLower();
 
+    public static string TruncateIfOverLength(this string text, int maxLength) => text.Length < maxLength ? text : text[..maxLength];
+
     [GeneratedRegex(RemoveNonAlphanumericCharactersRegexPattern)]
     private static partial Regex RemoveNonAlphaNumericCharactersPattern();
 }


### PR DESCRIPTION
Description on message has a max character length of _4096_. Stacktraces can easily go over that, meaning that the messages were not dead lettered.

Closes #201678