### PR TITLE
remove user tracking exception when no user id

### DIFF
--- a/src/Dfe.PlanTech.Web/Authorisation/Policies/PageModelAuthorisationPolicy.cs
+++ b/src/Dfe.PlanTech.Web/Authorisation/Policies/PageModelAuthorisationPolicy.cs
@@ -45,16 +45,19 @@ public class PageModelAuthorisationPolicy(ILogger<PageModelAuthorisationPolicy> 
         {
             context.Succeed(requirement);
 
-            try
+            if (userAuthorisationResult.UserAuthorisationStatus.IsAuthenticated)
             {
-                var userActionTrackingService =
-                    httpContext.RequestServices.GetRequiredService<IUserActionTrackingService>();
+                try
+                {
+                    var userActionTrackingService =
+                        httpContext.RequestServices.GetRequiredService<IUserActionTrackingService>();
 
-                await userActionTrackingService.RecordAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to record user action for authorised request.");
+                    await userActionTrackingService.RecordAsync();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to record user action for authorised request.");
+                }
             }
         }
         else

--- a/src/Dfe.PlanTech.Web/Context/UserActionTrackingService.cs
+++ b/src/Dfe.PlanTech.Web/Context/UserActionTrackingService.cs
@@ -2,13 +2,15 @@ using Dfe.PlanTech.Core.Constants;
 using Dfe.PlanTech.Data.Sql.Entities;
 using Dfe.PlanTech.Data.Sql.Interfaces;
 using Dfe.PlanTech.Web.Context.Interfaces;
+using Dfe.PlanTech.Web.Middleware;
 
 namespace Dfe.PlanTech.Web.Context;
 
 public class UserActionTrackingService(
     IUserActionRepository userActionRepository,
     IHttpContextAccessor httpContextAccessor,
-    ICurrentUser currentUser
+    ICurrentUser currentUser,
+    ILogger<UserActionTrackingService> logger
 ) : IUserActionTrackingService
 {
     public async Task RecordAsync()
@@ -26,6 +28,7 @@ public class UserActionTrackingService(
 
         if (userId is null)
         {
+            logger.LogInformation("No current user id found");
             return;
         }
 

--- a/src/Dfe.PlanTech.Web/Context/UserActionTrackingService.cs
+++ b/src/Dfe.PlanTech.Web/Context/UserActionTrackingService.cs
@@ -23,9 +23,10 @@ public class UserActionTrackingService(
         }
 
         var userId = currentUser.UserId;
+
         if (userId is null)
         {
-            throw new InvalidOperationException("Current user ID was not found.");
+            return;
         }
 
         var userActionId = Guid.NewGuid();

--- a/tests/Dfe.PlanTech.Web.UnitTests/Authorisation/Policies/PageModelAuthorisationPolicyTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Authorisation/Policies/PageModelAuthorisationPolicyTests.cs
@@ -1,7 +1,8 @@
-using System.Security.Claims;
 using Dfe.PlanTech.Application.Services.Interfaces;
+using Dfe.PlanTech.Core.Constants;
 using Dfe.PlanTech.Core.Contentful.Models;
 using Dfe.PlanTech.Core.Exceptions;
+using Dfe.PlanTech.Core.Models;
 using Dfe.PlanTech.UnitTests.Shared.Extensions;
 using Dfe.PlanTech.Web.Authorisation.Policies;
 using Dfe.PlanTech.Web.Authorisation.Requirements;
@@ -14,6 +15,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using System.Security.Claims;
+using System.Text.Json;
 
 namespace Dfe.PlanTech.Web.UnitTests.Authorisation.Policies;
 
@@ -231,10 +234,44 @@ public class PageModelAuthorisationPolicyTests
     {
         _contentfulService
             .GetPageBySlugAsync(Arg.Any<string>())
-            .Returns(callInfo => AuthNotRequiredPage);
+            .Returns(callInfo => AuthRequiredPage);
+
+        var org = new EstablishmentModel
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test School",
+            Urn = "123456",
+            Ukprn = "00000018",
+            Category = new IdWithNameModel
+            {
+                Id = "001",
+                Name = "Establishment",
+            },
+        };
+
+        var claimsIdentity = new ClaimsIdentity(
+        [
+            new Claim(ClaimConstants.NameIdentifier, "dsi-ref"),
+            new Claim(ClaimConstants.DB_USER_ID, "101"),
+            new Claim(ClaimConstants.DB_ESTABLISHMENT_ID, "201"),
+            new Claim(ClaimConstants.Organisation, JsonSerializer.Serialize(org)),
+        ],
+            CookieAuthenticationDefaults.AuthenticationScheme
+        );
+
+        var principal = new ClaimsPrincipal(claimsIdentity);
+
+        _httpContext.User.Returns(principal);
+
+        _authContext = new AuthorizationHandlerContext(
+            [new PageAuthorisationRequirement()],
+            principal,
+            _httpContext
+        );
 
         await _policy.HandleAsync(_authContext);
 
+        Assert.True(_authContext.HasSucceeded);
         await _userActionTrackingService.Received(1).RecordAsync();
     }
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/Context/UserActionTrackingServiceTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Context/UserActionTrackingServiceTests.cs
@@ -75,15 +75,16 @@ public class UserActionTrackingServiceTests
     }
 
     [Fact]
-    public async Task RecordAsync_WhenUserActionIdAlreadyExists_ThenDoesNotCreateUserAction()
+    public async Task RecordAsync_WhenUserIdIsNull_ThenDoesNotCreateUserAction()
     {
-        _httpContext.Items[UserActionIdConstants.HttpContextItemKey] = Guid.NewGuid();
+        _currentUser.UserId.Returns((int?)null);
 
         var service = BuildService();
 
         await service.RecordAsync();
 
         await _userActionRepository.DidNotReceive().CreateAsync(Arg.Any<UserActionEntity>());
+        Assert.False(_httpContext.Items.ContainsKey(UserActionIdConstants.HttpContextItemKey));
     }
 
     [Fact]
@@ -102,19 +103,5 @@ public class UserActionTrackingServiceTests
         );
 
         Assert.Equal("No active HttpContext found.", exception.Message);
