### PR TITLE
fix(functions): :ambulance: Page query + redelivery handler

### DIFF
--- a/docs/adr/0036-db-unit-tests.md
+++ b/docs/adr/0036-db-unit-tests.md
@@ -1,0 +1,38 @@
+# 0046 - DB Unit Tests
+
+* **Status**: proposed
+
+## Context and Problem Statement
+
+Unit testing against a database is difficult. It either involves mocking various components, substituting the database for one in memory, or creating a whole new local database just for testing.
+
+Microsoft particularly recommend [the latter](https://learn.microsoft.com/en-us/ef/ef6/fundamentals/testing/mocking).
+
+## Decision Drivers
+
+- Ease of development
+- Development best practices
+- Meets requirements currently
+
+## Considered Options
+
+- Mocking:
+  - Not recommended by Microsoft
+  - We could mock the various DB Sets in the database
+  - This is easily done with external Nuget packages such as [MockQueryable](https://www.nuget.org/packages/MockQueryable.Core)
+ 
+- We could test against a local in memory database copy (e.g. SQLite):
+  - Not recommended by Microsoft
+  - Database provider used is unlikely to match MSSQL/Azure SQL 1-to-1, meaning errors could occur
+
+- We could create a new database locally (or in CI/CD pipelines), using Docker for example, and perform unit tests against that.
+  - Recommended solution by Microsoft
+  - A lot of initial work
+  - Would mean our unit tests would test against an _exact copy_ of the functionality of the database.
+
+
+## Decision Outcome
+
+Currently we are using a combination of all 3, depending on the exact needs of each unit tests.
+
+However, we should probably move towards the last option where possible. Although it may take a bit of initial work, once done it should involve minimal changes to keep up-to-date (as we can, for example, just apply the DBUpgrader project against the local SQL instance).

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityRetriever.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityRetriever.cs
@@ -9,16 +9,46 @@ public class PageEntityRetriever(CmsDbContext db) : EntityRetriever(db)
     public override async Task<ContentComponentDbEntity?> GetExistingDbEntity(ContentComponentDbEntity entity, CancellationToken cancellationToken)
     {
         var page = await Db.Pages.IgnoreQueryFilters()
-                                .Include(page => page.AllPageContents)
-                                .Include(page => page.BeforeTitleContent)
-                                .Include(page => page.Content)
-                                .Include(page => page.Title)
+                                .Select(page => new PageDbEntity()
+                                {
+                                    Id = page.Id,
+                                    Slug = page.Slug,
+                                    TitleId = page.TitleId,
+                                    DisplayBackButton = page.DisplayBackButton,
+                                    DisplayHomeButton = page.DisplayHomeButton,
+                                    DisplayOrganisationName = page.DisplayOrganisationName,
+                                    DisplayTopicTitle = page.DisplayTopicTitle,
+                                    RequiresAuthorisation = page.RequiresAuthorisation,
+                                    AllPageContents = page.AllPageContents.Select(pageContent => new PageContentDbEntity()
+                                    {
+                                        BeforeContentComponentId = pageContent.BeforeContentComponentId,
+                                        ContentComponentId = pageContent.ContentComponentId,
+                                        PageId = pageContent.PageId,
+                                        Order = pageContent.Order,
+                                    }).ToList()
+                                })
                                 .FirstOrDefaultAsync(page => page.Id == entity.Id, cancellationToken);
 
         if (page == null)
         {
             return null;
         }
+
+        page.BeforeTitleContent = page.AllPageContents
+            .Where(pageContent => pageContent.BeforeContentComponentId != null)
+            .Select(pageContent => new ContentComponentDbEntity()
+            {
+                Id = pageContent.BeforeContentComponentId!
+            })
+            .ToList();
+
+        page.Content = page.AllPageContents
+            .Where(pageContent => pageContent.ContentComponentId != null)
+            .Select(pageContent => new ContentComponentDbEntity()
+            {
+                Id = pageContent.ContentComponentId!
+            })
+            .ToList();
 
         return page;
     }

--- a/src/Dfe.PlanTech.AzureFunctions/Utils/MessageRetryHandler.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Utils/MessageRetryHandler.cs
@@ -30,7 +30,7 @@ public class MessageRetryHandler(
             return false;
         }
 
-        RedeliverMessage(message, deliveryAttempts, cancellationToken);
+        await RedeliverMessage(message, deliveryAttempts, cancellationToken);
 
         return true;
     }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncQueryProvider.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/AsyncQueryProvider.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using System.Linq.Expressions;
 
 namespace Dfe.PlanTech.AzureFunctions.UnitTests;
@@ -11,6 +12,7 @@ public class AsyncQueryProvider<TEntity> : IAsyncQueryProvider
     {
         _inner = inner;
     }
+
 
     public IQueryable CreateQuery(Expression expression)
     {

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Dfe.PlanTech.AzureFunctions.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Dfe.PlanTech.AzureFunctions.UnitTests.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="bogus" Version="35.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MockQueryable.EntityFrameworkCore" Version="7.0.1" />
+    <PackageReference Include="MockQueryable.NSubstitute" Version="7.0.1" />
     <PackageReference Include="NSUbstitute" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.7.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityRetrieverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityRetrieverTests.cs
@@ -2,6 +2,7 @@ using Dfe.PlanTech.AzureFunctions.Mappings;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using MockQueryable.NSubstitute;
 using NSubstitute;
 
 namespace Dfe.PlanTech.AzureFunctions.UnitTests.Mappers;
@@ -27,16 +28,9 @@ public class PageEntityRetrieverTests
 
     private void MockPageDbSet()
     {
-        IQueryable<PageDbEntity> queryable = _pages.AsQueryable();
+        var mock = _pages.AsQueryable().BuildMockDbSet();
 
-        var asyncProvider = new AsyncQueryProvider<PageDbEntity>(queryable.Provider);
-
-        var mockPageDataSet = Substitute.For<DbSet<PageDbEntity>, IQueryable<PageDbEntity>>();
-        ((IQueryable<PageDbEntity>)mockPageDataSet).Provider.Returns(asyncProvider);
-        ((IQueryable<PageDbEntity>)mockPageDataSet).Expression.Returns(queryable.Expression);
-        ((IQueryable<PageDbEntity>)mockPageDataSet).ElementType.Returns(queryable.ElementType);
-        ((IQueryable<PageDbEntity>)mockPageDataSet).GetEnumerator().Returns(queryable.GetEnumerator());
-        _db.Pages = mockPageDataSet;
+        _db.Pages = mock;
     }
 
     [Theory]


### PR DESCRIPTION
## Reduces page query 

The existing page query resulted in a **massive** SQL query which often timed out, especially on more complex pages.
    
Whilst this has been fixed in various other places (e.g. the web app page query), it was missed from the Azure Function.

## Await message retry 

The redelivery message task was not awaited, meaning that redelivery might have not happened by the time the parent methods exits.

This fix awaits the redeliver message method.