### PR TITLE
fix(functions): :ambulance: Page content changes - 206886

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -113,7 +113,7 @@ public class QueueReceiver(
     {
         if (mapped.ExistingEntity == null)
         {
-            throw new NullReferenceException("ExistingEntity is null for removal event but various validations should have prevented this.");
+            throw new InvalidOperationException("ExistingEntity is null for removal event but various validations should have prevented this.");
         }
 
         return db.SetComponentPublishedAndDeletedStatuses(mapped.ExistingEntity, mapped.ExistingEntity.Published, mapped.ExistingEntity.Deleted, cancellationToken);

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -116,11 +116,7 @@ public class QueueReceiver(
             throw new NullReferenceException("ExistingEntity is null for removal event but various validations should have prevented this.");
         }
 
-        return db.ContentComponents.IgnoreAutoIncludes()
-                                    .IgnoreQueryFilters()
-                                    .Where(contentComponent => contentComponent.Id == mapped.ExistingEntity!.Id)
-                                    .ExecuteUpdateAsync((contentComponent) => contentComponent.SetProperty(cc => cc.Deleted, mapped.ExistingEntity.Deleted)
-                                                                                               .SetProperty(cc => cc.Published, mapped.ExistingEntity.Published), cancellationToken: cancellationToken);
+        return db.SetComponentPublishedAndDeletedStatuses(mapped.ExistingEntity, mapped.ExistingEntity.Published, mapped.ExistingEntity.Deleted, cancellationToken);
     }
 
     /// <summary>

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -73,7 +73,6 @@ public class QueueReceiver(
             }
 
             UpsertEntity(mapped);
-
             await DbSaveChanges(cancellationToken);
 
             await messageActions.CompleteMessageAsync(message, cancellationToken);
@@ -89,7 +88,7 @@ public class QueueReceiver(
 
             if (retryRequired)
             {
-                Logger.LogWarning("Error processing message ID {Message} will retry again", message.MessageId);
+                Logger.LogWarning(ex, "Error processing message ID {Message}will retry again", message.MessageId);
                 await messageActions.CompleteMessageAsync(message, cancellationToken);
                 return;
             }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
@@ -30,7 +30,7 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
 
         mappedEntity.UpdateEntity();
 
-        if (!mappedEntity.IsValidComponent(Db, _logger))
+        if (!mappedEntity.IsValidComponent(Db, _logger) || mappedEntity.IsRemovalEvent)
         {
             return mappedEntity;
         }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
@@ -30,7 +30,7 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
 
         mappedEntity.UpdateEntity();
 
-        if (!mappedEntity.IsValidComponent(Db, _logger) || mappedEntity.IsRemovalEvent)
+        if (!mappedEntity.IsValidComponent(Db, _logger) || mappedEntity.IsMinimalPayloadEvent)
         {
             return mappedEntity;
         }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityRetriever.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityRetriever.cs
@@ -23,6 +23,7 @@ public class PageEntityRetriever(CmsDbContext db) : EntityRetriever(db)
                                     {
                                         BeforeContentComponentId = pageContent.BeforeContentComponentId,
                                         ContentComponentId = pageContent.ContentComponentId,
+                                        Id = pageContent.Id,
                                         PageId = pageContent.PageId,
                                         Order = pageContent.Order,
                                     }).ToList()
@@ -33,22 +34,6 @@ public class PageEntityRetriever(CmsDbContext db) : EntityRetriever(db)
         {
             return null;
         }
-
-        page.BeforeTitleContent = page.AllPageContents
-            .Where(pageContent => pageContent.BeforeContentComponentId != null)
-            .Select(pageContent => new ContentComponentDbEntity()
-            {
-                Id = pageContent.BeforeContentComponentId!
-            })
-            .ToList();
-
-        page.Content = page.AllPageContents
-            .Where(pageContent => pageContent.ContentComponentId != null)
-            .Select(pageContent => new ContentComponentDbEntity()
-            {
-                Id = pageContent.ContentComponentId!
-            })
-            .ToList();
 
         return page;
     }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
@@ -19,19 +19,46 @@ public class PageEntityUpdater(ILogger<PageEntityUpdater> logger, CmsDbContext d
             throw new InvalidCastException($"Entities are not expected page types. Received {entity.IncomingEntity.GetType()} and {entity.ExistingEntity!.GetType()}");
         }
 
