### PR TITLE
Fix/cherry picks as unable to merge

### DIFF
--- a/.github/workflows/qa-viz.yml
+++ b/.github/workflows/qa-viz.yml
@@ -47,8 +47,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.0.x   # required to run your net8.0 app
-            9.0.x   # optional if you also build/test anything targeting net9.0
+            8.0.x
+            9.0.x
 
       - name: Login with AZ
         uses: ./.github/actions/azure-login


### PR DESCRIPTION
Cherry-picking the latest commits on main and pushing them to development so that we get around the 'unable to merge' problem.