### PR TITLE
fix: remove logger message for null SectionStatusDto as null SectionS…

### DIFF
--- a/src/Dfe.PlanTech.Web/ViewBuilders/CategoryLandingViewComponentViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/CategoryLandingViewComponentViewBuilder.cs
@@ -76,10 +76,6 @@ public class CategoryLandingViewComponentViewBuilder(
             }
 
             var sectionStatus = sectionStatuses.FirstOrDefault(sectionStatus => sectionStatus.SectionId.Equals(section.Id));
-            if (sectionStatus is null)
-            {
-                Logger.LogError("No section status found for subtopic with ID {sectionId} and name {sectionName}", section.Id, section.Name);
-            }
 
             var recommendations = await GetCategoryLandingSectionRecommendations(establishmentId, section, sectionStatus);
 


### PR DESCRIPTION
## Overview

Addresses ticket [#275609](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/275609)

Remove unnecessary null check and logging for section status when building the Category Landing view.

## Changes

### Minor

- Remove null check and log

## How to review the PR

Load a category landing page for a category where any of the section are in a status of 'Not started' and check logs - should no longer show the 'No section status found...' message

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