-        AddOrUpdatePageContents(incomingPage, existingPage);
-        RemoveOldPageContents(incomingPage, existingPage);
+        ProcessPageContentChanges(incomingPage, existingPage);
 
         return entity;
     }
 
-    private void RemoveOldPageContents(PageDbEntity incomingPage, PageDbEntity existingPage)
+    /// <summary>
+    /// CRUD page contents for the page
+    /// </summary>
+    /// <param name="incomingPage"></param>
+    /// <param name="existingPage"></param>
+    private static void ProcessPageContentChanges(PageDbEntity incomingPage, PageDbEntity existingPage)
     {
-        var removedPageContents = existingPage.AllPageContents.Where(pc => !incomingPage.AllPageContents.Exists(apc => apc.Matches(pc)));
-        Db.PageContents.RemoveRange(removedPageContents);
+        AddOrUpdatePageContents(incomingPage, existingPage);
+        DeleteRemovedPageContents(incomingPage, existingPage);
     }
 
-    private void AddOrUpdatePageContents(PageDbEntity incomingPage, PageDbEntity existingPage)
+    /// <summary>
+    /// Removes page contents from existing page if they are not in the incoming page update
+    /// </summary>
+    /// <param name="incomingPage"></param>
+    /// <param name="existingPage"></param>
+    private static void DeleteRemovedPageContents(PageDbEntity incomingPage, PageDbEntity existingPage)
+    {
+        var deletedPageContents = existingPage.AllPageContents.Where((existingPageContent) => !HasPageContent(incomingPage, existingPageContent)).ToList();
+
+        existingPage.AllPageContents.RemoveAll((existingPageContent) => !HasPageContent(incomingPage, existingPageContent));
+    }
+
+    private static bool HasPageContent(PageDbEntity page, PageContentDbEntity pageContent)
+     => page.AllPageContents.Any(incomingPageContent => incomingPageContent.Matches(pageContent));
+
+    /// <summary>
+    /// For each incoming page content:
+    /// - Add if it doesn't already exist
+    /// - Remove duplicates if any
+    /// - Update order if existing and order has changed
+    /// </summary>
+    /// <param name="incomingPage"></param>
+    /// <param name="existingPage"></param>
+    private static void AddOrUpdatePageContents(PageDbEntity incomingPage, PageDbEntity existingPage)
     {
         foreach (var pageContent in incomingPage.AllPageContents)
         {
@@ -39,22 +66,59 @@ public class PageEntityUpdater(ILogger<PageEntityUpdater> logger, CmsDbContext d
                                                               .OrderByDescending(pc => pc.Id)
                                                               .ToList();
 
-            if (matchingContents.Count == 0)
-            {
-                existingPage.AllPageContents.Add(pageContent);
-                continue;
-            }
+            ProcessPageContent(existingPage, pageContent, matchingContents);
+        }
+    }
 
-            if (matchingContents.Count > 1)
-            {
-                Db.PageContents.RemoveRange(matchingContents[1..]);
-            }
+    /// <summary>
+    /// - Add page content if missing from existing page
+    /// - Remove duplicates from existing page if found
+    /// - Update order if changed
+    /// </summary>
+    /// <param name="existingPage"></param>
+    /// <param name="pageContent"></param>
+    /// <param name="matchingContents"></param>
+    private static void ProcessPageContent(PageDbEntity existingPage, PageContentDbEntity pageContent, List<PageContentDbEntity> matchingContents)
+    {
+        if (matchingContents.Count == 0)
+        {
+            existingPage.AllPageContents.Add(pageContent);
+            return;
+        }
 
-            var remainingMatchingContent = matchingContents[0];
-            if (remainingMatchingContent.Order != pageContent.Order)
-            {
-                remainingMatchingContent.Order = pageContent.Order;
-            }
+        RemoveDuplicates(existingPage, matchingContents);
+        UpdatePageContentOrder(pageContent, matchingContents);
+    }
+
+    /// <summary>
+    /// Updates the order of the page content if it's different
+    /// </summary>
+    /// <param name="pageContent"></param>
+    /// <param name="matchingContents"></param>
+    private static void UpdatePageContentOrder(PageContentDbEntity pageContent, List<PageContentDbEntity> matchingContents)
+    {
+        var remainingMatchingContent = matchingContents[0];
+
+        //Only change the order if it has actually changed, to prevent unnecessary updates to the DB by EF Core
+        if (remainingMatchingContent.Order != pageContent.Order)
+        {
+            remainingMatchingContent.Order = pageContent.Order;
+        }
+    }
+
+    /// <summary>
+    /// Remove duplicate page content entities
+    /// </summary>
+    /// <remarks>
+    /// Shouldn't be needed anymore, but exists to fix old data issues if they arise.
+    /// </remarks>
+    /// <param name="existingPage"></param>
+    /// <param name="matchingContents"></param>
+    private static void RemoveDuplicates(PageDbEntity existingPage, List<PageContentDbEntity> matchingContents)
+    {
+        if (matchingContents.Count > 1)
+        {
+            existingPage.AllPageContents.RemoveAll((pc) => matchingContents[1..].Contains(pc));
         }
     }
 }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
