### PR TITLE
fix: Give checks permission to linting job + improve performance

### DIFF
--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -21,36 +21,14 @@ env:
   DOTNET_VERSION: ${{ vars.DOTNET_VERSION }}
 
 jobs:
-  get-src-dir-list:
-    name: Get Directories for Linting
-    runs-on: ubuntu-22.04
-    if: ${{ github.event_name == 'pull_request' }}
-    outputs:
-      directories: ${{ steps.list-dir.outputs.directories }}
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Get Directories
-        id: list-dir
-        uses: ./.github/actions/list-directory
-        with:
-          source: ./src/
-
   lint-code:
     name: Lint & Commit
     runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'pull_request' }}
-    needs: [get-src-dir-list]
-    strategy:
-      max-parallel: 1
-      fail-fast: true
-      matrix:
-        workspace: ${{ fromJson(needs.get-src-dir-list.outputs.directories) }}
     permissions:
       contents: write
       pull-requests: write
+      checks: write
 
     steps:
       - name: Checkout Repository
@@ -69,10 +47,10 @@ jobs:
         uses: wearerequired/lint-action@v2
         with:
           dotnet_format: true
-          dotnet_format_dir: ./src/${{ matrix.workspace }}
+          dotnet_format_dir: ./src
           git_email: "41898282+github-actions[bot]@users.noreply.github.com"
           git_name: "github-actions[bot]"
-          commit_message: "Linted Code in ${{ matrix.workspace }}"
+          commit_message: "Linted Code in source folder"
           auto_fix: true
           commit: true
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -25,6 +25,7 @@ jobs:
     name: Lint & Commit
     runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'pull_request' }}
+
     permissions:
       contents: write
       pull-requests: write
@@ -33,27 +34,31 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
           cache: false
-        env:
-          DOTNET_INSTALL_DIR: "/usr/share/dotnet"
-          DOTNET_CLI_TELEMETRY_OPTOUT: true
 
-      - name: Run Linter
-        uses: wearerequired/lint-action@v2
-        with:
-          dotnet_format: true
-          dotnet_format_dir: ./src
-          git_email: "41898282+github-actions[bot]@users.noreply.github.com"
-          git_name: "github-actions[bot]"
-          commit_message: "Linted Code in source folder"
-          auto_fix: true
-          commit: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lint plan-technology-for-your-school.sln solution
+        run: dotnet format plan-technology-for-your-school.sln
+
+      - name: Commit and push changes if necessary
+        if: 
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          if [[ `git status --porcelain` ]]; then
+            git commit -am "chore: Linted code for plan-technology-for-your-school.sln solution"
+            git push
+          else
+            echo 'No linting changes'
+          fi
 
   build-test-web-app:
     name: Build and run unit tests

