### PR TITLE
288358 fix to back link not taking users to their previous question

### DIFF
--- a/src/Dfe.PlanTech.Web/ViewBuilders/QuestionsViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/QuestionsViewBuilder.cs
@@ -291,13 +291,18 @@ public class QuestionsViewBuilder(
             Logger.LogError(e, "An error occurred while submitting an answer with the following message: {Message} ", e.Message);
             var viewModel = GenerateViewModel(controller, question, section, categorySlug, sectionSlug, questionSlug, null);
             viewModel.ErrorMessages = ["Save failed. Please try again later."];
+
             return controller.View(QuestionView, viewModel);
         }
 
         var nextQuestion = await _questionService.GetNextUnansweredQuestion(activeEstablishmentId, section);
         if (nextQuestion is not null)
         {
-            return await RouteBySlugAndQuestionAsync(controller, categorySlug, sectionSlug, nextQuestion.Slug, returnTo);
+            return controller.RedirectToAction(
+                nameof(QuestionsController.GetQuestionBySlug),
+                QuestionsController.Controller,
+                new { categorySlug, sectionSlug, questionSlug = nextQuestion.Slug, returnTo }
+            );
         }
 
         // No next questions so check answers

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/QuestionsViewBuilderTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/QuestionsViewBuilderTests.cs
@@ -360,7 +360,7 @@ public class QuestionsViewBuilderTests
         // Assert
         await _submissionSvc.Received(1).SubmitAnswerAsync(11, 22, null, Arg.Any<SubmitAnswerModel>());
 
-        var redirect = Assert.IsType<ViewResult>(result);
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
     }
 
     // ---------- RouteToContinueSelfAssessmentPage ----------


### PR DESCRIPTION
## Overview

fix to back link not taking users to their previous question

Addresses ticket [#288358](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/288358)

problem before: It was executing the GET logic directly and returning the result view. That meant the view was being served at the end of a POST request

now: browser performs a new GET request to the same destination (RouteBySlugAndQuestionAsync)

## How to review the PR

start new submission, answers first question then press 'back' on the next question - this should return you to the previous answered question and not to the interstitial page

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [ ] E2E tests have been added/updated
- [ ] GitHub workflows/actions have been added/updated
- [ ] Terraform has been updated
- [ ] Documentation has been updated where relevant
- [ ] Any Key Vault secrets have been added to the development Key Vault