@@ -32,13 +32,11 @@ public class PageEntityUpdater(ILogger<PageEntityUpdater> logger, CmsDbContext d
     /// <param name="existingPage"></param>
     private void DeleteRemovedPageContents(PageDbEntity incomingPage, PageDbEntity existingPage)
     {
-        foreach (var pageContent in existingPage.AllPageContents)
-        {
-            if (HasPageContent(incomingPage, pageContent))
-            {
-                continue;
-            }
+        var contentsToRemove = existingPage.AllPageContents.Where(pageContent => !HasPageContent(incomingPage, pageContent))
+                                                            .ToArray();
 
+        foreach (var pageContent in contentsToRemove)
+        {
             existingPage.AllPageContents.Remove(pageContent);
             Db.PageContents.Remove(pageContent);
         }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
@@ -43,7 +43,7 @@ public class PageEntityUpdater(ILogger<PageEntityUpdater> logger, CmsDbContext d
     }
 
     private static bool HasPageContent(PageDbEntity page, PageContentDbEntity pageContent)
-     => page.AllPageContents.Any(pc => pc.Matches(pageContent));
+     => page.AllPageContents.Exists(pc => pc.Matches(pageContent));
 
     /// <summary>
     /// For each incoming page content:

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/PageEntityUpdater.cs
@@ -42,8 +42,6 @@ public class PageEntityUpdater(ILogger<PageEntityUpdater> logger, CmsDbContext d
     /// <param name="existingPage"></param>
     private static void DeleteRemovedPageContents(PageDbEntity incomingPage, PageDbEntity existingPage)
     {
-        var deletedPageContents = existingPage.AllPageContents.Where((existingPageContent) => !HasPageContent(incomingPage, existingPageContent)).ToList();
-
         existingPage.AllPageContents.RemoveAll((existingPageContent) => !HasPageContent(incomingPage, existingPageContent));
     }
 

--- a/src/Dfe.PlanTech.AzureFunctions/Models/MappedEntity.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Models/MappedEntity.cs
@@ -22,9 +22,9 @@ public class MappedEntity
 
     public bool AlreadyExistsInDatabase => ExistingEntity != null;
 
-    public bool IsRemovalEvent => CmsEvent == CmsEvent.UNPUBLISH || CmsEvent == CmsEvent.DELETE;
+    public bool IsMinimalPayloadEvent => CmsEvent == CmsEvent.UNPUBLISH || CmsEvent == CmsEvent.DELETE;
 
-    public bool ShouldCopyProperties => AlreadyExistsInDatabase && !IsRemovalEvent;
+    public bool ShouldCopyProperties => AlreadyExistsInDatabase && !IsMinimalPayloadEvent;
 
     /// <summary>
     /// Checks if the incoming entity is a valid component.
@@ -35,7 +35,7 @@ public class MappedEntity
     /// <returns>True if the entity is valid, false otherwise.</returns>
     public bool IsValidComponent(CmsDbContext db, ILogger logger)
     {
-        if (IsRemovalEvent)
+        if (IsMinimalPayloadEvent)
         {
             IsValid = true;
             return true;
@@ -131,7 +131,7 @@ public class MappedEntity
                     throw new CmsEventException(string.Format("Content with Id \"{0}\" has event 'delete' despite not existing in the database!", IncomingEntity.Id));
                 }
                 IncomingEntity.Deleted = true;
-                ExistingEntity.Deleted = false;
+                ExistingEntity.Deleted = true;
                 break;
         }
     }

--- a/src/Dfe.PlanTech.AzureFunctions/Models/MappedEntity.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Models/MappedEntity.cs
@@ -47,10 +47,9 @@ public class MappedEntity
         IsValid = string.IsNullOrEmpty(nullProperties);
 
         // Log a message if the entity is not valid.
-        // Log a message if the entity is not valid.
         if (!IsValid)
         {
-            logger.LogInformation(
+            logger.LogWarning(
                 "Content Component with ID {Id} is missing the following required properties: {NullProperties}",
                 IncomingEntity.Id,
                 nullProperties

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -213,6 +213,9 @@ public class CmsDbContext : DbContext, ICmsDbContext
         modelBuilder.Entity<ContentComponentDbEntity>().HasQueryFilter(ShouldShowEntity());
     }
 
+    public async Task<int> SetComponentPublishedAndDeletedStatuses(ContentComponentDbEntity contentComponent, bool published, bool deleted, CancellationToken cancellationToken = default)
+        => await Database.ExecuteSqlAsync($"UPDATE [Contentful].[ContentComponents] SET Published = {published}, Deleted = {deleted} WHERE [Id] = {contentComponent.Id}", cancellationToken: cancellationToken);
+
     /// <summary>
     /// Should the given entity be displayed? I.e. is it not archived, not deleted, and either published or use preview mode is enabled
     /// </summary>

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -5,7 +5,6 @@ using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
@@ -15,6 +14,10 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Dfe.PlanTech.AzureFunctions.Utils;
 using NSubstitute.ExceptionExtensions;
+using MockQueryable.NSubstitute;
+using Microsoft.EntityFrameworkCore.Query;
+using System.Linq.Expressions;
+using Dfe.PlanTech.AzureFunctions.Models;
 
 namespace Dfe.PlanTech.AzureFunctions.UnitTests;
 
@@ -28,21 +31,18 @@ public class QueueReceiverTests
     private readonly ILogger _loggerMock;
     private readonly CmsDbContext _cmsDbContextMock;
     private readonly JsonToEntityMappers _jsonToEntityMappers;
-    private readonly ServiceBusClient _serviceBusClientMock;
-    private readonly IConfiguration _configurationMock;
     private readonly IMessageRetryHandler _messageRetryHandlerMock;
-
-    private object? _addedObject = null;
 
     private readonly static QuestionDbEntity _contentComponent = new() { Archived = false, Published = true, Deleted = false, Id = _contentId };
     private readonly static QuestionDbEntity _otherContentComponent = new() { Archived = false, Published = true, Deleted = false, Id = "other-content-component" };
 
-    private readonly List<QuestionDbEntity> _existing = [_otherContentComponent];
+    private readonly List<QuestionDbEntity> _questions = [_otherContentComponent];
+    private readonly List<AnswerDbEntity> _answers = [];
+
+    private readonly List<ContentComponentDbEntity> _contentComponents = [];
 
     public QueueReceiverTests()
     {
-        _serviceBusClientMock = Substitute.For<ServiceBusClient>();
-        _configurationMock = Substitute.For<IConfiguration>();
         _loggerFactoryMock = Substitute.For<ILoggerFactory>();
         _loggerMock = Substitute.For<ILogger>();
         _messageRetryHandlerMock = Substitute.For<IMessageRetryHandler>();
@@ -53,17 +53,69 @@ public class QueueReceiverTests
         });
 
         _cmsDbContextMock = Substitute.For<CmsDbContext>();
-        IQueryable<QuestionDbEntity> queryable = _existing.AsQueryable();
         _cmsDbContextMock.SaveChangesAsync().Returns(1);
 
-        var asyncProvider = new AsyncQueryProvider<QuestionDbEntity>(queryable.Provider);
+        var mockQuestionSet = _questions.AsQueryable().BuildMockDbSet();
+        _cmsDbContextMock.Questions = mockQuestionSet;
+        _cmsDbContextMock.Set<QuestionDbEntity>().Returns(mockQuestionSet);
 
-        var mockSet = Substitute.For<DbSet<QuestionDbEntity>, IQueryable<QuestionDbEntity>>();
-        ((IQueryable<QuestionDbEntity>)mockSet).Provider.Returns(asyncProvider);
-        ((IQueryable<QuestionDbEntity>)mockSet).Expression.Returns(queryable.Expression);
-        ((IQueryable<QuestionDbEntity>)mockSet).ElementType.Returns(queryable.ElementType);
-        ((IQueryable<QuestionDbEntity>)mockSet).GetEnumerator().Returns(queryable.GetEnumerator());
+        _cmsDbContextMock.When(db => db.Add(Arg.Any<ContentComponentDbEntity>()))
+                                    .Do((callinfo) =>
+                                    {
+                                        var contentComponent = callinfo.ArgAt<ContentComponentDbEntity>(0);
 
+                                        if (contentComponent is QuestionDbEntity question)
+                                        {
+                                            _questions.Add(question);
+                                        }
+                                        else
+                                        {
+                                            Console.Write("Shouldn't hit this");
+                                        }
+                                    });
+
+
+        var answersDbSet = _answers.AsQueryable().BuildMockDbSet();
+        _cmsDbContextMock.Answers = answersDbSet;
+
+        MockEntityType();
+
+        _jsonToEntityMappers = CreateMappers();
+
+        var sub = Substitute.ForPartsOf<QueueReceiver>(new ContentfulOptions(true), _loggerFactoryMock, _cmsDbContextMock, _jsonToEntityMappers, _messageRetryHandlerMock);
+
+        sub.ProcessEntityRemovalEvent(Arg.Any<MappedEntity>(), Arg.Any<CancellationToken>())
+                        .ReturnsForAnyArgs((callinfo) =>
+                        {
+                            var mappedEntity = callinfo.ArgAt<MappedEntity>(0);
+
+                            var existingEntity = mappedEntity.ExistingEntity as QuestionDbEntity;
+
+                            var matching = _questions.FirstOrDefault(q => q.Id == existingEntity!.Id);
+
+                            matching!.Published = mappedEntity.IncomingEntity.Published;
+                            matching!.Deleted = mappedEntity.IncomingEntity.Deleted;
+
+                            return 1;
+                        });
+
+
+        _queueReceiver = sub;
+        DbSet<ContentComponentDbEntity> contentComponentsMock = MockContentComponents();
+        _cmsDbContextMock.ContentComponents = contentComponentsMock;
+    }
+
+    private DbSet<ContentComponentDbEntity> MockContentComponents()
+    {
+        _contentComponents.Add(_contentComponent);
+        _contentComponents.Add(_otherContentComponent);
+
+        var contentComponentsMock = _contentComponents.AsQueryable().BuildMockDbSet();
+        return contentComponentsMock;
+    }
+
+    private void MockEntityType()
+    {
         var entityTypeMock = Substitute.For<IEntityType>();
         entityTypeMock.ClrType.Returns(typeof(QuestionDbEntity));
 
@@ -81,38 +133,17 @@ public class QueueReceiverTests
         });
 
         entityTypeMock.GetProperties().Returns(questionProperties);
+    }
 
-        _cmsDbContextMock.Set<QuestionDbEntity>().Returns(mockSet);
-
+    private JsonToEntityMappers CreateMappers()
+    {
         JsonSerializerOptions jsonOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
         };
 
-        Type questionDbEntityType = typeof(QuestionDbEntity);
-
-        DbSet<AnswerDbEntity> _answerDbSet = Substitute.For<DbSet<AnswerDbEntity>>();
-
-        _cmsDbContextMock.Answers = _answerDbSet;
-
-        _answerDbSet.WhenForAnyArgs(answerDbSet => answerDbSet.Attach(Arg.Any<AnswerDbEntity>()))
-                    .Do(callinfo =>
-                    {
-                        var answer = callinfo.ArgAt<AnswerDbEntity>(0);
-                    });
-
-        _jsonToEntityMappers = Substitute.For<JsonToEntityMappers>(new JsonToDbMapper[] { new QuestionMapper(new EntityRetriever(_cmsDbContextMock), new EntityUpdater(Substitute.For<ILogger<EntityUpdater>>(), _cmsDbContextMock), _cmsDbContextMock, Substitute.For<ILogger<QuestionMapper>>(), jsonOptions) }, jsonOptions);
-
-        _queueReceiver = new QueueReceiver(new ContentfulOptions(true), _loggerFactoryMock, _cmsDbContextMock, _jsonToEntityMappers, _messageRetryHandlerMock);
-
-        _cmsDbContextMock.Add(Arg.Any<ContentComponentDbEntity>()).Returns(callinfo =>
-        {
-            var added = callinfo.ArgAt<ContentComponentDbEntity>(0);
-            _addedObject = added;
-
-            return null!;
-        });
+        return Substitute.For<JsonToEntityMappers>(new JsonToDbMapper[] { new QuestionMapper(new EntityRetriever(_cmsDbContextMock), new EntityUpdater(Substitute.For<ILogger<EntityUpdater>>(), _cmsDbContextMock), _cmsDbContextMock, Substitute.For<ILogger<QuestionMapper>>(), jsonOptions) }, jsonOptions);
     }
 
     [Fact]