--- a/src/Dfe.PlanTech.DatabaseUpgrader/DatabaseExecutor.cs
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/DatabaseExecutor.cs
@@ -9,85 +9,85 @@ namespace Dfe.PlanTech.DatabaseUpgrader;
 
 public class DatabaseExecutor
 {
-  private readonly Logger _logger;
-  private readonly Options _options;
+    private readonly Logger _logger;
+    private readonly Options _options;
 
-  private const string SCRIPTS_NAMESPACE = "Dfe.PlanTech.DatabaseUpgrader.Scripts";
-  private const string ENVIRONMENT_SPECIFIC_SCRIPTS_NAMESPACE = "Dfe.PlanTech.DatabaseUpgrader.EnvironmentSpecificScripts";
+    private const string SCRIPTS_NAMESPACE = "Dfe.PlanTech.DatabaseUpgrader.Scripts";
+    private const string ENVIRONMENT_SPECIFIC_SCRIPTS_NAMESPACE = "Dfe.PlanTech.DatabaseUpgrader.EnvironmentSpecificScripts";
 
-  public DatabaseExecutor(Options options, Logger logger)
-  {
-    _options = options ?? throw new ArgumentNullException(nameof(options));
-    _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-  }
-
-  public bool MigrateDatabase()
-  {
-    UpgradeEngine scriptsUpgrader = CreateUpgradeEngine();
-
-    var result = SetupRetryPolicy().ExecuteAndCapture(() => TryExecute(scriptsUpgrader));
-
-    return result.Result;
-  }
-
-  private UpgradeEngine CreateUpgradeEngine()
-  {
-    var executingAssembley = Assembly.GetExecutingAssembly();
-
-    var engine = DeployChanges.To.SqlDatabase(_options.DatabaseConnectionString)
-                                  .WithScriptsEmbeddedInAssembly(executingAssembley, ScriptNamespaceMatches(SCRIPTS_NAMESPACE));
-
-    AddSqlParameters(engine);
-    AddEnvironmentSpecificScripts(executingAssembley, engine);
-
-    return engine.LogToConsole()
-    .LogScriptOutput()
-    .WithTransaction()
-    .Build();
-  }
-
-  private void AddEnvironmentSpecificScripts(Assembly executingAssembley, UpgradeEngineBuilder engine)
-  {
-    foreach (var environment in _options.Environments)
+    public DatabaseExecutor(Options options, Logger logger)
     {
-      var ns = GetNamespaceForEnvironment(environment);
-      engine.WithScriptsEmbeddedInAssembly(executingAssembley, ScriptNamespaceMatches(ns));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
-  }
 
-  private void AddSqlParameters(UpgradeEngineBuilder engine)
-  {
-    var parameters = _options.FormattedSqlParameters;
-    if (parameters != null)
+    public bool MigrateDatabase()
     {
-      foreach (var param in parameters)
-      {
-        engine.WithVariable(param.Key, param.Value);
-      }
+        UpgradeEngine scriptsUpgrader = CreateUpgradeEngine();
+
+        var result = SetupRetryPolicy().ExecuteAndCapture(() => TryExecute(scriptsUpgrader));
+
+        return result.Result;
     }
-  }
-  
-  private static Func<string, bool> ScriptNamespaceMatches(string expectedStartsWith)
-   => scriptNamespace => scriptNamespace.StartsWith(expectedStartsWith, StringComparison.InvariantCultureIgnoreCase);
 
-  private static string GetNamespaceForEnvironment(string environment)
-   => string.Format("{0}.{1}", ENVIRONMENT_SPECIFIC_SCRIPTS_NAMESPACE, environment);
+    private UpgradeEngine CreateUpgradeEngine()
+    {
+        var executingAssembley = Assembly.GetExecutingAssembly();
 
-  private bool TryExecute(UpgradeEngine upgrader)
-  {
-    var result = upgrader.PerformUpgrade();
+        var engine = DeployChanges.To.SqlDatabase(_options.DatabaseConnectionString)
+                                      .WithScriptsEmbeddedInAssembly(executingAssembley, ScriptNamespaceMatches(SCRIPTS_NAMESPACE));
 
-    if (result.Successful) return true;
+        AddSqlParameters(engine);
+        AddEnvironmentSpecificScripts(executingAssembley, engine);
 
-    _logger.DisplayErrors("The database migration was not successful.", result.Error.Message, result.Error.StackTrace);
-    return false;
-  }
+        return engine.LogToConsole()
+        .LogScriptOutput()
+        .WithTransaction()
+        .Build();
+    }
 
-  private static RetryPolicy SetupRetryPolicy() => Policy.Handle<Exception>().WaitAndRetry(
-        new[]
+    private void AddEnvironmentSpecificScripts(Assembly executingAssembley, UpgradeEngineBuilder engine)
+    {
+        foreach (var environment in _options.Environments)
         {
+            var ns = GetNamespaceForEnvironment(environment);
+            engine.WithScriptsEmbeddedInAssembly(executingAssembley, ScriptNamespaceMatches(ns));
+        }
+    }
+
+    private void AddSqlParameters(UpgradeEngineBuilder engine)
+    {
+        var parameters = _options.FormattedSqlParameters;
+        if (parameters != null)
+        {
+            foreach (var param in parameters)
+            {
+                engine.WithVariable(param.Key, param.Value);
+            }
+        }
+    }
+
+    private static Func<string, bool> ScriptNamespaceMatches(string expectedStartsWith)
+     => scriptNamespace => scriptNamespace.StartsWith(expectedStartsWith, StringComparison.InvariantCultureIgnoreCase);
+
+    private static string GetNamespaceForEnvironment(string environment)
+     => string.Format("{0}.{1}", ENVIRONMENT_SPECIFIC_SCRIPTS_NAMESPACE, environment);
+
+    private bool TryExecute(UpgradeEngine upgrader)
+    {
+        var result = upgrader.PerformUpgrade();
+
+        if (result.Successful) return true;
+
+        _logger.DisplayErrors("The database migration was not successful.", result.Error.Message, result.Error.StackTrace);
+        return false;
+    }
+
+    private static RetryPolicy SetupRetryPolicy() => Policy.Handle<Exception>().WaitAndRetry(
+          new[]
+          {
                 TimeSpan.FromMinutes(1),
                 TimeSpan.FromMinutes(2),
                 TimeSpan.FromMinutes(3)
-        });
+          });
 }

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Logger.cs
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Logger.cs
@@ -3,48 +3,48 @@ namespace Dfe.PlanTech.DatabaseUpgrader;
 
 public class Logger
 {
-  private readonly ConsoleColor _successColour = ConsoleColor.Green;
-  private readonly ConsoleColor _errorColour = ConsoleColor.Red;
+    private readonly ConsoleColor _successColour = ConsoleColor.Green;
+    private readonly ConsoleColor _errorColour = ConsoleColor.Red;
 
-  public void DisplaySuccess(string successMessage)
-  {
-    DisplayMessages(_successColour, successMessage);
-    Console.ResetColor();
-  }
-
-  public void DisplayError(string errorMessage, Exception? exception = null)
-  {
-    if (!string.IsNullOrEmpty(exception?.StackTrace))
+    public void DisplaySuccess(string successMessage)
     {
-      DisplayMessages(_errorColour, errorMessage, exception.StackTrace);
-    }
-    else
-    {
-      DisplayMessages(_errorColour, errorMessage);
-    }
-  }
-
-  public void DisplayErrors(params string?[] errors)
-  {
-    DisplayMessages(_errorColour, errors);
-  }
-
-  public void DisplayInfo(params string?[] infos)
-  {
-    DisplayMessages(ConsoleColor.White, infos);
-  }
-
-  private static void DisplayMessages(ConsoleColor foregroundColour, params string?[] messages)
-  {
-    Console.ForegroundColor = foregroundColour;
-
-    foreach (var message in messages)
-    {
-      if (string.IsNullOrEmpty(message)) continue;
-
-      Console.WriteLine(message);
+        DisplayMessages(_successColour, successMessage);
+        Console.ResetColor();
     }
 
-    Console.ResetColor();
-  }
+    public void DisplayError(string errorMessage, Exception? exception = null)
+    {
+        if (!string.IsNullOrEmpty(exception?.StackTrace))
+        {
+            DisplayMessages(_errorColour, errorMessage, exception.StackTrace);
+        }
+        else
+        {
+            DisplayMessages(_errorColour, errorMessage);
+        }
+    }
+
+    public void DisplayErrors(params string?[] errors)
+    {
+        DisplayMessages(_errorColour, errors);
+    }
+
+    public void DisplayInfo(params string?[] infos)
+    {
+        DisplayMessages(ConsoleColor.White, infos);
+    }
+
+    private static void DisplayMessages(ConsoleColor foregroundColour, params string?[] messages)
+    {
+        Console.ForegroundColor = foregroundColour;
+
+        foreach (var message in messages)
+        {
+            if (string.IsNullOrEmpty(message)) continue;
+
+            Console.WriteLine(message);
+        }
+
+        Console.ResetColor();
+    }
 }

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Options.cs
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Options.cs
@@ -4,15 +4,15 @@ namespace Dfe.PlanTech.DatabaseUpgrader;
 
 public class Options
 {
-  [Option('c', "connectionstring", Required = true, HelpText = "Connection string for the database we should execute scripts on")]
-  public string DatabaseConnectionString { get; init; } = null!;
+    [Option('c', "connectionstring", Required = true, HelpText = "Connection string for the database we should execute scripts on")]
+    public string DatabaseConnectionString { get; init; } = null!;
 
-  [Option("env", Required = false, HelpText = "What environments should we run additional environment specific scripts on")]
-  public IEnumerable<string> Environments { get; init; } = Array.Empty<string>();
+    [Option("env", Required = false, HelpText = "What environments should we run additional environment specific scripts on")]
+    public IEnumerable<string> Environments { get; init; } = Array.Empty<string>();
 
-  [Option('p', "sql-params", Required = false, HelpText = "Parameters for SQL scripts. Enumerable formatted as KEY=VALUE")]
-  public IEnumerable<string>? SqlParameters { get; init; }
+    [Option('p', "sql-params", Required = false, HelpText = "Parameters for SQL scripts. Enumerable formatted as KEY=VALUE")]
+    public IEnumerable<string>? SqlParameters { get; init; }
 
-  public Dictionary<string, string>? FormattedSqlParameters =>
-        SqlParameters?.Select(param => param.Split('=')).ToDictionary(param => param[0], param => param[1]);
+    public Dictionary<string, string>? FormattedSqlParameters =>
+          SqlParameters?.Select(param => param.Split('=')).ToDictionary(param => param[0], param => param[1]);
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetCategorySectionsQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetCategorySectionsQueryTests.cs
@@ -234,7 +234,7 @@ public class GetCategorySectionsQueryTests
         await _db.ReceivedWithAnyArgs(0)
                      .ToListAsync(Arg.Any<IQueryable<SectionDbEntity>>(), Arg.Any<CancellationToken>());
     }
