### PR TITLE
fix: Activity log now shows no additional message when note text is blank

### DIFF
--- a/src/Dfe.PlanTech.Web/ViewBuilders/RecommendationsViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/RecommendationsViewBuilder.cs
@@ -125,14 +125,16 @@ public class RecommendationsViewBuilder(
             OriginatingSlug = chunkSlug,
             History = groupedHistory,
             FirstActivity = firstActivity,
-            RelatedActions = currentRecommendationChunk.RelatedActions?
-                .Where(x => x is not null)
-                .Select(x => new RelatedActionViewModel
-                {
-                    Text = x.Title ?? string.Empty,
-                    Url = x.Url ?? string.Empty,
-                })
-                .ToList() ?? [],
+            RelatedActions =
+                currentRecommendationChunk
+                    .RelatedActions?.Where(x => x is not null)
+                    .Select(x => new RelatedActionViewModel
+                    {
+                        Text = x.Title ?? string.Empty,
+                        Url = x.Url ?? string.Empty,
+                    })
+                    .ToList()
+                ?? [],
         };
 
         return controller.View(SingleRecommendationViewName, viewModel);
@@ -291,16 +293,19 @@ public class RecommendationsViewBuilder(
             ["recStatus"] = selectedStatusEnum.Value.GetDisplayName(),
         };
 
+        string? defaultNoteText = await _microcopyProvider.GetTextByKeyAsync(
+            ContentfulMicrocopyConstants.SingleRecommendationHistoryReason,
+            dynamicValues
+        );
+
+        defaultNoteText = string.IsNullOrWhiteSpace(defaultNoteText) ? null : defaultNoteText;
+
         await _recommendationService.UpdateRecommendationStatusAsync(
             currentRecommendationChunk.Id,
             establishmentId,
             userId,
             selectedStatusEnum.Value,
-            notes
-                ?? await _microcopyProvider.GetTextByKeyAsync(
-                    ContentfulMicrocopyConstants.SingleRecommendationHistoryReason,
-                    dynamicValues
-                ),
+            notes ?? defaultNoteText,
             CurrentUser.IsMat ? userOrganisationId : null
         );
 

--- a/tests/Dfe.PlanTech.Web.SeedTestData/README.md
+++ b/tests/Dfe.PlanTech.Web.SeedTestData/README.md
@@ -42,23 +42,36 @@ npm install -g sql-cli
 Then run `./scripts/setup-sql-cli.sh` from the project root and pass a server name and password as arguments. For example:
 
 - Mac/Linux
+
   ```bash
   ./scripts/setup-sql-cli.sh azuresqledge Pa5ssw0rd@G0esH3r3
   ```
+
 - Windows
+
   ```bash
   sh scripts/setup-sql-cli.sh azuresqledge Pa5ssw0rd@G0esH3r3
   ```
 
 #### Standard Setup
 
-If your machine does support `sqlcmd` you can skip installing `sql-cli` and just run `scripts/setup.sh` with a server name and admin password as arguments. For example:
+If your machine does support `sqlcmd` you can skip installing `sql-cli` and just run `scripts/setup.sh` with a server name and admin password as arguments. The password must be at least 8 characters long and contain characters from three of the following four sets:
+
+- Uppercase letters
+- Lowercase letters
+- Base 10 digits
+- Symbols
+
+For example:
 
 - Mac/Linux
+
   ```bash
   ./scripts/setup.sh azuresqledge Pa5ssw0rd@G0esH3r3
   ```
+
 - Windows
+
   ```bash
   sh scripts/setup.sh azuresqledge Pa5ssw0rd@G0esH3r3
   ```
@@ -78,9 +91,11 @@ If you don't have docker and have an MSSQL instance to use instead, you need to
 1. Create a new database
 2. Follow the instructions in the [Database Upgrader Readme](../../src/Dfe.PlanTech.DatabaseUpgrader/README.md) to run the database upgrader against your database
 3. Set the connection string to the database in the dotnet secrets for this project using the command
+
    ```bash
    dotnet user-secrets set "ConnectionStrings:Database" <connection_string>
    ```
+
 4. Run this project to populate the database with the test data
 
 ### Using Plan Tech With Local Test Database

--- a/tests/Dfe.PlanTech.Web.SeedTestData/scripts/setup.sh
+++ b/tests/Dfe.PlanTech.Web.SeedTestData/scripts/setup.sh
@@ -1,24 +1,33 @@
+set -euo pipefail
+
 name=$1
 password=$2
 
-docker run --cap-add SYS_PTRACE -e 'ACCEPT_EULA=1' -e "MSSQL_SA_PASSWORD=$password" -p 1433:1433 --name $name -d mcr.microsoft.com/azure-sql-edge
+docker run \
+  --cap-add SYS_PTRACE \
+  -e 'ACCEPT_EULA=1' \
+  -e "MSSQL_SA_PASSWORD=$password" \
+  -p 1433:1433 \
+  --name $name \
+  -d mcr.microsoft.com/mssql/server:latest
 
-echo "Waiting for server to start"
-until docker logs $name 2>&1 | grep -q "SQL Server is now ready for client connections"; do
+echo "Waiting for SQL Server to accept connections..."
+until docker exec "$name" //opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P "$password" -C -l 1 \
+  -Q "SELECT 1" >/dev/null 2>$1; do
   sleep 1
 done
 
-docker exec -it "$name" /opt/mssql-tools/bin/sqlcmd \
-          -S localhost -U SA -P "$password" \
-          -Q 'CREATE DATABASE [plantech-mock-db]'
+echo "SQL Server is now ready for client connections"
+
+docker exec "$name" //opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U SA -P "$password" -C \
+  -b -Q 'CREATE DATABASE [plantech-mock-db]'
+
+CONN="Server=tcp:localhost,1433;User ID=sa;Password=$password;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;Max Pool Size=1000;Database=plantech-mock-db"
 
 dotnet user-secrets init
-dotnet user-secrets set "ConnectionStrings:Database" "Server=tcp:localhost,1433;Persist Security Info=False;User ID=sa;Password=$password;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;Max Pool Size=1000;Database=plantech-mock-db"
+dotnet user-secrets set "ConnectionStrings:Database" "$CONN"
 
-cd ../../src/Dfe.PlanTech.DatabaseUpgrader || exit
-
-dotnet run --connectionstring "Server=tcp:localhost,1433;Persist Security Info=False;User ID=sa;Password=$password;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;Max Pool Size=1000;Database=plantech-mock-db"
-
-cd ../../tests/Dfe.PlanTech.Web.SeedTestData || exit
-
-dotnet run
+cd ../../src/Dfe.PlanTech.DatabaseUpgrader && dotnet run --connectionstring "$CONN"
+cd ../../tests/Dfe.PlanTech.Web.SeedTestData && dotnet run


### PR DESCRIPTION
## Overview

Addresses ticket [#307604](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/307604)

## Changes

### Major

- Update local SQL server installation and setup script
- Change handling of default noteText values on recommendations so that blank microcopy inserts NULL

### Minor

- Updates to Contentful to remove text for empty notes

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests pass