@@ -132,12 +163,14 @@ public class QueueReceiverTests
         await _cmsDbContextMock.ReceivedWithAnyArgs(1).SaveChangesAsync(Arg.Any<CancellationToken>());
         _cmsDbContextMock.ReceivedWithAnyArgs(1).Add(Arg.Any<ContentComponentDbEntity>());
 
-        Assert.NotNull(_addedObject);
 
-        var asContentComponentDbEntity = _addedObject as ContentComponentDbEntity;
+        Assert.Equal(2, _questions.Count);
+
+        var addedQuestion = _questions[1];
+
+        var asContentComponentDbEntity = addedQuestion as ContentComponentDbEntity;
 
         Assert.NotNull(asContentComponentDbEntity);
-
         Assert.Equal(_contentId, asContentComponentDbEntity.Id);
     }
 
@@ -162,7 +195,7 @@ public class QueueReceiverTests
     [Fact]
     public async Task QueueReceiverDbWriter_Should_MapExistingDbEntity_To_Message()
     {
-        _existing.Add(_contentComponent);
+        _questions.Add(_contentComponent);
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
 
@@ -195,7 +228,8 @@ public class QueueReceiverTests
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
 
-        var added = _addedObject as ContentComponentDbEntity;
+        Assert.Equal(2, _questions.Count);
+        var added = _questions[1];
         Assert.NotNull(added);
         Assert.True(added.Archived);
     }
