### PR TITLE
feat(265045): link to your-self-assessment chunk in recommendations overview

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Recommendations/Content.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/Content.cshtml
@@ -17,7 +17,7 @@
             <div class="govuk-inset-text">
                 <p>
                     The self-assessment for @sectionName.ToLower() was completed on
-                    <strong>@submissionDate</strong>. You can change your answers at any time.
+                    <strong>@submissionDate</strong>. You can <a href="#your-self-assessment" class="govuk-link">change your answers at any time</a>.
                 </p>
             </div>
         }


### PR DESCRIPTION
## Overview

Addresses ticket [#265045](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/265045)

Adds hyperlink to introductory text in the recommendations overview to take users to the 'your self assessment chunk'.

## Changes

### Minor

- Added hyperlink

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
