### PR TITLE
fix: Feedback banner alignment

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Content/Shared/_Feedback.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Content/Shared/_Feedback.cshtml
@@ -14,43 +14,43 @@
 
 @if (track)
 {
-        <div class="dfe-feedback-banner govuk-!-margin-top-9 js-only govuk-!-display-none-print" id="feedback-banner">
-            <div class="dfe-feedback-banner--content">
-                <form id="feedbackForm">
-                    <div class="dfe-feedback-banner--content-questions">
-                        <div class="dfe-feedback-banner--content-question" id="questionForm">
-                            <h2 class="govuk-heading-s dfe-feedback-banner--content-question-text">
-                                Is this page
-                                useful?
-                            </h2>
-                            <div class="govuk-button-group">
-                                <button id="feedbackYes" type="button" class="govuk-button govuk-button--secondary" value="Yes"
-                                        data-module="govuk-button">
-                                    Yes
-                                </button>
-                                <button id="feedbackNo" type="button" class="govuk-button govuk-button--secondary" value="No"
-                                        data-module="govuk-button">
-                                    No
-                                </button>
-                            </div>
-                        </div>
+    <div class="dfe-feedback-banner govuk-!-margin-top-9 js-only govuk-!-display-none-print" id="feedback-banner">
+    <div class="dfe-feedback-banner--content">
+        <form id="feedbackForm">
+            <div>
+                <div class="dfe-feedback-banner--content-question" id="questionForm">
+                    <h2 class="govuk-heading-s dfe-feedback-banner--content-question-text">
+                        Is this page
+                        useful?
+                    </h2>
+                    <div class="govuk-button-group">
+                        <button id="feedbackYes" type="button" class="govuk-button govuk-button--secondary" value="Yes"
+                            data-module="govuk-button">
+                            Yes
+                        </button>
+                        <button id="feedbackNo" type="button" class="govuk-button govuk-button--secondary" value="No"
+                            data-module="govuk-button">
+                            No
+                        </button>
                     </div>
-                    <div id="feedbackMessage" class="govuk-body govuk-!-margin-bottom-0">
-                        Thank you for your feedback.
-                    </div>
-                </form>
+                </div>
             </div>
-        </div>
+            <div id="feedbackMessage" class="govuk-body govuk-!-margin-bottom-0">
+                Thank you for your feedback.
+            </div>
+        </form>
+    </div>
+</div>
 
-        <script nonce="@Context.Items["nonce"]">
-        function onAction (){
-            document.getElementById('questionForm').style.display = 'none';
-            document.getElementById('feedbackMessage').style.display = 'block';
-        }
+    <script nonce="@Context.Items["nonce"]">
+    function onAction() {
+        document.getElementById('questionForm').style.display = 'none';
+        document.getElementById('feedbackMessage').style.display = 'block';
+    }
 
-        const YesBtn = document.getElementById('feedbackYes')
-        const NoBtn = document.getElementById('feedbackNo')
-        YesBtn.addEventListener('click', ()=>onAction());
-        NoBtn.addEventListener('click', ()=>onAction());
-    </script>
+    const YesBtn = document.getElementById('feedbackYes')
+    const NoBtn = document.getElementById('feedbackNo')
+    YesBtn.addEventListener('click', () => onAction());
+    NoBtn.addEventListener('click', () => onAction());
+</script>
 }

--- a/src/Dfe.PlanTech.Web/wwwroot/css/cands-site.css
+++ b/src/Dfe.PlanTech.Web/wwwroot/css/cands-site.css
@@ -96,16 +96,9 @@ video {
     line-height: 1.333;
 }
 
-.dfe-feedback-banner--content-questions {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-}
-
 .dfe-feedback-banner--content-question {
     display: flex;
-    align-items: center;
+    align-items: baseline;
 }
 
 .dfe-feedback-banner


### PR DESCRIPTION
## Overview

Improve alignment of elements in the feedback banner on C&S pages as per 237765.

## Changes

### Minor

- Change alignment to `baseline` not `center`
- Remove superfluous class + styling from parent element

## How to review the PR

Load the web app and compare the alignment of elements in the feedback banner on C&S pages.

Currently should look like this:
![image](https://github.com/user-attachments/assets/9d0e2f8d-5331-4941-9c7c-aa517efde713)

This PR should improve it to look like this:
<img width="934" alt="image" src="https://github.com/user-attachments/assets/862c1906-4caa-403e-8ceb-940d15588032" />

## Additional notes

1. The CSS class names used for the feedback banner should be fixed when possible. Looks like they're supposed to use BEM convention but they're not quite right
2. Same with using CSS classes when an ID is more appropriate
3. Should move the CSS for `cands-site.css` to the Node project, maybe not bundle it but at least then we can minify it.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch