### PR TITLE
fix: restrict push triggers to 'main' branch only in matrix-deploy.yml

### DIFF
--- a/.github/workflows/matrix-deploy.yml
+++ b/.github/workflows/matrix-deploy.yml
@@ -3,7 +3,7 @@ name: Multi stage build & deploy
 on:
   workflow_dispatch:
   push:
-    branches: ['main', 'development']
+    branches: ['main']
     paths:
       - 'src/**'
       - '.github/actions/**'


### PR DESCRIPTION
## Overview

Addresses ticket [#310551](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/310551)

Stop auto-releasing to dev on PR completion.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch