### PR TITLE
fix: adjust continue-on-error flag for E2E tests in workflows

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -167,10 +167,7 @@ jobs:
   run-e2e-tests:
     if: ${{ inputs.run-e2e-tests }}
     needs: flush-redis-cache
-    continue-on-error: true
     uses: ./.github/workflows/e2e-test-playwright-environment.yml
     with:
       environment: ${{ inputs.environment }}
     secrets: inherit
-
-   

--- a/.github/workflows/e2e-test-smoke-environment.yml
+++ b/.github/workflows/e2e-test-smoke-environment.yml
@@ -39,6 +39,7 @@ jobs:
     name: Run Playwright + Cucumber Tests
     environment: ${{ inputs.environment || github.event.inputs.environment || 'Tst' }}
     runs-on: ubuntu-22.04
+    continue-on-error: true
     env:
       PROJECT_PATH: ./src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj
       KEYVAULT_NAME: ${{ secrets.AZ_ENVIRONMENT }}${{ secrets.DFE_PROJECT_NAME }}-kv


### PR DESCRIPTION
pipeline fix on deploy-image + e2e-test-smoke-environment