### PR TITLE
feature: Allow MAT users to access the home page if they have selected an establishment

### DIFF
--- a/src/Dfe.PlanTech.Web/ViewBuilders/PagesViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/PagesViewBuilder.cs
@@ -27,7 +27,8 @@ public class PagesViewBuilder(
 
     public async Task<IActionResult> RouteBasedOnOrganisationTypeAsync(Controller controller, PageEntry page)
     {
-        if (string.Equals(page.Slug, UrlConstants.HomePage.Replace("/", "")) && CurrentUser.IsMat)
+        var isMatUserWhoNeedsToSelectSchool = CurrentUser.IsMat && CurrentUser.GroupSelectedSchoolUrn is null;
+        if (isMatUserWhoNeedsToSelectSchool)
         {
             return controller.Redirect(UrlConstants.SelectASchoolPage);
         }


### PR DESCRIPTION
This is a teeny PR just to enable MAT users the ability to access the establishment home page.

The functionality is not complete (e.g. security checks to validate the selected school exists and is one the user is permitted to access, and displaying the _establishment_ name etc.) but will unblock additional testing and exploration to understand what currently works/doesn't work.