@@ -203,7 +237,7 @@ public class QueueReceiverTests
     [Fact]
     public async Task QueueReceiverDbWriter_Should_CompleteSuccessfully_After_Unarchive()
     {
-        _existing.Add(_contentComponent);
+        _questions.Add(_contentComponent);
         _contentComponent.Archived = true;
 
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
@@ -218,7 +252,10 @@ public class QueueReceiverTests
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
 
-        Assert.Null(_addedObject);
+        Assert.Equal(2, _questions.Count);
+        var added = _questions[1];
+        Assert.NotNull(added);
+        Assert.False(added.Archived);
     }
 
     [Fact]
@@ -238,7 +275,8 @@ public class QueueReceiverTests
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
 
-        var added = _addedObject as ContentComponentDbEntity;
+        Assert.Equal(2, _questions.Count);
+        var added = _questions[1];
         Assert.NotNull(added);
         Assert.True(added.Published);
     }
@@ -264,9 +302,9 @@ public class QueueReceiverTests
     [Fact]
     public async Task QueueReceiverDbWriter_Should_CompleteSuccessfully_After_Existing_Unpublish()
     {
-        _existing.Add(_contentComponent);
+        _questions.Add(_contentComponent);
 
-        _contentComponent.Published = false;
+        _contentComponent.Published = true;
 
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
@@ -281,13 +319,18 @@ public class QueueReceiverTests
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
         _cmsDbContextMock.ReceivedWithAnyArgs(0).Add(Arg.Any<ContentComponentDbEntity>());
         await _cmsDbContextMock.ReceivedWithAnyArgs(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+
+        Assert.Equal(2, _questions.Count);
+
+        var question = _questions[1];
+        Assert.False(question.Published);
     }
 
     [Fact]
     public async Task QueueReceiverDbWriter_Should_CompleteSuccessfully_After_Delete()
     {
         _contentComponent.Deleted = false;
-        _existing.Add(_contentComponent);
+        _questions.Add(_contentComponent);
 
         ServiceBusReceivedMessage serviceBusReceivedMessageMock = Substitute.For<ServiceBusReceivedMessage>();
         ServiceBusMessageActions serviceBusMessageActionsMock = Substitute.For<ServiceBusMessageActions>();
@@ -302,7 +345,8 @@ public class QueueReceiverTests
         await serviceBusMessageActionsMock.Received()
                                           .CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
 
-        Assert.Null(_addedObject);
+        Assert.Equal(2, _questions.Count);
+        Assert.True(_questions[1].Deleted);
     }
 
     [Fact]
@@ -322,8 +366,7 @@ public class QueueReceiverTests
 
         await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
 
-        var added = _addedObject as ContentComponentDbEntity;
-        Assert.Null(added);
+        Assert.Single(_questions);
     }
 
 
