### PR TITLE
feature: Redirect to the home page after selecting a school

### DIFF
--- a/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
@@ -38,7 +38,7 @@ public class GroupsController : BaseController<GroupsController>
         await _groupsViewBuilder.RecordGroupSelectionAsync(schoolUrn, schoolName);
         _currentUser.SetGroupSelectedSchool(schoolUrn);
 
-        return RedirectToAction(GetSchoolDashboardAction);
+        return Redirect(UrlConstants.HomePage);
     }
 
     [HttpGet($"{UrlConstants.GroupsSlug}/{UrlConstants.GroupsDashboardSlug}", Name = GetSchoolDashboardAction)]

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/GroupsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/GroupsControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using Dfe.PlanTech.Web.Context.Interfaces;
+﻿using Dfe.PlanTech.Core.Constants;
+using Dfe.PlanTech.Web.Context.Interfaces;
 using Dfe.PlanTech.Web.Controllers;
 using Dfe.PlanTech.Web.ViewBuilders.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -68,8 +69,8 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
             await _viewBuilder.Received(1).RecordGroupSelectionAsync(schoolUrn, schoolName);
             _currentUser.Received(1).SetGroupSelectedSchool(schoolUrn);
 
-            var redirectResult = Assert.IsType<RedirectToActionResult>(result);
-            Assert.Equal(GroupsController.GetSchoolDashboardAction, redirectResult.ActionName);
+            var redirect = Assert.IsType<RedirectResult>(result);
+            Assert.Equal(UrlConstants.HomePage, redirect.Url);
         }
 
         [Fact]


### PR DESCRIPTION
## Overview

A small change to have MAT users redirected to the home page (instead of the to-be-removed group dashboard).


## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated

