### PR TITLE
310371 session tracking

### DIFF
--- a/src/Dfe.PlanTech.Core/Constants/ClaimConstants.cs
+++ b/src/Dfe.PlanTech.Core/Constants/ClaimConstants.cs
@@ -33,6 +33,7 @@ public static class ClaimConstants
     public const string Nonce = "nonce";
     public const string AccessTokenHash = "at_hash";
     public const string AuthenticationTime = "auth_time";
+    public const string SessionId = "session_id";
 
     public const string DB_USER_ID = "db_user_id";
     public const string DB_ESTABLISHMENT_ID = "db_establishment_id";

--- a/src/Dfe.PlanTech.Data.Sql/Entities/UserActionEntity.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Entities/UserActionEntity.cs
@@ -3,6 +3,7 @@ namespace Dfe.PlanTech.Data.Sql.Entities;
 public class UserActionEntity
 {
     public Guid Id { get; set; }
+    public Guid? SessionId { get; set; }
     public int UserId { get; set; }
     public int? EstablishmentId { get; set; }
     public int? MatEstablishmentId { get; set; }

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2026/20260507_1100_AddSessionIdUserAction.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2026/20260507_1100_AddSessionIdUserAction.sql
@@ -1,0 +1,3 @@
+ALTER TABLE dbo.userAction
+ADD sessionId UNIQUEIDENTIFIER NULL;
+GO

--- a/src/Dfe.PlanTech.Infrastructure.SignIn/ConnectEvents/OnUserInformationReceivedEvent.cs
+++ b/src/Dfe.PlanTech.Infrastructure.SignIn/ConnectEvents/OnUserInformationReceivedEvent.cs
@@ -67,6 +67,7 @@ public static class OnUserInformationReceivedEvent
         ClaimsIdentity claimsIdentity = new([
             new Claim(ClaimConstants.DB_USER_ID, signin.UserId.ToString()),
             new Claim(ClaimConstants.DB_ESTABLISHMENT_ID, establishmentId),
+            new Claim(ClaimConstants.SessionId, Guid.NewGuid().ToString()),
         ]);
 
         principal.AddIdentity(claimsIdentity);

--- a/src/Dfe.PlanTech.Web/Context/CurrentUser.cs
+++ b/src/Dfe.PlanTech.Web/Context/CurrentUser.cs
@@ -142,6 +142,11 @@ public class CurrentUser : ICurrentUser
 
     public int? UserId => GetIntFromClaim(ClaimConstants.DB_USER_ID);
 
+    public Guid? SessionId =>
+        Guid.TryParse(GetNameIdentifierFromClaim(ClaimConstants.SessionId), out var sessionId)
+        ? sessionId
+        : null;
+
     public bool IsInRole(string role) => _contextAccessor.HttpContext?.User.IsInRole(role) ?? false;
 
     public void SetGroupSelectedSchool(string selectedSchoolUrn, string selectedSchoolName)

--- a/src/Dfe.PlanTech.Web/Context/Interfaces/ICurrentUser.cs
+++ b/src/Dfe.PlanTech.Web/Context/Interfaces/ICurrentUser.cs
@@ -36,4 +36,5 @@ public interface ICurrentUser
     (string Urn, string Name)? GetGroupSelectedSchool();
     bool IsInRole(string role);
     void SetGroupSelectedSchool(string selectedSchoolUrn, string selectedSchoolName);
+    Guid? SessionId { get; }
 }

--- a/src/Dfe.PlanTech.Web/Context/UserActionTrackingService.cs
+++ b/src/Dfe.PlanTech.Web/Context/UserActionTrackingService.cs
@@ -33,6 +33,7 @@ public class UserActionTrackingService(
         var userAction = new UserActionEntity
         {
             Id = userActionId,
+            SessionId = currentUser.SessionId,
             UserId = userId.Value,
             EstablishmentId = await currentUser.GetActiveEstablishmentIdAsync(),
             MatEstablishmentId = currentUser.IsMat ? currentUser.UserOrganisationId : null,

--- a/tests/Dfe.PlanTech.Web.UnitTests/Context/CurrentUserTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Context/CurrentUserTests.cs
@@ -1,6 +1,3 @@
-using System.Security.Authentication;
-using System.Security.Claims;
-using System.Text.Json;
 using Dfe.PlanTech.Application.Services.Interfaces;
 using Dfe.PlanTech.Core.Constants;
 using Dfe.PlanTech.Core.DataTransferObjects.Sql;
@@ -10,6 +7,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 using NSubstitute;
+using System.Security.Authentication;
+using System.Security.Claims;
+using System.Text.Json;
 
 namespace Dfe.PlanTech.Web.UnitTests.Context;
 
@@ -208,6 +208,38 @@ public class CurrentUserTests
     {
         var (sut, _) = Build();
         Assert.Null(sut.UserId);
+    }
+
+    // ---------- SessionId ----------
+
+    [Fact]
+    public void SessionId_Returns_SessionId_When_Claim_Exists()
+    {
+        var expectedSessionId = Guid.NewGuid();
+
+        var (sut, _) = Build([
+            BuildClaim(ClaimConstants.SessionId, expectedSessionId.ToString())
+        ]);
+
+        Assert.Equal(expectedSessionId, sut.SessionId);
+    }
+
+    [Fact]
+    public void SessionId_ReturnsNull_When_Claim_Is_Missing()
+    {
+        var (sut, _) = Build();
+
+        Assert.Null(sut.SessionId);
+    }
+
+    [Fact]
+    public void SessionId_ReturnsNull_When_Claim_Is_Not_Guid()
+    {
+        var (sut, _) = Build([
+            BuildClaim(ClaimConstants.SessionId, "not-a-guid")
+        ]);
+
+        Assert.Null(sut.SessionId);
     }
 
     // ---------- IsAuthenticated ----------


### PR DESCRIPTION
## Overview

Added session tracking to userAction table and claims

Addresses ticket [#310371](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_boards/board/t/STS%202.0%20Scrum%20Teams/Stories?System.Tags=Dev&System.IterationPath=s190-schools-technology-services%5CSTS%202.0%20Scrum%20Teams%5CSprint%2041%20(STS%202.0)&workitem=310371)

## How to review the PR

Visit any page locally and check that the user sessionId is stored in userAction table with relevant entry.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [ ] Unit tests pass
- [ ] E2E tests have been added/updated
- [ ] GitHub workflows/actions have been added/updated
- [ ] Terraform has been updated
- [ ] Documentation has been updated where relevant
- [ ] Any Key Vault secrets have been added to the development Key Vault