@@ -345,8 +388,7 @@ public class QueueReceiverTests
         await serviceBusMessageActionsMock.Received()
                                           .CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
 
-        var added = _addedObject as ContentComponentDbEntity;
-        Assert.Null(added);
+        Assert.Single(_questions);
     }
 
     [Fact]
@@ -383,8 +425,7 @@ public class QueueReceiverTests
         await serviceBusMessageActionsMock.Received()
                                           .CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
 
-        var added = _addedObject as ContentComponentDbEntity;
-        Assert.Null(added);
+        Assert.Single(_questions);
     }
 
     [Fact]
@@ -403,8 +444,7 @@ public class QueueReceiverTests
         await serviceBusMessageActionsMock.Received()
                                           .CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
 
-        var added = _addedObject as ContentComponentDbEntity;
-        Assert.Null(added);
+        Assert.Single(_questions);
     }
 
     [Fact]
@@ -424,12 +464,7 @@ public class QueueReceiverTests
 
         await _queueReceiver.QueueReceiverDbWriter([serviceBusReceivedMessage], serviceBusMessageActionsMock, CancellationToken.None);
 
-        await serviceBusMessageActionsMock.Received()
-            .CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
-
-        var added = _addedObject as ContentComponentDbEntity;
-        Assert.NotNull(added);
-        Assert.True(added.Published);
+        await serviceBusMessageActionsMock.Received().CompleteMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -450,9 +485,5 @@ public class QueueReceiverTests
         await _queueReceiver.QueueReceiverDbWriter([serviceBusReceivedMessage], serviceBusMessageActionsMock, CancellationToken.None);
 
         await serviceBusMessageActionsMock.Received().DeadLetterMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), null, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-
