### PR TITLE
Fix print links to be more specific to endpoint

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Recommendations/SingleRecommendation.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/SingleRecommendation.cshtml
@@ -30,13 +30,22 @@
                     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break govuk-section-break--visible custom-hr-blue">
                     <h2 class="govuk-heading-m govuk-!-padding-top-4">Related actions</h2>
                     <p class="govuk-body-s">
-                        <a class="govuk-link" href="print/@Model.CurrentChunkPosition">
+                        <a class="govuk-link"
+                           asp-route="GetRecommendationChecklist"
+                           asp-route-categorySlug="@Model.CategorySlug"
+                           asp-route-sectionSlug="@Model.SectionSlug"
+                           asp-route-currentRecommendationCount="@Model.CurrentChunkPosition">
                             Print this recommendation
                         </a>
                     </p>
 
                     <p class="govuk-body-s">
-                        <a class="govuk-link" href="print">Print your school's @Model.Section.Name.ToLower() recommendations</a>
+                        <a class="govuk-link"
+                           asp-route="GetRecommendationChecklist"
+                           asp-route-categorySlug="@Model.CategorySlug"
+                           asp-route-sectionSlug="@Model.SectionSlug">
+                            Print your school's @Model.Section.Name.ToLower() recommendations
+                        </a>
                     </p>
                 </div>
                 <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Overview

updated print links to be more specific so appended URL params are ignored (e.g. update-status after status is updated before going to print page)

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [ ] Unit tests have been added/updated
- [ ] E2E tests have been added/updated
- [ ] GitHub workflows/actions have been added/updated
- [ ] Terraform has been updated
- [ ] Documentation has been updated where relevant
- [ ] Any Key Vault secrets have been added to the development Key Vault