-    }
-
-    [Fact]
-    public async Task RecordAsync_WhenUserIdIsNull_ThenThrowsInvalidOperationException()
-    {
-        _currentUser.UserId.Returns((int?)null);
-
-        var service = BuildService();
-
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.RecordAsync()
-        );
-
-        Assert.Equal("Current user ID was not found.", exception.Message);
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Context/UserActionTrackingServiceTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Context/UserActionTrackingServiceTests.cs
@@ -1,9 +1,11 @@
+using Castle.Core.Logging;
 using Dfe.PlanTech.Core.Constants;
 using Dfe.PlanTech.Data.Sql.Entities;
 using Dfe.PlanTech.Data.Sql.Interfaces;
 using Dfe.PlanTech.Web.Context;
 using Dfe.PlanTech.Web.Context.Interfaces;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 
 namespace Dfe.PlanTech.Web.UnitTests.Context;
@@ -13,6 +15,7 @@ public class UserActionTrackingServiceTests
     private readonly IUserActionRepository _userActionRepository = Substitute.For<IUserActionRepository>();
     private readonly IHttpContextAccessor _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
     private readonly ICurrentUser _currentUser = Substitute.For<ICurrentUser>();
+    private readonly ILogger<UserActionTrackingService> _logger = Substitute.For<ILogger<UserActionTrackingService>>();
     private readonly DefaultHttpContext _httpContext = new();
 
     private UserActionTrackingService BuildService()
@@ -22,7 +25,8 @@ public class UserActionTrackingServiceTests
         return new UserActionTrackingService(
             _userActionRepository,
             _httpContextAccessor,
-            _currentUser
+            _currentUser,
+            _logger
         );
     }
 
@@ -95,7 +99,8 @@ public class UserActionTrackingServiceTests
         var service = new UserActionTrackingService(
             _userActionRepository,
             _httpContextAccessor,
-            _currentUser
+            _currentUser,
+            _logger
         );
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>


### PR DESCRIPTION
## Overview

fix pre-logged in user action tracker throwing exception with no user id

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [ ] Unit tests pass
- [ ] E2E tests have been added/updated
- [ ] GitHub workflows/actions have been added/updated
- [ ] Terraform has been updated
- [ ] Documentation has been updated where relevant
- [ ] Any Key Vault secrets have been added to the development Key Vault