-        var added = _addedObject as ContentComponentDbEntity;
-        Assert.NotNull(added);
-        Assert.True(added.Published);
     }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -486,4 +486,10 @@ public class QueueReceiverTests
 
         await serviceBusMessageActionsMock.Received().DeadLetterMessageAsync(Arg.Any<ServiceBusReceivedMessage>(), null, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task ProcessEntityRemovalEvent_Should_Throw_Exception_If_Entity_Null()
+    {
+        await Assert.ThrowsAsync<NullReferenceException>(() => _queueReceiver.ProcessEntityRemovalEvent(null!, CancellationToken.None));
+    }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -490,6 +490,6 @@ public class QueueReceiverTests
     [Fact]
     public async Task ProcessEntityRemovalEvent_Should_Throw_Exception_If_Entity_Null()
     {
-        await Assert.ThrowsAsync<InvalidOperationException>(() => _queueReceiver.ProcessEntityRemovalEvent(null!, CancellationToken.None));
+        await Assert.ThrowsAnyAsync<Exception>(() => _queueReceiver.ProcessEntityRemovalEvent(null!, CancellationToken.None));
     }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -490,6 +490,6 @@ public class QueueReceiverTests
     [Fact]
     public async Task ProcessEntityRemovalEvent_Should_Throw_Exception_If_Entity_Null()
     {
-        await Assert.ThrowsAsync<NullReferenceException>(() => _queueReceiver.ProcessEntityRemovalEvent(null!, CancellationToken.None));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _queueReceiver.ProcessEntityRemovalEvent(null!, CancellationToken.None));
     }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityUpdaterTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Mappers/PageEntityUpdaterTests.cs
@@ -24,25 +24,29 @@ public class PageEntityUpdaterTests
       {
           ContentComponentId = "A",
           Order = 2,
-          PageId = PageId
+          PageId = PageId,
+          Id = 1,
       },
         new PageContentDbEntity()
         {
             ContentComponentId = "B",
             Order = 1,
-            PageId = PageId
+            PageId = PageId,
+            Id = 2
         },
         new PageContentDbEntity()
         {
             BeforeContentComponentId = "D",
             Order = 2,
-            PageId = PageId
+            PageId = PageId,
+            Id = 3
         },
         new PageContentDbEntity()
         {
             BeforeContentComponentId = "E",
             Order = 1,
-            PageId = PageId
+            PageId = PageId,
+            Id = 4
         }
     ];
 
