### PR TITLE
(tests): Disable new E2E playwright tests tin PR

### DIFF
--- a/.github/workflows/e2e-test-playwright.yml
+++ b/.github/workflows/e2e-test-playwright.yml
@@ -10,13 +10,13 @@ on:
         options: ['Dev', 'StagingUnprotected']
         default: 'Dev'
 
-  pull_request:
-    branches: ['main', 'development']
-    paths:
-      - 'src/**'
-      - 'tests/Dfe.PlanTech.Web.E2ETests.Beta/**'
-      - '.github/workflows/e2e-tests-playwright.yml'
-      - '.gitmodules'
+  # pull_request:
+  #   branches: ['main', 'development']
+  #   paths:
+  #     - 'src/**'
+  #     - 'tests/Dfe.PlanTech.Web.E2ETests.Beta/**'
+  #     - '.github/workflows/e2e-tests-playwright.yml'
+  #     - '.gitmodules'
 
 concurrency:
     group: "${{ github.workflow }}"


### PR DESCRIPTION
Temporarily disable the new e2e tests in the PR pipeline as we need to create a new set of lighter smoke tests instead of running the full suite of tests.