-    
+
     [Fact]
     public async Task Should_Log_No_Matching_Category_Error()
     {

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromContentfulQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromContentfulQueryTests.cs
@@ -136,9 +136,9 @@ public class GetSubTopicRecommendationFromContentfulQueryTests
         {
             Intros =
             [
-                new RecommendationIntro(){ Maturity = "Low", Header = new Header() { Text = "Low-Maturity-Intro"}},
-                new RecommendationIntro(){ Maturity = "Medium",Header = new Header() { Text = "Medium-Maturity-Intro"}},
-                new RecommendationIntro(){ Maturity = "High",Header = new Header() { Text = "High-Maturity-Intro"}},
+                new RecommendationIntro() { Maturity = "Low", Header = new Header() { Text = "Low-Maturity-Intro" } },
+                new RecommendationIntro() { Maturity = "Medium", Header = new Header() { Text = "Medium-Maturity-Intro" } },
+                new RecommendationIntro() { Maturity = "High", Header = new Header() { Text = "High-Maturity-Intro" } },
             ],
             Section = recommendationSectionOne,
             Subtopic = _subTopicOne,

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromDbQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromDbQueryTests.cs
@@ -52,15 +52,15 @@ public class GetSubTopicRecommendationFromDbQueryTests
                     [
                         new AnswerDbEntity()
                         {
-                             Id = "1"
+                            Id = "1"
                         },
                         new AnswerDbEntity()
                         {
-                             Id = "2"
+                            Id = "2"
                         },
                         new AnswerDbEntity()
                         {
-                             Id = "3"
+                            Id = "3"
                         }
                     ],
                     Header = new HeaderDbEntity()
@@ -71,7 +71,8 @@ public class GetSubTopicRecommendationFromDbQueryTests
                         Id = "Header-one"
                     },
                     Content = [
-                        new TextBodyDbEntity(){
+                        new TextBodyDbEntity()
+                        {
                             Id = "Chunk-one"
                         }
                     ]
@@ -101,7 +102,8 @@ public class GetSubTopicRecommendationFromDbQueryTests
                         Id = "Header-two"
                     },
                     Content = [
-                        new TextBodyDbEntity(){
+                        new TextBodyDbEntity()
+                        {
                             Id = "Chunk-two"
                         }
                     ]
@@ -112,11 +114,11 @@ public class GetSubTopicRecommendationFromDbQueryTests
                     [
                         new AnswerDbEntity()
                         {
-                             Id = "7"
+                            Id = "7"
                         },
                         new AnswerDbEntity()
                         {
-                           Id = "8"
+                            Id = "8"
                         },
                         new AnswerDbEntity()
                         {
@@ -131,7 +133,8 @@ public class GetSubTopicRecommendationFromDbQueryTests
                         Id = "Header-three"
                     },
                     Content = [
-                        new TextBodyDbEntity(){
+                        new TextBodyDbEntity()
+                        {
                             Id = "Chunk-three"
                         }
                     ]
@@ -148,9 +151,9 @@ public class GetSubTopicRecommendationFromDbQueryTests
         {
             Intros =
             [
-                new RecommendationIntroDbEntity(){ Maturity = "Low", Id = "Intro-One" },
-                new RecommendationIntroDbEntity(){ Maturity = "Medium", Id = "Intro-Two"},
-                new RecommendationIntroDbEntity(){ Maturity = "High", Id = "Intro-Three"},
+                new RecommendationIntroDbEntity() { Maturity = "Low", Id = "Intro-One" },
+                new RecommendationIntroDbEntity() { Maturity = "Medium", Id = "Intro-Two" },
+                new RecommendationIntroDbEntity() { Maturity = "High", Id = "Intro-Three" },
             ],
             Section = recommendationSectionOne,
             SectionId = recommendationSectionOne.Id,

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationQueryTests.cs
@@ -116,9 +116,9 @@ public class GetSubTopicRecommendationQueryTests
         {
             Intros =
             [
-                new(){ Maturity = "Low"},
-                new(){ Maturity = "Medium"},
-                new(){ Maturity = "High"},
+                new() { Maturity = "Low" },
+                new() { Maturity = "Medium" },
+                new() { Maturity = "High" },
             ],
             Section = recommendationSectionOne,
             Subtopic = subtopicOne,

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationChunkMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationChunkMapperTests.cs
@@ -10,10 +10,10 @@ namespace Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
 
 public class RecommendationChunkMapperTests : BaseMapperTests
 {
-    
+
     private readonly DbSet<RecommendationChunkAnswerDbEntity> _chunkAnswerDbSet = Substitute.For<DbSet<RecommendationChunkAnswerDbEntity>>();
     private readonly DbSet<RecommendationChunkContentDbEntity> _chunkContentDbSet = Substitute.For<DbSet<RecommendationChunkContentDbEntity>>();
-    
+
     private static readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
     private static readonly ILogger<RecommendationChunkUpdater> _logger = Substitute.For<ILogger<RecommendationChunkUpdater>>();
     private static RecommendationChunkUpdater CreateMockRecommendationChunkUpdater() => new(_logger, _db);
@@ -25,11 +25,11 @@ public class RecommendationChunkMapperTests : BaseMapperTests
         var values = new Dictionary<string, object?>
         {
             ["id"] = "ChunkId",
-            ["header"] =  "HeaderId",
+            ["header"] = "HeaderId",
             ["content"] = new string[] { "content1", "content2", "content3" },
             ["answers"] = new string[] { "answer1", "answer2", "answer3" }
         };
-        
+
         var loggerSubstitute = Substitute.For<ILogger<RecommendationChunkMapper>>();
         var jsonSerializerOptions = new JsonSerializerOptions();
 
@@ -42,7 +42,7 @@ public class RecommendationChunkMapperTests : BaseMapperTests
         var recommendationChunk = mapper.PerformAdditionalMapping(values);
 
         Assert.NotNull(recommendationChunk);
-        
+
         _db.RecommendationChunkContents.Received(3).Attach(Arg.Any<RecommendationChunkContentDbEntity>());
         _db.RecommendationChunkAnswers.Received(3).Attach(Arg.Any<RecommendationChunkAnswerDbEntity>());
     }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationChunkUpdaterTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationChunkUpdaterTests.cs
@@ -14,25 +14,25 @@ public class RecommendationChunkUpdaterTests
     private readonly List<RecommendationChunkAnswerDbEntity> _chunkAnswers =
 [
     new RecommendationChunkAnswerDbEntity()
-        {
-            RecommendationChunkId = "1",
-            AnswerId = "E"
-        },
-        new RecommendationChunkAnswerDbEntity()
-        {
-            RecommendationChunkId = "B",
-            AnswerId = "F"
-        },
-        new RecommendationChunkAnswerDbEntity()
-        {
-            RecommendationChunkId = "C",
-            AnswerId = "G"
-        },
-        new RecommendationChunkAnswerDbEntity()
-        {
-            RecommendationChunkId = "D",
-            AnswerId = "H"
-        }
+    {
+        RecommendationChunkId = "1",
+        AnswerId = "E"
+    },
+    new RecommendationChunkAnswerDbEntity()
+    {
+        RecommendationChunkId = "B",
+        AnswerId = "F"
+    },
+    new RecommendationChunkAnswerDbEntity()
+    {
+        RecommendationChunkId = "C",
+        AnswerId = "G"
+    },
+    new RecommendationChunkAnswerDbEntity()
+    {
+        RecommendationChunkId = "D",
+        AnswerId = "H"
+    }
 ];
 
 
@@ -40,8 +40,8 @@ public class RecommendationChunkUpdaterTests
     [
         new RecommendationChunkContentDbEntity()
         {
-            ContentComponentId= "I",
-            RecommendationChunkId= "M"
+            ContentComponentId = "I",
+            RecommendationChunkId = "M"
         },
         new RecommendationChunkContentDbEntity()
         {

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationIntroMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationIntroMapperTests.cs
@@ -10,13 +10,13 @@ namespace Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
 
 public class RecommendationIntroMapperTests : BaseMapperTests
 {
-        
+
     private readonly DbSet<RecommendationIntroContentDbEntity> _introContentDbSet = Substitute.For<DbSet<RecommendationIntroContentDbEntity>>();
-    
+
     private static readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
     private static readonly ILogger<RecommendationIntroUpdater> _logger = Substitute.For<ILogger<RecommendationIntroUpdater>>();
     private static RecommendationIntroUpdater CreateMockRecommendationIntroUpdater() => new(_logger, _db);
-    
+
     [Fact]
     public void RecommendationIntrosAreMappedCorrectly()
     {
@@ -24,7 +24,7 @@ public class RecommendationIntroMapperTests : BaseMapperTests
         {
             ["id"] = "introId",
             ["slug"] = "test-slug",
-            ["header"] =  "HeaderId",
+            ["header"] = "HeaderId",
             ["content"] = new string[] { "content1", "content2", "content3" },
         };
 
@@ -39,7 +39,7 @@ public class RecommendationIntroMapperTests : BaseMapperTests
         var recommendationIntro = mapper.PerformAdditionalMapping(values);
 
         Assert.NotNull(recommendationIntro);
-        
+
         _db.RecommendationIntroContents.Received(3).Attach(Arg.Any<RecommendationIntroContentDbEntity>());
     }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationSectionMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationSectionMapperTests.cs
@@ -10,7 +10,7 @@ namespace Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
 
 public class RecommendationSectionMapperTests : BaseMapperTests
 {
-    
+
     private readonly DbSet<RecommendationSectionAnswerDbEntity> _sectionAnswerDbSet = Substitute.For<DbSet<RecommendationSectionAnswerDbEntity>>();
     private readonly DbSet<RecommendationSectionChunkDbEntity> _sectionChunkDbSet = Substitute.For<DbSet<RecommendationSectionChunkDbEntity>>();
     private static readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
@@ -19,7 +19,7 @@ public class RecommendationSectionMapperTests : BaseMapperTests
 
 
     [Fact]
-    public void RecommendationSectionsAreMappedCorrectly()  
+    public void RecommendationSectionsAreMappedCorrectly()
     {
         var values = new Dictionary<string, object?>
         {
@@ -27,20 +27,20 @@ public class RecommendationSectionMapperTests : BaseMapperTests
             ["chunks"] = new string[] { "chunk1", "chunk2", "chunk3" },
             ["answers"] = new string[] { "answer1", "answer2", "answer3" }
         };
-        
+
         var loggerSubstitute = Substitute.For<ILogger<RecommendationSectionMapper>>();
         var jsonSerializerOptions = new JsonSerializerOptions();
 
         _db.RecommendationSectionChunks = _sectionChunkDbSet;
         _db.RecommendationSectionAnswers = _sectionAnswerDbSet;
-        
+
         var mapper = new RecommendationSectionMapper(MapperHelpers.CreateMockEntityRetriever(),
             CreateMockRecommendationSectionUpdater(), _db, loggerSubstitute, jsonSerializerOptions);
 
         var recommendationChunk = mapper.PerformAdditionalMapping(values);
 
         Assert.NotNull(recommendationChunk);
-        
+
         _db.RecommendationSectionAnswers.Received(3).Attach(Arg.Any<RecommendationSectionAnswerDbEntity>());
         _db.RecommendationSectionChunks.Received(3).Attach(Arg.Any<RecommendationSectionChunkDbEntity>());
     }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationSectionUpdaterTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/RecommendationSectionUpdaterTests.cs
@@ -41,7 +41,7 @@ public class RecommendationSectionUpdaterTests
         new RecommendationSectionChunkDbEntity()
         {
             RecommendationSectionId = "I",
-            RecommendationChunkId= "M"
+            RecommendationChunkId = "M"
         },
         new RecommendationSectionChunkDbEntity()
         {

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/SubtopicRecommendationMapperTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/SubtopicRecommendationMapperTests.cs
@@ -11,7 +11,7 @@ namespace Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
 public class SubtopicRecommendationMapperTests : BaseMapperTests
 {
     private readonly DbSet<SubtopicRecommendationIntroDbEntity> _subtopicIntroDbSet = Substitute.For<DbSet<SubtopicRecommendationIntroDbEntity>>();
-    
+
     private static readonly CmsDbContext _db = Substitute.For<CmsDbContext>();
     private static readonly ILogger<SubtopicRecommendationUpdater> _logger = Substitute.For<ILogger<SubtopicRecommendationUpdater>>();
     private static SubtopicRecommendationUpdater CreateMockSubTopicRecommendationUpdater() => new(_logger, _db);
@@ -21,11 +21,11 @@ public class SubtopicRecommendationMapperTests : BaseMapperTests
         var values = new Dictionary<string, object?>
         {
             ["id"] = "ChunkId",
-            ["section"] =  "sectionId",
-            ["subtopic"] =  "subtopicId",
+            ["section"] = "sectionId",
+            ["subtopic"] = "subtopicId",
             ["intros"] = new string[] { "intro1", "intro2", "intro3" },
         };
-        
+
         var _db = Substitute.For<CmsDbContext>();
         var loggerSubstitute = Substitute.For<ILogger<SubtopicRecommendationMapper>>();
         var jsonSerializerOptions = new JsonSerializerOptions();
@@ -38,8 +38,8 @@ public class SubtopicRecommendationMapperTests : BaseMapperTests
         var subtopicRecommendationContents = mapper.PerformAdditionalMapping(values);
 
         Assert.NotNull(subtopicRecommendationContents);
-        
+
         _db.SubtopicRecommendationIntros.Received(3).Attach(Arg.Any<SubtopicRecommendationIntroDbEntity>());
     }
-    
+
 }

--- a/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Repositories/RecommendationsRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Repositories/RecommendationsRepositoryTests.cs
@@ -13,241 +13,246 @@ namespace Dfe.PlanTech.Infrastructure.Data.UnitTests;
 public class RecommendationsRepositoryTests
 {
 #pragma warning disable CA1859 // Use concrete type
-  private readonly IRecommendationsRepository _repository;
+    private readonly IRecommendationsRepository _repository;
 #pragma warning disable CA1859 // Use concrete type
 
-  private readonly ICmsDbContext _db = Substitute.For<ICmsDbContext>();
+    private readonly ICmsDbContext _db = Substitute.For<ICmsDbContext>();
 
-  private readonly SubtopicRecommendationDbEntity _subtopicRecommendation;
-
-
-  private readonly List<AnswerDbEntity> _answers = [];
-  private readonly List<RecommendationChunkDbEntity> _chunks = [];
-  private readonly List<RecommendationIntroDbEntity> _intros = [];
-  private readonly List<SectionDbEntity> _sections = [];
-  private readonly List<SubtopicRecommendationDbEntity> _subtopicRecommendations = [];
-
-  public RecommendationsRepositoryTests()
-  {
-    _subtopicRecommendation = CreateSubtopicRecommendationDbEntity();
-    _subtopicRecommendations.Add(_subtopicRecommendation);
-
-    _answers.AddRange([.. _subtopicRecommendation.Section.Answers, .. _subtopicRecommendation.Section.Chunks.SelectMany(chunk => chunk.Answers)]);
-    _chunks.AddRange(_subtopicRecommendation.Section.Chunks);
-    _intros.AddRange(_subtopicRecommendation.Section.RecommendationIntro);
-    _sections.Add(_subtopicRecommendation.Subtopic);
-
-    var testing = new List<SubtopicRecommendationDbEntity>() { new() { Id = "One" } };
-    var queryable = testing.AsQueryable();
-
-    var mockContext = Substitute.For<ICmsDbContext>();
-
-    var subtopicRecDbSetMock = _subtopicRecommendations.BuildMock();
-    _db.SubtopicRecommendations.Returns(subtopicRecDbSetMock);
-
-    var sectionsDbSetMock = _sections.BuildMock();
-    _db.Sections.Returns(sectionsDbSetMock);
-
-    var introsMockSet = _intros.BuildMock();
-    _db.RecommendationIntros.Returns(introsMockSet);
-
-    var chunksMockSet = _chunks.BuildMock();
-    _db.RecommendationChunks.Returns(chunksMockSet);
-
-    List<RecommendationIntroContentDbEntity> introContent = [];
-    var introContentMock = introContent.BuildMock();
-    _db.RecommendationIntroContents.Returns(introContentMock);
-
-    List<RecommendationChunkContentDbEntity> chunkContent = [];
-    var chunkContentMock = chunkContent.BuildMock();
-    _db.RecommendationChunkContents.Returns(chunkContentMock);
+    private readonly SubtopicRecommendationDbEntity _subtopicRecommendation;
 
 
-    List<RichTextContentWithSubtopicRecommendationId> richTexts = [];
-    var richTextsMock = richTexts.BuildMock();
-    _db.RichTextContentWithSubtopicRecommendationIds.Returns(richTextsMock);
+    private readonly List<AnswerDbEntity> _answers = [];
+    private readonly List<RecommendationChunkDbEntity> _chunks = [];
+    private readonly List<RecommendationIntroDbEntity> _intros = [];
+    private readonly List<SectionDbEntity> _sections = [];
+    private readonly List<SubtopicRecommendationDbEntity> _subtopicRecommendations = [];
 
-    _repository = new RecommendationsRepository(_db);
-  }
-
-  private SubtopicRecommendationDbEntity CreateSubtopicRecommendationDbEntity()
-  {
-    var recommendationSectionOne = new RecommendationSectionDbEntity()
+    public RecommendationsRepositoryTests()
     {
-      Answers = [
-        new AnswerDbEntity()
+        _subtopicRecommendation = CreateSubtopicRecommendationDbEntity();
+        _subtopicRecommendations.Add(_subtopicRecommendation);
+
+        _answers.AddRange([.. _subtopicRecommendation.Section.Answers, .. _subtopicRecommendation.Section.Chunks.SelectMany(chunk => chunk.Answers)]);
+        _chunks.AddRange(_subtopicRecommendation.Section.Chunks);
+        _intros.AddRange(_subtopicRecommendation.Section.RecommendationIntro);
+        _sections.Add(_subtopicRecommendation.Subtopic);
+
+        var testing = new List<SubtopicRecommendationDbEntity>() { new() { Id = "One" } };
+        var queryable = testing.AsQueryable();
+
+        var mockContext = Substitute.For<ICmsDbContext>();
+
+        var subtopicRecDbSetMock = _subtopicRecommendations.BuildMock();
+        _db.SubtopicRecommendations.Returns(subtopicRecDbSetMock);
+
+        var sectionsDbSetMock = _sections.BuildMock();
+        _db.Sections.Returns(sectionsDbSetMock);
+
+        var introsMockSet = _intros.BuildMock();
+        _db.RecommendationIntros.Returns(introsMockSet);
+
+        var chunksMockSet = _chunks.BuildMock();
+        _db.RecommendationChunks.Returns(chunksMockSet);
+
+        List<RecommendationIntroContentDbEntity> introContent = [];
+        var introContentMock = introContent.BuildMock();
+        _db.RecommendationIntroContents.Returns(introContentMock);
+
+        List<RecommendationChunkContentDbEntity> chunkContent = [];
+        var chunkContentMock = chunkContent.BuildMock();
+        _db.RecommendationChunkContents.Returns(chunkContentMock);
+
+
+        List<RichTextContentWithSubtopicRecommendationId> richTexts = [];
+        var richTextsMock = richTexts.BuildMock();
+        _db.RichTextContentWithSubtopicRecommendationIds.Returns(richTextsMock);
+
+        _repository = new RecommendationsRepository(_db);
+    }
+
+    private SubtopicRecommendationDbEntity CreateSubtopicRecommendationDbEntity()
+    {
+        var recommendationSectionOne = new RecommendationSectionDbEntity()
         {
-          Id= "section-answer-one",
-        },
-        new AnswerDbEntity(){
-          Id= "section-answer-two",
-        },
-        new AnswerDbEntity(){
-          Id= "section-answer-three",
-        },
-      ],
-      Chunks =
-          [
-          new RecommendationChunkDbEntity()
+            Answers = [
+            new AnswerDbEntity()
             {
-              Id = "recommendation-chunk-one",
-                Answers =
-                [
-                    new AnswerDbEntity()
-                    {
-                          Id = "1"
-                    },
-                    new AnswerDbEntity()
-                    {
-                          Id = "2"
-                    },
-                    new AnswerDbEntity()
-                    {
-                          Id = "3"
-                    }
-                ],
-                Header = new HeaderDbEntity()
-                {
-                    Tag = HeaderTag.H1,
-                    Size = HeaderSize.Large,
-                    Text = "chunk1",
-                    Id = "Header-one"
-                },
-                Content = [
-                    new TextBodyDbEntity(){
-                        Id = "Chunk-one"
-                    }
-                ]
+                Id = "section-answer-one",
             },
-            new RecommendationChunkDbEntity()
-            {
-              Id = "recommendation-chunk-two",
-                Answers =
-                [
-                    new AnswerDbEntity()
-                    {
-                        Id = "4"
-                    },
-                    new AnswerDbEntity()
-                    {
-                        Id = "5"
-                    },
-                    new AnswerDbEntity()
-                    {
-                        Id = "6"
-                    }
-                ],
-                Header = new HeaderDbEntity()
+                new AnswerDbEntity()
                 {
-                    Tag = HeaderTag.H1,
-                    Size = HeaderSize.Large,
-                    Text = "chunk2",
-                    Id = "Header-two"
+                    Id = "section-answer-two",
                 },
-                Content = [
-                    new TextBodyDbEntity(){
-                        Id = "Chunk-two"
-                    }
-                ]
-            },
-            new RecommendationChunkDbEntity()
-            {
-              Id = "recommendation-chunk-three",
-                Answers =
-                [
-                    new AnswerDbEntity()
-                    {
-                          Id = "7"
-                    },
-                    new AnswerDbEntity()
-                    {
-                        Id = "8"
-                    },
-                    new AnswerDbEntity()
-                    {
-                        Id = "9"
-                    }
-                ],
-                Header = new HeaderDbEntity()
+                new AnswerDbEntity()
                 {
-                    Tag = HeaderTag.H1,
-                    Size = HeaderSize.Large,
-                    Text = "chunk3",
-                    Id = "Header-three"
+                    Id = "section-answer-three",
                 },
-                Content = [
-                    new TextBodyDbEntity(){
-                        Id = "Chunk-three"
-                    }
-                ]
-            }
-          ],
-      Id = "recommendation-section-one"
-    };
-
-    var subtopic = new SectionDbEntity() { Id = "SubTopicId" };
-
-    var recommendation = new SubtopicRecommendationDbEntity()
-    {
-      Intros =
-        [
-          new RecommendationIntroDbEntity(){ Maturity = "Low", Id = "Intro-One-Low", Slug = "Low-Maturity", Header = new HeaderDbEntity() { Text = "Low maturity header", Id = "Intro-header-one"} },
-          new RecommendationIntroDbEntity(){ Maturity = "Medium", Id = "Intro-Two-Medium", Slug = "Medium-Maturity", Header = new HeaderDbEntity() { Text = "Medium maturity header", Id = "Intro-header-two"} },
-          new RecommendationIntroDbEntity(){ Maturity = "High", Id = "Intro-Three-High", Slug = "High-Maturity", Header = new HeaderDbEntity() { Text = "High maturity header", Id = "Intro-header-three"} },
             ],
-      Section = recommendationSectionOne,
-      SectionId = recommendationSectionOne.Id,
-      Subtopic = subtopic,
-      SubtopicId = subtopic.Id,
-      Id = "subtopic-recommendation-one"
-    };
+            Chunks =
+              [
+              new RecommendationChunkDbEntity()
+              {
+                  Id = "recommendation-chunk-one",
+                  Answers =
+                    [
+                        new AnswerDbEntity()
+                        {
+                            Id = "1"
+                        },
+                        new AnswerDbEntity()
+                        {
+                            Id = "2"
+                        },
+                        new AnswerDbEntity()
+                        {
+                            Id = "3"
+                        }
+                    ],
+                  Header = new HeaderDbEntity()
+                  {
+                      Tag = HeaderTag.H1,
+                      Size = HeaderSize.Large,
+                      Text = "chunk1",
+                      Id = "Header-one"
+                  },
+                  Content = [
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Chunk-one"
+                        }
+                    ]
+              },
+                  new RecommendationChunkDbEntity()
+                  {
+                      Id = "recommendation-chunk-two",
+                      Answers =
+                    [
+                        new AnswerDbEntity()
+                        {
+                            Id = "4"
+                        },
+                        new AnswerDbEntity()
+                        {
+                            Id = "5"
+                        },
+                        new AnswerDbEntity()
+                        {
+                            Id = "6"
+                        }
+                    ],
+                      Header = new HeaderDbEntity()
+                      {
+                          Tag = HeaderTag.H1,
+                          Size = HeaderSize.Large,
+                          Text = "chunk2",
+                          Id = "Header-two"
+                      },
+                      Content = [
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Chunk-two"
+                        }
+                    ]
+                  },
+                  new RecommendationChunkDbEntity()
+                  {
+                      Id = "recommendation-chunk-three",
+                      Answers =
+                    [
+                        new AnswerDbEntity()
+                        {
+                            Id = "7"
+                        },
+                        new AnswerDbEntity()
+                        {
+                            Id = "8"
+                        },
+                        new AnswerDbEntity()
+                        {
+                            Id = "9"
+                        }
+                    ],
+                      Header = new HeaderDbEntity()
+                      {
+                          Tag = HeaderTag.H1,
+                          Size = HeaderSize.Large,
+                          Text = "chunk3",
+                          Id = "Header-three"
+                      },
+                      Content = [
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Chunk-three"
+                        }
+                    ]
+                  }
+              ],
+            Id = "recommendation-section-one"
+        };
 
-    subtopic.SubtopicRecommendation = recommendation;
+        var subtopic = new SectionDbEntity() { Id = "SubTopicId" };
 
-    return recommendation;
-  }
+        var recommendation = new SubtopicRecommendationDbEntity()
+        {
+            Intros =
+            [
+              new RecommendationIntroDbEntity() { Maturity = "Low", Id = "Intro-One-Low", Slug = "Low-Maturity", Header = new HeaderDbEntity() { Text = "Low maturity header", Id = "Intro-header-one" } },
+                new RecommendationIntroDbEntity() { Maturity = "Medium", Id = "Intro-Two-Medium", Slug = "Medium-Maturity", Header = new HeaderDbEntity() { Text = "Medium maturity header", Id = "Intro-header-two" } },
+                new RecommendationIntroDbEntity() { Maturity = "High", Id = "Intro-Three-High", Slug = "High-Maturity", Header = new HeaderDbEntity() { Text = "High maturity header", Id = "Intro-header-three" } },
+            ],
+            Section = recommendationSectionOne,
+            SectionId = recommendationSectionOne.Id,
+            Subtopic = subtopic,
+            SubtopicId = subtopic.Id,
+            Id = "subtopic-recommendation-one"
+        };
 
-  [Theory]
-  [InlineData(Maturity.Low, "Low-Maturity", "Low maturity header")]
-  [InlineData(Maturity.Medium, "Medium-Maturity", "Medium maturity header")]
-  [InlineData(Maturity.High, "High-Maturity", "High maturity header")]
-  public async Task GetRecommenationsViewDtoForSubtopicAndMaturity_Should_Retrieve_Partial_Data_When_Found(Maturity maturity, string expectedSlug, string expectedDisplayName)
-  {
-    var recommendationView = await _repository.GetRecommenationsViewDtoForSubtopicAndMaturity(_subtopicRecommendation.Subtopic.Id, maturity.ToString(), CancellationToken.None);
+        subtopic.SubtopicRecommendation = recommendation;
 
-    Assert.NotNull(recommendationView);
-    Assert.Equal(expectedDisplayName, recommendationView.DisplayName);
-    Assert.Equal(expectedSlug, recommendationView.RecommendationSlug);
-  }
+        return recommendation;
+    }
 
-  [Fact]
-  public async Task GetRecommenationsViewDtoForSubtopicAndMaturity_Should_Return_Null_When_Not_Found()
-  {
-    var recommendationView = await _repository.GetRecommenationsViewDtoForSubtopicAndMaturity("not a real subtopic", Maturity.Low.ToString(), CancellationToken.None);
-    Assert.Null(recommendationView);
-  }
+    [Theory]
+    [InlineData(Maturity.Low, "Low-Maturity", "Low maturity header")]
+    [InlineData(Maturity.Medium, "Medium-Maturity", "Medium maturity header")]
+    [InlineData(Maturity.High, "High-Maturity", "High maturity header")]
+    public async Task GetRecommenationsViewDtoForSubtopicAndMaturity_Should_Retrieve_Partial_Data_When_Found(Maturity maturity, string expectedSlug, string expectedDisplayName)
+    {
+        var recommendationView = await _repository.GetRecommenationsViewDtoForSubtopicAndMaturity(_subtopicRecommendation.Subtopic.Id, maturity.ToString(), CancellationToken.None);
 
-  [Fact]
-  public async Task GetRecommenationsViewDtoForSubtopicAndMaturity_Should_Return_Null_When_Maturity_NotFound()
-  {
-    var recommendationView = await _repository.GetRecommenationsViewDtoForSubtopicAndMaturity(_subtopicRecommendation.Subtopic.Id, "not a real maturity", CancellationToken.None);
-    Assert.Null(recommendationView);
-  }
+        Assert.NotNull(recommendationView);
+        Assert.Equal(expectedDisplayName, recommendationView.DisplayName);
+        Assert.Equal(expectedSlug, recommendationView.RecommendationSlug);
+    }
 
-  [Fact]
-  public async Task GetCompleteRecommendationsForSubtopic_Should_Return_Complete_Subtopic()
-  {
-    var recommendation = await _repository.GetCompleteRecommendationsForSubtopic(_subtopicRecommendation.Subtopic.Id, CancellationToken.None);
+    [Fact]
+    public async Task GetRecommenationsViewDtoForSubtopicAndMaturity_Should_Return_Null_When_Not_Found()
+    {
+        var recommendationView = await _repository.GetRecommenationsViewDtoForSubtopicAndMaturity("not a real subtopic", Maturity.Low.ToString(), CancellationToken.None);
+        Assert.Null(recommendationView);
+    }
 
-    Assert.NotNull(recommendation);
-    Assert.Equal(_subtopicRecommendation.Id, recommendation.Id);
-  }
+    [Fact]
+    public async Task GetRecommenationsViewDtoForSubtopicAndMaturity_Should_Return_Null_When_Maturity_NotFound()
+    {
+        var recommendationView = await _repository.GetRecommenationsViewDtoForSubtopicAndMaturity(_subtopicRecommendation.Subtopic.Id, "not a real maturity", CancellationToken.None);
+        Assert.Null(recommendationView);
+    }
 
-  [Fact]
-  public async Task GetCompleteRecommendationsForSubtopic_Should_Return_Null_When_NotFound()
-  {
-    var recommendation = await _repository.GetCompleteRecommendationsForSubtopic("Not a real subtopic", CancellationToken.None);
+    [Fact]
+    public async Task GetCompleteRecommendationsForSubtopic_Should_Return_Complete_Subtopic()
+    {
+        var recommendation = await _repository.GetCompleteRecommendationsForSubtopic(_subtopicRecommendation.Subtopic.Id, CancellationToken.None);
 
-    Assert.Null(recommendation);
-  }
+        Assert.NotNull(recommendation);
+        Assert.Equal(_subtopicRecommendation.Id, recommendation.Id);
+    }
+
+    [Fact]
+    public async Task GetCompleteRecommendationsForSubtopic_Should_Return_Null_When_NotFound()
+    {
+        var recommendation = await _repository.GetCompleteRecommendationsForSubtopic("Not a real subtopic", CancellationToken.None);
+
+        Assert.Null(recommendation);
+    }
 }


### PR DESCRIPTION
- Adds check permissions to linting job so that it works
- Removes the job matrix, and just lint the entire `./src` directory anyway [^1]

[^1]: Originally the job would get every directory within the `src` folder, and then lint them all individually one by one. This seems unnecessary, and takes a lot longer (as we have to checkout each time, then install .NET, etc.). This should make it a lot quicker.