@@ -97,7 +101,7 @@ public class PageEntityUpdaterTests
     }
 
     [Fact]
-    public void Should_AddOrUpddotnetate_NewAndExistingPageComponents()
+    public void Should_AddOrUpdate_NewAndExistingPageComponents()
     {
         var addedEntity = new PageContentDbEntity()
         {
@@ -136,6 +140,38 @@ public class PageEntityUpdaterTests
         Assert.Equivalent(2, eContent!.Order);
     }
 
+    [Fact]
+    public void Should_Delete_Removed_Entities()
+    {
+        var removedEntity = _pageContents.First();
+
+        var pageId = "page-id";
+
+        var existingPage = new PageDbEntity()
+        {
+            AllPageContents = [.. _pageContents],
+            Id = pageId
+        };
+
+        var incomingPage = new PageDbEntity()
+        {
+            AllPageContents = [.. _pageContents.Skip(1)],
+            Id = pageId
+        };
+
+        var mappedEntity = new MappedEntity()
+        {
+            IncomingEntity = incomingPage,
+            ExistingEntity = existingPage,
+            CmsEvent = CmsEvent.SAVE
+        };
+
+        _updater.UpdateEntityConcrete(mappedEntity);
+
+        Assert.DoesNotContain(removedEntity, existingPage.AllPageContents);
+    }
+
+
     private static readonly Func<PageContentDbEntity, PageContentDbEntity> InverseOrder
       = pc => new PageContentDbEntity()
       {
@@ -144,28 +180,4 @@ public class PageEntityUpdaterTests
           PageId = pc.PageId,
           Order = pc.Order == 1 ? 2 : 1
       };
-
-    [Fact]
-    public void Should_Delete_Removed_Entities()
-    {
-        var removedEntity = _pageContents.First();
-
-        var mappedEntity = new MappedEntity()
-        {
-            IncomingEntity = new PageDbEntity()
-            {
-                AllPageContents = [.. _pageContents.Skip(1)],
-                Id = "page-id"
-            },
-            ExistingEntity = new PageDbEntity()
-            {
-                AllPageContents = [.. _pageContents]
-            },
-            CmsEvent = CmsEvent.SAVE
-        };
-
-        _updater.UpdateEntityConcrete(mappedEntity);
-
-        Assert.DoesNotContain(removedEntity, _pageContents);
-    }
 }

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Utils/MessageRetryHandlerTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Utils/MessageRetryHandlerTests.cs
@@ -42,7 +42,7 @@ public class MessageRetryHandlerTests
 
         var retryRequired = await _messageRetryHandler.RetryRequired(serviceBusReceivedMessage, CancellationToken.None);
 
-        _serviceBusSender.Received(1).SendMessageAsync(Arg.Any<ServiceBusMessage>());
+        await _serviceBusSender.Received(1).SendMessageAsync(Arg.Any<ServiceBusMessage>());
 
         Assert.True(retryRequired);
     }


### PR DESCRIPTION
# Fixes issue with page contents not updating correctly

1. Retrieve the `Id` column for the `PageContents` table joins when retrieving the existing page from the DB
   - The lack of this was causing the code that removed duplicate content to fail (hard to delete something without the PK).
2. Don't use the specific `Content` and `BeforeTitleContent` fields in the existing entity when doing any mapping; just amend the `AllPageContent` field.
   - This was causing errors as EF Core was assuming that these fields + AllPageContents had different copies of the same data.

# Other changes

1. Don't bother with extra mapping when processing an `UNPUBLISH` or `DELETE` event.
    - Shouldn't fix anything, but should just slightly speed up these events, and reduce any chances of errors.
    - This could be further improved by not even bothering to retrieve the existing entity for these events, just use EF Core's `<DbContextObject>.<DbSetField>.ExecuteUpdateAsync` command.
2. If a message failed and is being retried, log the exception
    - We only logged the exception if all retries failed. This made debugging painful.
3. Split up a function or two in the `PageEntityUpdater.cs` class
   - Just makes it a bit easier to read in terms of understanding what's going on.