### PR TITLE
fix: Add verification that the selected school is one which the user is permitted to view and access (i.e., it exists, and is within "my" group)

### DIFF
--- a/src/Dfe.PlanTech.Web/Context/CurrentUser.cs
+++ b/src/Dfe.PlanTech.Web/Context/CurrentUser.cs
@@ -27,8 +27,7 @@ public class CurrentUser(IHttpContextAccessor contextAccessor) : ICurrentUser
 
     public int? MatEstablishmentId => GetIntFromClaim(ClaimConstants.DB_MAT_ESTABLISHMENT_ID);
 
-    public EstablishmentModel Organisation => _contextAccessor.HttpContext?.User.Claims.GetOrganisation()
-            ?? throw new InvalidDataException($"Could not parse user's {nameof(Organisation)} claim");
+    public EstablishmentModel? Organisation => _contextAccessor.HttpContext?.User.Claims.GetOrganisation();
 
     public int? UserId => GetIntFromClaim(ClaimConstants.DB_USER_ID);
 

--- a/src/Dfe.PlanTech.Web/Context/Interfaces/ICurrentUser.cs
+++ b/src/Dfe.PlanTech.Web/Context/Interfaces/ICurrentUser.cs
@@ -11,7 +11,7 @@ public interface ICurrentUser
     bool IsAuthenticated { get; }
     bool IsMat { get; }
     int? MatEstablishmentId { get; }
-    EstablishmentModel Organisation { get; }
+    EstablishmentModel? Organisation { get; }
     int? UserId { get; }
     string? GetGroupSelectedSchool();
     bool IsInRole(string role);

--- a/tests/Dfe.PlanTech.Web.UnitTests/Context/CurrentUserTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Context/CurrentUserTests.cs
@@ -146,16 +146,23 @@ public class CurrentUserTests
     }
 
     [Fact]
-    public void Organisation_Throws_When_Claim_Missing_And_IsMat_Also_Throws()
+    public void Organisation_When_ClaimsNotPresent_OrganisationIsNull()
     {
+        // Arrange - no Organisation claim
         var (sut, _) = Build();
 
-        var ex1 = Assert.Throws<InvalidDataException>(() => _ = sut.Organisation);
-        Assert.Equal("Could not parse user's Organisation claim", ex1.Message);
+        // Act / Assert
+        Assert.Null(sut.Organisation);
+    }
 
-        // Because the getter throws, IsMat will propagate that exception too
-        var ex2 = Assert.Throws<InvalidDataException>(() => _ = sut.IsMat);
-        Assert.Equal("Could not parse user's Organisation claim", ex2.Message);
+    [Fact]
+    public void Organisation_When_ClaimsNotPresent_Then_IsMatIsFalse()
+    {
+        // Arrange - no Organisation claim
+        var (sut, _) = Build();
+
+        // Act / Assert
+        Assert.False(sut.IsMat);
     }
 
     [Fact]
@@ -221,13 +228,4 @@ public class CurrentUserTests
         Assert.Contains("samesite=strict", setCookie.ToLowerInvariant());
     }
 
-    // ---------- EstablishmentModel via extension ----------
-
-    [Fact]
-    public void GetEstablishmentModel_Throws_When_Not_Present()
-    {
-        var (sut, _) = Build();
-        var ex = Assert.Throws<InvalidDataException>(() => sut.Organisation);
-        Assert.Equal("Could not parse user's Organisation claim", ex.Message);
-    }
 }


### PR DESCRIPTION
## Overview
This PR:
- Fixes a nullability issue where a user's `Organisation` will be `null` when not logged in.
- Adds validation/verification to restrict MAT users being able to select establishments that are outside of "their" MAT.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
