### PR TITLE
feat(311761): add group self-assessment view and logic for MAT submissions

### DIFF
--- a/src/Dfe.PlanTech.Application/ServiceCollectionExtensions.cs
+++ b/src/Dfe.PlanTech.Application/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IQuestionService, QuestionService>()
             .AddScoped<IRecommendationService, RecommendationService>()
             .AddScoped<ISubmissionService, SubmissionService>()
+            .AddScoped<IGroupService, GroupService>()
             .AddScoped<IUserService, UserService>();
     }
 
@@ -41,6 +42,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<ISignInWorkflow, SignInWorkflow>()
             .AddScoped<IRecommendationWorkflow, RecommendationWorkflow>()
             .AddScoped<ISubmissionWorkflow, SubmissionWorkflow>()
+            .AddScoped<IGroupWorkflow, GroupWorkflow>()
             .AddScoped<IUserWorkflow, UserWorkflow>();
     }
 

--- a/src/Dfe.PlanTech.Application/Services/ContentfulService.cs
+++ b/src/Dfe.PlanTech.Application/Services/ContentfulService.cs
@@ -27,6 +27,11 @@ public class ContentfulService(IContentfulWorkflow contentfulWorkflow) : IConten
         return _contentfulWorkflow.GetAllSectionsAsync();
     }
 
+    public Task<IEnumerable<QuestionnaireCategoryEntry>> GetAllCategoriesAsync()
+    {
+        return _contentfulWorkflow.GetAllCategoriesAsync();
+    }
+
     public Task<QuestionnaireSectionEntry> GetSectionBySlugAsync(
         string slug,
         int? includeLevel = null

--- a/src/Dfe.PlanTech.Application/Services/EstablishmentService.cs
+++ b/src/Dfe.PlanTech.Application/Services/EstablishmentService.cs
@@ -26,6 +26,16 @@ public class EstablishmentService(
         return _establishmentWorkflow.GetOrCreateEstablishmentAsync(establishmentModel);
     }
 
+    public Task<List<SqlEstablishmentLinkDto>> GetEstablishmentLinks(int establishmentId)
+    {
+        return _establishmentWorkflow.GetGroupEstablishments(establishmentId);
+    }
+
+    public Task<IEnumerable<SqlEstablishmentDto>> GetEstablishmentsByReferencesAsync(IEnumerable<string> establishmentReferences)
+    {
+        return _establishmentWorkflow.GetEstablishmentsByReferencesAsync(establishmentReferences);
+    }
+
     public async Task<SqlEstablishmentDto?> GetEstablishmentByReferenceAsync(
         string establishmentReference
     )

--- a/src/Dfe.PlanTech.Application/Services/GroupService.cs
+++ b/src/Dfe.PlanTech.Application/Services/GroupService.cs
@@ -1,0 +1,17 @@
+using Dfe.PlanTech.Application.Services.Interfaces;
+using Dfe.PlanTech.Application.Workflows.Interfaces;
+using Dfe.PlanTech.Core.DataTransferObjects.Sql;
+
+namespace Dfe.PlanTech.Application.Services;
+
+public class GroupService(IGroupWorkflow groupWorkflow) : IGroupService
+{
+    private readonly IGroupWorkflow _groupWorkflow =
+        groupWorkflow ?? throw new ArgumentNullException(nameof(groupWorkflow));
+
+    public async Task<List<SqlSubmissionDto>> GetGroupCompletedSubmissionsBySections(int[] establishmentIds)
+    {
+        var submissions = await _groupWorkflow.GetGroupCompletedSubmissions(establishmentIds);
+        return submissions;
+    }
+}

--- a/src/Dfe.PlanTech.Application/Services/Interfaces/IContentfulService.cs
+++ b/src/Dfe.PlanTech.Application/Services/Interfaces/IContentfulService.cs
@@ -7,6 +7,7 @@ public interface IContentfulService
     Task<QuestionnaireCategoryEntry?> GetCategoryBySlugAsync(string slug, int? includeLevel = null);
     Task<string?> GetCategoryHeaderTextBySlugAsync(string slug);
     Task<IEnumerable<QuestionnaireSectionEntry>> GetAllSectionsAsync();
+    Task<IEnumerable<QuestionnaireCategoryEntry>> GetAllCategoriesAsync();
     Task<QuestionnaireSectionEntry> GetSectionBySlugAsync(string slug, int? includeLevel = null);
     Task<NavigationLinkEntry> GetLinkByIdAsync(string contentId);
     Task<List<MicrocopyEntry>> GetMicrocopyEntriesAsync();

--- a/src/Dfe.PlanTech.Application/Services/Interfaces/IEstablishmentService.cs
+++ b/src/Dfe.PlanTech.Application/Services/Interfaces/IEstablishmentService.cs
@@ -8,8 +8,14 @@ public interface IEstablishmentService
     Task<List<SqlEstablishmentLinkDto>> GetEstablishmentLinksWithRecommendationCounts(
         int establishmentId
     );
+    Task<List<SqlEstablishmentLinkDto>> GetEstablishmentLinks(
+        int establishmentId
+    );
+    Task<IEnumerable<SqlEstablishmentDto>> GetEstablishmentsByReferencesAsync(
+        IEnumerable<string> establishmentReferences
+    );
+
     Task<SqlEstablishmentDto?> GetEstablishmentByReferenceAsync(string establishmentReference);
-    Task<SqlEstablishmentDto> GetOrCreateEstablishmentAsync(EstablishmentModel establishmentModel);
     Task RecordGroupSelection(
         string userDsiReference,
         int? userEstablishmentId,

--- a/src/Dfe.PlanTech.Application/Services/Interfaces/IGroupService.cs
+++ b/src/Dfe.PlanTech.Application/Services/Interfaces/IGroupService.cs
@@ -1,0 +1,9 @@
+using Dfe.PlanTech.Core.DataTransferObjects.Sql;
+
+namespace Dfe.PlanTech.Application.Services.Interfaces;
+
+public interface IGroupService
+{
+    Task<List<SqlSubmissionDto>> GetGroupCompletedSubmissionsBySections(int[] establishmentIds);
+
+}

--- a/src/Dfe.PlanTech.Application/Workflows/ContentfulWorkflow.cs
+++ b/src/Dfe.PlanTech.Application/Workflows/ContentfulWorkflow.cs
@@ -91,6 +91,25 @@ public class ContentfulWorkflow(
         }
     }
 
+    public async Task<IEnumerable<QuestionnaireCategoryEntry>> GetAllCategoriesAsync()
+    {
+        try
+        {
+            var options = new GetEntriesOptions(include: 2);
+            var categories = await _contentfulRepository.GetEntriesAsync<QuestionnaireCategoryEntry>(
+                options
+            );
+            return categories;
+        }
+        catch (Exception ex)
+        {
+            throw new ContentfulDataUnavailableException(
+                "Error getting categories from Contentful",
+                ex
+            );
+        }
+    }
+
     public async Task<string?> GetCategoryHeaderTextBySlugAsync(string slug)
     {
         var contentTypeQuery = new ContentfulQuerySingleValue

--- a/src/Dfe.PlanTech.Application/Workflows/EstablishmentWorkflow.cs
+++ b/src/Dfe.PlanTech.Application/Workflows/EstablishmentWorkflow.cs
@@ -7,8 +7,7 @@ namespace Dfe.PlanTech.Application.Workflows;
 
 public class EstablishmentWorkflow(
     IEstablishmentRepository establishmentRepository,
-    IEstablishmentLinkRepository establishmentLinkRepository,
-    ISubmissionRepository submissionsRepository
+    IEstablishmentLinkRepository establishmentLinkRepository
 ) : IEstablishmentWorkflow
 {
     private readonly IEstablishmentRepository _establishmentRepository =
@@ -16,8 +15,6 @@ public class EstablishmentWorkflow(
     private readonly IEstablishmentLinkRepository _establishmentLinkRepository =
         establishmentLinkRepository
         ?? throw new ArgumentNullException(nameof(establishmentLinkRepository));
-    private readonly ISubmissionRepository _submissionRespository =
-        submissionsRepository ?? throw new ArgumentNullException(nameof(submissionsRepository));
     public async Task<SqlEstablishmentDto> GetOrCreateEstablishmentAsync(
         EstablishmentModel establishmentModel
     )

--- a/src/Dfe.PlanTech.Application/Workflows/EstablishmentWorkflow.cs
+++ b/src/Dfe.PlanTech.Application/Workflows/EstablishmentWorkflow.cs
@@ -7,7 +7,8 @@ namespace Dfe.PlanTech.Application.Workflows;
 
 public class EstablishmentWorkflow(
     IEstablishmentRepository establishmentRepository,
-    IEstablishmentLinkRepository establishmentLinkRepository
+    IEstablishmentLinkRepository establishmentLinkRepository,
+    ISubmissionRepository submissionsRepository
 ) : IEstablishmentWorkflow
 {
     private readonly IEstablishmentRepository _establishmentRepository =
@@ -15,7 +16,8 @@ public class EstablishmentWorkflow(
     private readonly IEstablishmentLinkRepository _establishmentLinkRepository =
         establishmentLinkRepository
         ?? throw new ArgumentNullException(nameof(establishmentLinkRepository));
-
+    private readonly ISubmissionRepository _submissionRespository =
+        submissionsRepository ?? throw new ArgumentNullException(nameof(submissionsRepository));
     public async Task<SqlEstablishmentDto> GetOrCreateEstablishmentAsync(
         EstablishmentModel establishmentModel
     )

--- a/src/Dfe.PlanTech.Application/Workflows/GroupWorkflow.cs
+++ b/src/Dfe.PlanTech.Application/Workflows/GroupWorkflow.cs
@@ -1,0 +1,18 @@
+using Dfe.PlanTech.Application.Workflows.Interfaces;
+using Dfe.PlanTech.Core.DataTransferObjects.Sql;
+using Dfe.PlanTech.Data.Sql.Interfaces;
+
+namespace Dfe.PlanTech.Application.Workflows;
+
+public class GroupWorkflow(ISubmissionRepository submissionRepository) : IGroupWorkflow
+{
+    private readonly ISubmissionRepository _submissionRepository =
+        submissionRepository ?? throw new ArgumentNullException(nameof(submissionRepository));
+
+    public async Task<List<SqlSubmissionDto>> GetGroupCompletedSubmissions(int[] establishmentIds)
+    {
+        var submissions = await _submissionRepository.GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync(establishmentIds);
+
+        return submissions.Select(s => s.AsDto()).ToList();
+    }
+}

--- a/src/Dfe.PlanTech.Application/Workflows/Interfaces/IContentfulWorkflow.cs
+++ b/src/Dfe.PlanTech.Application/Workflows/Interfaces/IContentfulWorkflow.cs
@@ -5,6 +5,7 @@ namespace Dfe.PlanTech.Application.Workflows.Interfaces;
 public interface IContentfulWorkflow
 {
     Task<IEnumerable<QuestionnaireSectionEntry>> GetAllSectionsAsync();
+    Task<IEnumerable<QuestionnaireCategoryEntry>> GetAllCategoriesAsync();
 
     Task<QuestionnaireCategoryEntry?> GetCategoryBySlugAsync(string slug, int? includeLevel = null);
 

--- a/src/Dfe.PlanTech.Application/Workflows/Interfaces/IGroupWorkflow.cs
+++ b/src/Dfe.PlanTech.Application/Workflows/Interfaces/IGroupWorkflow.cs
@@ -1,0 +1,9 @@
+using Dfe.PlanTech.Core.DataTransferObjects.Sql;
+
+namespace Dfe.PlanTech.Application.Workflows.Interfaces;
+
+public interface IGroupWorkflow
+{
+    Task<List<SqlSubmissionDto>> GetGroupCompletedSubmissions(int[] establishmentIds);
+
+}

--- a/src/Dfe.PlanTech.Core/Constants/UrlConstants.cs
+++ b/src/Dfe.PlanTech.Core/Constants/UrlConstants.cs
@@ -24,6 +24,7 @@ public static class UrlConstants
     public const string ViewAnswersSlug = "view-answers";
 
     public const string GroupsSelectionPageSlug = "select-a-school";
+    public const string GroupSelfAssessmentSelectionSlug = "select-a-self-assessment";
     public const string GroupsSlug = "groups";
 
     public const string Home = "home";

--- a/src/Dfe.PlanTech.Data.Sql/Interfaces/ISubmissionRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Interfaces/ISubmissionRepository.cs
@@ -36,4 +36,5 @@ public interface ISubmissionRepository
     Task<List<SectionStatusEntity>> GetSectionStatusesAsync(string sectionIds, int establishmentId);
     Task SetSubmissionDeletedAsync(int establishmentId, string sectionId);
     Task<int> SubmitResponse(AssessmentResponseModel response);
+    Task<List<SubmissionEntity>> GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync(IEnumerable<int> establishmentIds);
 }

--- a/src/Dfe.PlanTech.Data.Sql/Repositories/SubmissionRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Repositories/SubmissionRepository.cs
@@ -716,6 +716,34 @@ public class SubmissionRepository(
         return question.Id;
     }
 
+    public async Task<List<SubmissionEntity>> GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync(
+        IEnumerable<int> establishmentIds)
+    {
+        var establishmentIdList = establishmentIds
+            .Distinct()
+            .ToList();
+
+        var results = await dbContext.Submissions
+            .Where(s =>
+                establishmentIdList.Contains(s.EstablishmentId) &&
+                s.Status == SubmissionStatus.CompleteReviewed &&
+                !s.Deleted &&
+                s.DateCompleted != null)
+            .Where(s => !dbContext.Submissions.Any(s2 =>
+                s2.EstablishmentId == s.EstablishmentId &&
+                s2.SectionName == s.SectionName &&
+                s2.SectionId == s.SectionId &&
+                s2.Status == SubmissionStatus.CompleteReviewed &&
+                !s2.Deleted &&
+                s2.DateCompleted != null &&
+                s2.DateCompleted > s.DateCompleted))
+            .OrderBy(s => s.EstablishmentId)
+            .ThenBy(s => s.SectionName)
+            .ToListAsync();
+
+        return results;
+    }
+
     private RecommendationEntity BuildRecommendationEntity(SqlRecommendationDto recommendationDto)
     {
         return new RecommendationEntity

--- a/src/Dfe.PlanTech.Data.Sql/Repositories/SubmissionRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Repositories/SubmissionRepository.cs
@@ -731,7 +731,7 @@ public class SubmissionRepository(
                 s.DateCompleted != null)
             .Where(s => !dbContext.Submissions.Any(s2 =>
                 s2.EstablishmentId == s.EstablishmentId &&
-                s2.SectionName == s.SectionName &&
+                s2.SectionId == s.SectionId &&
                 s2.SectionId == s.SectionId &&
                 s2.Status == SubmissionStatus.CompleteReviewed &&
                 !s2.Deleted &&

--- a/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
@@ -36,7 +36,7 @@ public class GroupsController : BaseController<GroupsController>
     }
 
     [HttpGet(
-        $"trust/{UrlConstants.GroupSelfAssessmentSelectionSlug}",
+        $"{UrlConstants.GroupsSlug}/{UrlConstants.GroupSelfAssessmentSelectionSlug}",
         Name = GetSelectASelfAssessmentAction
     )]
     public async Task<IActionResult> GetSelectASelfAssessment()

--- a/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
@@ -9,6 +9,7 @@ namespace Dfe.PlanTech.Web.Controllers;
 public class GroupsController : BaseController<GroupsController>
 {
     public const string GetSelectASchoolAction = "GetSelectASchoolView";
+    public const string GetSelectASelfAssessmentAction = "GetSelectASelfAssessmentView";
 
     private readonly ICurrentUser _currentUser;
     private readonly IGroupsViewBuilder _groupsViewBuilder;
@@ -32,6 +33,15 @@ public class GroupsController : BaseController<GroupsController>
     public async Task<IActionResult> GetSelectASchoolView()
     {
         return await _groupsViewBuilder.RouteToSelectASchoolViewModelAsync(this);
+    }
+
+    [HttpGet(
+        $"trust/{UrlConstants.GroupSelfAssessmentSelectionSlug}",
+        Name = GetSelectASelfAssessmentAction
+    )]
+    public async Task<IActionResult> GetSelectASelfAssessment()
+    {
+        return await _groupsViewBuilder.RouteToSelectASelfAssessmentViewModelAsync(this);
     }
 
     [HttpPost($"{UrlConstants.GroupsSlug}/{UrlConstants.GroupsSelectionPageSlug}")]

--- a/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
@@ -9,7 +9,7 @@ namespace Dfe.PlanTech.Web.Controllers;
 public class GroupsController : BaseController<GroupsController>
 {
     public const string GetSelectASchoolAction = "GetSelectASchoolView";
-    public const string GetSelectASelfAssessmentAction = "GetSelectASelfAssessmentView";
+    public const string GetSelectASelfAssessmentAction = "GetSelectASelfAssessment";
 
     private readonly ICurrentUser _currentUser;
     private readonly IGroupsViewBuilder _groupsViewBuilder;

--- a/src/Dfe.PlanTech.Web/ViewBuilders/GroupsViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/GroupsViewBuilder.cs
@@ -83,9 +83,9 @@ public class GroupsViewBuilder(
 
         var categories = (await ContentfulService.GetAllCategoriesAsync() ?? []).ToList();
 
-        if (!categories.Any())
+        if (categories.Count() == 0)
         {
-            throw new NullReferenceException("No categories found on groups assessment selection page.");
+            throw new Exception("No categories found on groups assessment selection page.");
         }
 
         // establishments for the MAT

--- a/src/Dfe.PlanTech.Web/ViewBuilders/GroupsViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/GroupsViewBuilder.cs
@@ -17,15 +17,19 @@ public class GroupsViewBuilder(
     IOptions<ContactOptionsConfiguration> contactOptions,
     IContentfulService contentfulService,
     ICurrentUser currentUser,
-    IEstablishmentService establishmentService
+    IEstablishmentService establishmentService,
+    IGroupService groupService
 ) : BaseViewBuilder(logger, contentfulService, currentUser), IGroupsViewBuilder
 {
     private readonly IEstablishmentService _establishmentService =
         establishmentService ?? throw new ArgumentNullException(nameof(establishmentService));
+    private readonly IGroupService _groupService =
+        groupService ?? throw new ArgumentNullException(nameof(groupService));
     private readonly ContactOptionsConfiguration _contactOptions =
         contactOptions?.Value ?? throw new ArgumentNullException(nameof(contactOptions));
 
     private const string SelectASchoolViewName = "GroupsSelectSchool";
+    private const string SelectASelfAssessmentViewName = "GroupsSelectSelfAssessment";
 
     public async Task<IActionResult> RouteToSelectASchoolViewModelAsync(Controller controller)
     {
@@ -69,6 +73,73 @@ public class GroupsViewBuilder(
 
         controller.ViewData[StatePassingMechanismConstants.Title] = "Select a school";
         return controller.View(SelectASchoolViewName, viewModel);
+    }
+
+    public async Task<IActionResult> RouteToSelectASelfAssessmentViewModelAsync(Controller controller)
+    {
+        // Get the MAT id
+        var establishmentId = GetUserOrganisationIdOrThrowException();
+        var groupName = CurrentUser.UserOrganisationName ?? "Your organisation";
+
+        var categories = (await ContentfulService.GetAllCategoriesAsync() ?? []).ToList();
+
+        if (!categories.Any())
+        {
+            throw new NullReferenceException("No categories found on groups assessment selection page.");
+        }
+
+        // establishments for the MAT
+        var matEstablishmentLinks = await _establishmentService.GetEstablishmentLinks(establishmentId) ?? [];
+
+        // Get urn's from links (filter for distinct, white spaces).
+        var matEstablishmentUrns = matEstablishmentLinks
+            .Select(e => e.Urn)
+            .Where(urn => !string.IsNullOrWhiteSpace(urn))
+            .Distinct()
+            .ToArray();
+
+        // Retrieve the actual establishments.
+        var matEstablishments = await _establishmentService.GetEstablishmentsByReferencesAsync(matEstablishmentUrns) ?? [];
+
+        // Get the ids of the establishments.
+        var matEstablishmentIds = matEstablishments
+            .Select(e => e.Id)
+            .Distinct()
+            .ToArray();
+
+        // Get the completed submissions for the MAT.
+        var completedSubmissions = matEstablishmentIds.Length != 0
+            ? await _groupService.GetGroupCompletedSubmissionsBySections(matEstablishmentIds) ?? []
+            : [];
+
+        var completedCountBySectionId = completedSubmissions
+            .Where(cs => matEstablishmentIds.Contains(cs.EstablishmentId))
+            .GroupBy(cs => cs.SectionId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(cs => cs.EstablishmentId).Distinct().Count());
+
+
+        var viewModel = new GroupSelectAssessmentViewModel()
+        {
+            GroupName = groupName,
+            Categories = categories.Select(c => new CategorySectionViewModel
+            {
+                CategoryName = c.Header?.Text ?? string.Empty,
+                Sections = (c.Sections ?? []).Select(ccs =>
+                {
+                    var completedCount = completedCountBySectionId.GetValueOrDefault(ccs.Id);
+                    var uncompletedCount = Math.Max(0, matEstablishmentIds.Length - completedCount);
+                    return new GroupSelectAssessmentSectionViewModel()
+                    {
+                        SectionName = ccs.Name,
+                        UncompletedGroupSubmissions = uncompletedCount
+                    };
+                }).ToList()
+            }).ToList()
+        };
+
+        return controller.View(SelectASelfAssessmentViewName, viewModel);
     }
 
     public async Task RecordGroupSelectionAsync(

--- a/src/Dfe.PlanTech.Web/ViewBuilders/Interfaces/IGroupsViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/Interfaces/IGroupsViewBuilder.cs
@@ -5,6 +5,7 @@ namespace Dfe.PlanTech.Web.ViewBuilders.Interfaces
     public interface IGroupsViewBuilder
     {
         Task<IActionResult> RouteToSelectASchoolViewModelAsync(Controller controller);
+        Task<IActionResult> RouteToSelectASelfAssessmentViewModelAsync(Controller controller);
         Task RecordGroupSelectionAsync(
             string selectedEstablishmentUrn,
             string selectedEstablishmentName

--- a/src/Dfe.PlanTech.Web/ViewModels/GroupSelectAssessmentCategorySectionViewModel.cs
+++ b/src/Dfe.PlanTech.Web/ViewModels/GroupSelectAssessmentCategorySectionViewModel.cs
@@ -1,0 +1,7 @@
+namespace Dfe.PlanTech.Web.ViewModels;
+
+public class CategorySectionViewModel
+{
+    public string? CategoryName { get; set; }
+    public List<GroupSelectAssessmentSectionViewModel> Sections { get; set; } = [];
+}

--- a/src/Dfe.PlanTech.Web/ViewModels/GroupSelectAssessmentSectionViewModel.cs
+++ b/src/Dfe.PlanTech.Web/ViewModels/GroupSelectAssessmentSectionViewModel.cs
@@ -1,0 +1,7 @@
+namespace Dfe.PlanTech.Web.ViewModels;
+
+public class GroupSelectAssessmentSectionViewModel
+{
+    public string? SectionName { get; set; }
+    public int? UncompletedGroupSubmissions { get; set; }
+}

--- a/src/Dfe.PlanTech.Web/ViewModels/GroupSelectAssessmentViewModel.cs
+++ b/src/Dfe.PlanTech.Web/ViewModels/GroupSelectAssessmentViewModel.cs
@@ -1,0 +1,12 @@
+using Dfe.PlanTech.Core.Contentful.Models;
+using Dfe.PlanTech.Web.ViewModels.QaVisualiser;
+
+namespace Dfe.PlanTech.Web.ViewModels;
+
+public class GroupSelectAssessmentViewModel
+{
+    public string? GroupName { get; set; }
+    public List<CategorySectionViewModel> Categories { get; set; } = [];
+}
+
+

--- a/src/Dfe.PlanTech.Web/Views/Groups/GroupsSelectSelfAssessment.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Groups/GroupsSelectSelfAssessment.cshtml
@@ -1,0 +1,35 @@
+@model GroupSelectAssessmentViewModel
+@{
+    ViewData[StatePassingMechanismConstants.Title] = "Select a self-assessment";
+}
+<div>
+    <h1 class="govuk-heading-xl">Select a self-assessment</h1>
+
+    @foreach (var category in Model.Categories)
+    {
+        <h2 class="govuk-heading-m">@category.CategoryName</h2>
+        <ul class="govuk-task-list">
+            @foreach (var s in category.Sections)
+            {
+                <li class="govuk-task-list__item govuk-task-list__item--with-link govuk-!-padding-bottom-3 govuk-!-padding-top-3">
+                    <div class="govuk-task-list__name-and-hint">
+                        <a class="govuk-link govuk-task-list__link" href="#"
+                           aria-describedby="roles-and-responsibilities-status">
+                            @s.SectionName
+                        </a>
+                    </div>
+                    <div class="govuk-task-list__status" id="roles-and-responsibilities-status">
+                            @if (s.UncompletedGroupSubmissions == 0)
+                            {
+                                <span>All self-assessments submitted.</span>
+                            }
+                            else
+                            {
+                                <span>Self assessment required for @s.UncompletedGroupSubmissions schools.</span>
+                            }
+                    </div>
+                </li>
+            }
+        </ul>
+    }
+</div>

--- a/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
@@ -70,6 +70,11 @@
                         [GroupsController.GetSelectASchoolAction],
                         StringComparer.OrdinalIgnoreCase)
                 },
+                {
+                    "Groups", new HashSet<string>(
+                        [GroupsController.GetSelectASelfAssessmentAction],
+                        StringComparer.OrdinalIgnoreCase)
+                },
             };
 
             showChangeSchool =

--- a/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
@@ -67,12 +67,7 @@
                 },
                 {
                     "Groups", new HashSet<string>(
-                        [GroupsController.GetSelectASchoolAction],
-                        StringComparer.OrdinalIgnoreCase)
-                },
-                {
-                    "Groups", new HashSet<string>(
-                        [GroupsController.GetSelectASelfAssessmentAction],
+                        [GroupsController.GetSelectASchoolAction, GroupsController.GetSelectASelfAssessmentAction],
                         StringComparer.OrdinalIgnoreCase)
                 },
             };

--- a/tests/Dfe.PlanTech.Application.UnitTests/Services/ContentfulServiceTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Services/ContentfulServiceTests.cs
@@ -40,6 +40,22 @@ public class ContentfulServiceTests
     }
 
     [Fact]
+    public async Task GetAllCategories_Delegates_And_Returns()
+    {
+        var (contentfulService, contentfulWorkflow) = Build();
+        var expected = new List<QuestionnaireCategoryEntry>
+        {
+            new() { Sys = new SystemDetails("S1") },
+        };
+        contentfulWorkflow.GetAllCategoriesAsync().Returns(expected);
+
+        var result = await contentfulService.GetAllCategoriesAsync();
+
+        Assert.Same(expected, result);
+        await contentfulWorkflow.Received(1).GetAllCategoriesAsync();
+    }
+
+    [Fact]
     public async Task GetCategoryHeaderTextBySlug_Delegates_And_Returns()
     {
         var (contentfulService, contentfulWorkflow) = Build();

--- a/tests/Dfe.PlanTech.Application.UnitTests/Services/GroupServiceTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Services/GroupServiceTests.cs
@@ -1,0 +1,58 @@
+using Dfe.PlanTech.Application.Services;
+using Dfe.PlanTech.Application.Workflows.Interfaces;
+using Dfe.PlanTech.Core.DataTransferObjects.Sql;
+using NSubstitute;
+
+namespace Dfe.PlanTech.Application.UnitTests.Services;
+
+public class GroupServiceTests
+{
+    private readonly IGroupWorkflow _groupWorkflow =
+        Substitute.For<IGroupWorkflow>();
+
+    private GroupService CreateServiceUnderTest() =>
+        new GroupService(_groupWorkflow);
+
+    [Fact]
+    public async Task GetGroupCompletedSubmissionsBySections_Calls_Workflow_And_Returns_Result()
+    {
+        // Arrange
+        var sut = CreateServiceUnderTest();
+
+        var establishmentIds = new[] { 1, 2, 3 };
+
+        var expected = new List<SqlSubmissionDto>
+        {
+            new() { Id = 100, EstablishmentId = 1 },
+            new() { Id = 200, EstablishmentId = 2 },
+        };
+
+        _groupWorkflow
+            .GetGroupCompletedSubmissions(establishmentIds)
+            .Returns(expected);
+
+        // Act
+        var result = await sut.GetGroupCompletedSubmissionsBySections(establishmentIds);
+
+        // Assert
+        Assert.Same(expected, result);
+
+        await _groupWorkflow
+            .Received(1)
+            .GetGroupCompletedSubmissions(
+                Arg.Is<int[]>(ids =>
+                    ids.SequenceEqual(establishmentIds)
+                )
+            );
+    }
+
+    [Fact]
+    public void Constructor_Throws_ArgumentNullException_When_GroupWorkflow_Is_Null()
+    {
+        // Act
+        var exception = Assert.Throws<ArgumentNullException>(() => new GroupService(null!));
+
+        // Assert
+        Assert.Equal("groupWorkflow", exception.ParamName);
+    }
+}

--- a/tests/Dfe.PlanTech.Application.UnitTests/Workflows/ContentfulWorkflowTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Workflows/ContentfulWorkflowTests.cs
@@ -14,6 +14,7 @@ public class ContentfulWorkflowTests
     private readonly ILogger<ContentfulWorkflow> _logger = Substitute.For<
         ILogger<ContentfulWorkflow>
     >();
+
     private readonly IContentfulRepository _repo = Substitute.For<IContentfulRepository>();
     private readonly GetPageFromContentfulOptions _pageOpts = new() { Include = 4 };
 
@@ -144,6 +145,36 @@ public class ContentfulWorkflowTests
 
         await Assert.ThrowsAsync<ContentfulDataUnavailableException>(() =>
             sut.GetAllSectionsAsync()
+        );
+    }
+
+    // ---------- GetAllCategoriesAsync ----------
+    [Fact]
+    public async Task GetAllCategories_Returns()
+    {
+        var sut = CreateServiceUnderTest();
+        var secs = new List<QuestionnaireCategoryEntry> { new() { Sys = new SystemDetails("S1") } };
+        _repo
+            .GetEntriesAsync<QuestionnaireCategoryEntry>(Arg.Any<GetEntriesOptions>())
+            .Returns(secs);
+
+        var result = await sut.GetAllCategoriesAsync();
+
+        Assert.Equal(secs, result);
+    }
+
+    [Fact]
+    public async Task GetAllCategories_When_RepoThrows_Wraps()
+    {
+        var sut = CreateServiceUnderTest();
+        _repo
+            .GetEntriesAsync<QuestionnaireCategoryEntry>(Arg.Any<GetEntriesOptions>())
+            .Returns<Task<IEnumerable<QuestionnaireCategoryEntry>>>(_ =>
+                throw new Exception("boom")
+            );
+
+        await Assert.ThrowsAsync<ContentfulDataUnavailableException>(() =>
+            sut.GetAllCategoriesAsync()
         );
     }
 

--- a/tests/Dfe.PlanTech.Application.UnitTests/Workflows/EstablishmentWorkflowTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Workflows/EstablishmentWorkflowTests.cs
@@ -11,10 +11,12 @@ public class EstablishmentWorkflowTests
     private readonly IEstablishmentRepository _estRepo = Substitute.For<IEstablishmentRepository>();
     private readonly IEstablishmentLinkRepository _linkRepo =
         Substitute.For<IEstablishmentLinkRepository>();
+    private readonly ISubmissionRepository _subRepo =
+        Substitute.For<ISubmissionRepository>();
     private static readonly string[] abString = new[] { "A", "B" };
 
     private EstablishmentWorkflow CreateServiceUnderTest() =>
-        new EstablishmentWorkflow(_estRepo, _linkRepo);
+        new EstablishmentWorkflow(_estRepo, _linkRepo, _subRepo);
 
     // ── Helpers: create minimal entities that map via AsDto() in YOUR codebase ──
     // Replace these types with your real entity classes (what the repos return),
@@ -253,13 +255,13 @@ public class EstablishmentWorkflowTests
     public void Ctor_Null_Repos_Throw()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new EstablishmentWorkflow(null!, _linkRepo)
+            new EstablishmentWorkflow(null!, _linkRepo, _subRepo)
         );
         Assert.Throws<ArgumentNullException>(() =>
-            new EstablishmentWorkflow(_estRepo, null!)
+            new EstablishmentWorkflow(_estRepo, null!, _subRepo)
         );
         Assert.Throws<ArgumentNullException>(() =>
-            new EstablishmentWorkflow(null!, null!)
+            new EstablishmentWorkflow(null!, null!, _subRepo)
         );
     }
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Workflows/EstablishmentWorkflowTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Workflows/EstablishmentWorkflowTests.cs
@@ -16,7 +16,7 @@ public class EstablishmentWorkflowTests
     private static readonly string[] abString = new[] { "A", "B" };
 
     private EstablishmentWorkflow CreateServiceUnderTest() =>
-        new EstablishmentWorkflow(_estRepo, _linkRepo, _subRepo);
+        new EstablishmentWorkflow(_estRepo, _linkRepo);
 
     // ── Helpers: create minimal entities that map via AsDto() in YOUR codebase ──
     // Replace these types with your real entity classes (what the repos return),
@@ -255,13 +255,13 @@ public class EstablishmentWorkflowTests
     public void Ctor_Null_Repos_Throw()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new EstablishmentWorkflow(null!, _linkRepo, _subRepo)
+            new EstablishmentWorkflow(null!, _linkRepo)
         );
         Assert.Throws<ArgumentNullException>(() =>
-            new EstablishmentWorkflow(_estRepo, null!, _subRepo)
+            new EstablishmentWorkflow(_estRepo, null!)
         );
         Assert.Throws<ArgumentNullException>(() =>
-            new EstablishmentWorkflow(null!, null!, _subRepo)
+            new EstablishmentWorkflow(null!, null!)
         );
     }
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Workflows/GroupWorkflowTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Workflows/GroupWorkflowTests.cs
@@ -1,0 +1,143 @@
+using Dfe.PlanTech.Application.Workflows;
+using Dfe.PlanTech.Core.Enums;
+using Dfe.PlanTech.Data.Sql.Entities;
+using Dfe.PlanTech.Data.Sql.Interfaces;
+using NSubstitute;
+
+namespace Dfe.PlanTech.Application.UnitTests.Workflows;
+
+public class GroupWorkflowTests
+{
+    private readonly ISubmissionRepository _submissionRepository =
+        Substitute.For<ISubmissionRepository>();
+
+    private GroupWorkflow CreateServiceUnderTest() => new(_submissionRepository);
+
+    private static EstablishmentEntity BuildEstablishment(int id = 1)
+    {
+        return new EstablishmentEntity
+        {
+            Id = id,
+            EstablishmentRef = $"testRef{id}",
+            OrgName = $"testName{id}",
+            DateCreated = DateTime.UtcNow,
+        };
+    }
+
+    private static SubmissionEntity BuildSubmission(
+        int id,
+        int establishmentId,
+        string sectionId,
+        SubmissionStatus status = SubmissionStatus.CompleteReviewed
+    )
+    {
+        return new SubmissionEntity
+        {
+            Id = id,
+            EstablishmentId = establishmentId,
+            Establishment = BuildEstablishment(establishmentId),
+            SectionId = sectionId,
+            SectionName = $"Section {sectionId}",
+            Status = status,
+            Responses = new List<ResponseEntity>(),
+        };
+    }
+
+    [Fact]
+    public async Task GetGroupCompletedSubmissions_CallsRepository()
+    {
+        var sut = CreateServiceUnderTest();
+
+        var establishmentIds = new[] { 1, 2, 3 };
+
+        _submissionRepository
+            .GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync(establishmentIds)
+            .Returns(new List<SubmissionEntity>());
+
+        await sut.GetGroupCompletedSubmissions(establishmentIds);
+
+        await _submissionRepository
+            .Received(1)
+            .GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync(
+                Arg.Is<int[]>(ids => ids.SequenceEqual(establishmentIds))
+            );
+    }
+
+    [Fact]
+    public async Task GetGroupCompletedSubmissions_ReturnsSubmissionDtos()
+    {
+        var sut = CreateServiceUnderTest();
+
+        var establishmentIds = new[] { 1, 2 };
+
+        var submissions = new List<SubmissionEntity>
+        {
+            BuildSubmission(
+                id: 100,
+                establishmentId: 1,
+                sectionId: "SEC-1"
+            ),
+            BuildSubmission(
+                id: 200,
+                establishmentId: 2,
+                sectionId: "SEC-2"
+            ),
+        };
+
+        _submissionRepository
+            .GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync(establishmentIds)
+            .Returns(submissions);
+
+        var result = await sut.GetGroupCompletedSubmissions(establishmentIds);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+
+        Assert.Collection(
+            result,
+            submission =>
+            {
+                Assert.Equal(100, submission.Id);
+                Assert.Equal(1, submission.EstablishmentId);
+                Assert.Equal("SEC-1", submission.SectionId);
+                Assert.Equal(SubmissionStatus.CompleteReviewed, submission.Status);
+            },
+            submission =>
+            {
+                Assert.Equal(200, submission.Id);
+                Assert.Equal(2, submission.EstablishmentId);
+                Assert.Equal("SEC-2", submission.SectionId);
+                Assert.Equal(SubmissionStatus.CompleteReviewed, submission.Status);
+            }
+        );
+    }
+
+    [Fact]
+    public async Task GetGroupCompletedSubmissions_WhenNoSubmissions_ReturnsEmptyList()
+    {
+        var sut = CreateServiceUnderTest();
+
+        var establishmentIds = new[] { 1, 2, 3 };
+
+        _submissionRepository
+            .GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync(establishmentIds)
+            .Returns(new List<SubmissionEntity>());
+
+        var result = await sut.GetGroupCompletedSubmissions(establishmentIds);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+
+        await _submissionRepository
+            .Received(1)
+            .GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync(establishmentIds);
+    }
+
+    [Fact]
+    public void Constructor_Throws_ArgumentNullException_When_SubmissionRepository_Is_Null()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new GroupWorkflow(null!));
+
+        Assert.Equal("submissionRepository", exception.ParamName);
+    }
+}

--- a/tests/Dfe.PlanTech.Data.Sql.UnitTests/Repositories/SubmissionRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Data.Sql.UnitTests/Repositories/SubmissionRepositoryTests.cs
@@ -149,8 +149,9 @@ public class SubmissionRepositoryTests
         );
         var repo = new SubmissionRepository(db, BuildUserActionIdAccessor());
 
-        var result = await Assert.ThrowsAsync<ArgumentException>(() => repo.GetLatestSubmissionAndResponsesAsync(1, "SEC", [])
-        );
+        var result =
+            await Assert.ThrowsAsync<ArgumentException>(() => repo.GetLatestSubmissionAndResponsesAsync(1, "SEC", [])
+            );
 
         Assert.Contains("At least one submission status must be provided", result.Message);
     }
@@ -207,7 +208,8 @@ public class SubmissionRepositoryTests
 
         db.SaveChanges();
 
-        var result = await repo.GetLatestSubmissionAndResponsesAsync(1, "SEC", [SubmissionStatus.Inaccessible, SubmissionStatus.InProgress]);
+        var result = await repo.GetLatestSubmissionAndResponsesAsync(1, "SEC",
+            [SubmissionStatus.Inaccessible, SubmissionStatus.InProgress]);
 
         Assert.NotNull(result);
         Assert.Equal(2, result.Id);
@@ -276,6 +278,168 @@ public class SubmissionRepositoryTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             repo.SetSubmissionInProgressAsync(establishmentId: 99, sectionId: "NA")
+        );
+    }
+
+    [Fact]
+    public async Task
+        GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync_Returns_Latest_Completed_NotDeleted_Submissions_Per_Establishment_And_Section()
+    {
+        using var db = BuildPlanTechDbContext(
+            nameof(
+                GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync_Returns_Latest_Completed_NotDeleted_Submissions_Per_Establishment_And_Section)
+        );
+        var repo = new SubmissionRepository(db, BuildUserActionIdAccessor());
+
+        db.Establishments.AddRange(
+            new EstablishmentEntity { Id = 1 },
+            new EstablishmentEntity { Id = 2 },
+            new EstablishmentEntity { Id = 3 }
+        );
+
+        db.Submissions.AddRange(
+            // Establishment 1, Section B - older completed submission, should be excluded
+            new SubmissionEntity
+            {
+                Id = 1,
+                EstablishmentId = 1,
+                SectionId = "SEC-B",
+                SectionName = "Section B",
+                Status = SubmissionStatus.CompleteReviewed,
+                DateCreated = new DateTime(2024, 1, 1),
+                DateCompleted = new DateTime(2024, 1, 1),
+                DateLastUpdated = new DateTime(2024, 1, 1),
+                Deleted = false,
+            },
+
+            // Establishment 1, Section B - latest valid completed submission, should be returned
+            new SubmissionEntity
+            {
+                Id = 2,
+                EstablishmentId = 1,
+                SectionId = "SEC-B",
+                SectionName = "Section B",
+                Status = SubmissionStatus.CompleteReviewed,
+                DateCreated = new DateTime(2024, 2, 1),
+                DateCompleted = new DateTime(2024, 2, 1),
+                DateLastUpdated = new DateTime(2024, 2, 1),
+                Deleted = false,
+            },
+
+            // Establishment 1, Section A - different section, should also be returned
+            new SubmissionEntity
+            {
+                Id = 3,
+                EstablishmentId = 1,
+                SectionId = "SEC-A",
+                SectionName = "Section A",
+                Status = SubmissionStatus.CompleteReviewed,
+                DateCreated = new DateTime(2024, 3, 1),
+                DateCompleted = new DateTime(2024, 3, 1),
+                DateLastUpdated = new DateTime(2024, 3, 1),
+                Deleted = false,
+            },
+
+            // Newer but deleted, should be excluded and should not replace Id 2
+            new SubmissionEntity
+            {
+                Id = 4,
+                EstablishmentId = 1,
+                SectionId = "SEC-B",
+                SectionName = "Section B",
+                Status = SubmissionStatus.CompleteReviewed,
+                DateCreated = new DateTime(2024, 4, 1),
+                DateCompleted = new DateTime(2024, 4, 1),
+                DateLastUpdated = new DateTime(2024, 4, 1),
+                Deleted = true,
+            },
+
+            // CompleteReviewed but no DateCompleted, should be excluded
+            new SubmissionEntity
+            {
+                Id = 5,
+                EstablishmentId = 1,
+                SectionId = "SEC-C",
+                SectionName = "Section C",
+                Status = SubmissionStatus.CompleteReviewed,
+                DateCreated = new DateTime(2024, 5, 1),
+                DateCompleted = null,
+                DateLastUpdated = new DateTime(2024, 5, 1),
+                Deleted = false,
+            },
+
+            // Not CompleteReviewed, should be excluded
+            new SubmissionEntity
+            {
+                Id = 6,
+                EstablishmentId = 1,
+                SectionId = "SEC-D",
+                SectionName = "Section D",
+                Status = SubmissionStatus.InProgress,
+                DateCreated = new DateTime(2024, 6, 1),
+                DateCompleted = new DateTime(2024, 6, 1),
+                DateLastUpdated = new DateTime(2024, 6, 1),
+                Deleted = false,
+            },
+
+            // Establishment 2, should be returned
+            new SubmissionEntity
+            {
+                Id = 7,
+                EstablishmentId = 2,
+                SectionId = "SEC-A",
+                SectionName = "Section A",
+                Status = SubmissionStatus.CompleteReviewed,
+                DateCreated = new DateTime(2024, 7, 1),
+                DateCompleted = new DateTime(2024, 7, 1),
+                DateLastUpdated = new DateTime(2024, 7, 1),
+                Deleted = false,
+            },
+
+            // Establishment 3 is not requested, should be excluded
+            new SubmissionEntity
+            {
+                Id = 8,
+                EstablishmentId = 3,
+                SectionId = "SEC-A",
+                SectionName = "Section A",
+                Status = SubmissionStatus.CompleteReviewed,
+                DateCreated = new DateTime(2024, 8, 1),
+                DateCompleted = new DateTime(2024, 8, 1),
+                DateLastUpdated = new DateTime(2024, 8, 1),
+                Deleted = false,
+            }
+        );
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await repo.GetLatestEstablishmentsCompletedSubmissionsBySectionsAsync(
+            [1, 1, 2]
+        );
+
+        Assert.Collection(
+            result,
+            submission =>
+            {
+                Assert.Equal(3, submission.Id);
+                Assert.Equal(1, submission.EstablishmentId);
+                Assert.Equal("SEC-A", submission.SectionId);
+                Assert.Equal("Section A", submission.SectionName);
+            },
+            submission =>
+            {
+                Assert.Equal(2, submission.Id);
+                Assert.Equal(1, submission.EstablishmentId);
+                Assert.Equal("SEC-B", submission.SectionId);
+                Assert.Equal("Section B", submission.SectionName);
+            },
+            submission =>
+            {
+                Assert.Equal(7, submission.Id);
+                Assert.Equal(2, submission.EstablishmentId);
+                Assert.Equal("SEC-A", submission.SectionId);
+                Assert.Equal("Section A", submission.SectionName);
+            }
         );
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/GroupsViewBuilderTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/GroupsViewBuilderTests.cs
@@ -359,7 +359,7 @@ public class GroupsViewBuilderTests
         var controller = new TestController();
 
         // Act
-        var exception = await Assert.ThrowsAsync<NullReferenceException>(() =>
+        var exception = await Assert.ThrowsAsync<Exception>(() =>
             sut.RouteToSelectASelfAssessmentViewModelAsync(controller)
         );
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/GroupsViewBuilderTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/GroupsViewBuilderTests.cs
@@ -26,6 +26,7 @@ public class GroupsViewBuilderTests
         IOptions<ContactOptionsConfiguration>? contactOpts = null,
         IContentfulService? contentful = null,
         IEstablishmentService? est = null,
+        IGroupService? group = null,
         ICurrentUser? currentUser = null,
         ILogger<BaseViewBuilder>? logger = null
     )
@@ -33,6 +34,7 @@ public class GroupsViewBuilderTests
         contactOpts ??= Opt();
         contentful ??= Substitute.For<IContentfulService>();
         est ??= Substitute.For<IEstablishmentService>();
+        group ??= Substitute.For<IGroupService>();
         currentUser ??= Substitute.For<ICurrentUser>();
         logger ??= NullLogger<BaseViewBuilder>.Instance;
 
@@ -54,7 +56,7 @@ public class GroupsViewBuilderTests
         // ActiveEstablishmentId, ActiveEstablishmentName, etc. not set
         // GroupSelectedSchoolUrn not set
 
-        return new GroupsViewBuilder(logger, contactOpts, contentful, currentUser, est);
+        return new GroupsViewBuilder(logger, contactOpts, contentful, currentUser, est, group);
     }
 
     private static QuestionnaireCategoryEntry MakeCategory(
@@ -85,6 +87,7 @@ public class GroupsViewBuilderTests
     {
         var contentful = Substitute.For<IContentfulService>();
         var est = Substitute.For<IEstablishmentService>();
+        var group = Substitute.For<IGroupService>();
         var current = Substitute.For<ICurrentUser>();
 
         Assert.Throws<ArgumentNullException>(() =>
@@ -93,7 +96,8 @@ public class GroupsViewBuilderTests
                 null!,
                 contentful,
                 current,
-                est
+                est,
+                group
             )
         );
     }
@@ -105,6 +109,7 @@ public class GroupsViewBuilderTests
         var contentful = Substitute.For<IContentfulService>();
         var current = Substitute.For<ICurrentUser>();
         var est = Substitute.For<IEstablishmentService>();
+        var group = Substitute.For<IGroupService>();
 
         Assert.Throws<ArgumentNullException>(() =>
             new GroupsViewBuilder(
@@ -112,7 +117,8 @@ public class GroupsViewBuilderTests
                 opts,
                 contentful,
                 current,
-                null!
+                null!,
+                group
             )
         );
     }

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/GroupsViewBuilderTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/GroupsViewBuilderTests.cs
@@ -241,4 +241,174 @@ public class GroupsViewBuilderTests
                 "Bond Primary"
             );
     }
+
+    // --- RouteToSelectASelfAssessmentViewModelAsync ----------------------------
+
+    [Fact]
+    public async Task RouteToSelectASelfAssessmentViewModelAsync_Builds_View_With_Expected_Model()
+    {
+        // Arrange
+        var contentful = Substitute.For<IContentfulService>();
+        var est = Substitute.For<IEstablishmentService>();
+        var group = Substitute.For<IGroupService>();
+
+        var sec1 = MakeSection("SEC-1");
+        var sec2 = MakeSection("SEC-2");
+        var category = MakeCategory(sec1, sec2);
+
+        contentful
+            .GetAllCategoriesAsync()
+            .Returns(new List<QuestionnaireCategoryEntry> { category });
+
+        est.GetEstablishmentLinks(100)
+            .Returns(
+                new List<SqlEstablishmentLinkDto>
+                {
+                    new() { Urn = "URN-1" },
+                    new() { Urn = "URN-2" },
+                    new() { Urn = "URN-2" }, // duplicate should be removed
+                    new() { Urn = "" }, // blank should be ignored
+                    new() { Urn = " " }, // whitespace should be ignored
+                }
+            );
+
+        est.GetEstablishmentsByReferencesAsync(Arg.Any<string[]>())
+            .Returns(
+                new List<SqlEstablishmentDto>
+                {
+                    new() { Id = 10 },
+                    new() { Id = 20 },
+                    new() { Id = 10 }, // duplicate establishment id should be removed
+                }
+            );
+
+        group.GetGroupCompletedSubmissionsBySections(Arg.Any<int[]>())
+            .Returns(
+                new List<SqlSubmissionDto>
+                {
+                    // SEC-1 completed by both establishments, so uncompleted count should be 0
+                    new() { Id = 1, EstablishmentId = 10, SectionId = "SEC-1" },
+                    new() { Id = 2, EstablishmentId = 20, SectionId = "SEC-1" },
+
+                    // SEC-2 completed by one establishment, so uncompleted count should be 1
+                    new() { Id = 3, EstablishmentId = 10, SectionId = "SEC-2" },
+
+                    // Not part of the MAT establishments, should be ignored
+                    new() { Id = 4, EstablishmentId = 999, SectionId = "SEC-1" },
+                }
+            );
+
+        var sut = CreateServiceUnderTest(contentful: contentful, est: est, group: group);
+        var controller = new TestController();
+
+        // Act
+        var action = await sut.RouteToSelectASelfAssessmentViewModelAsync(controller);
+
+        // Assert
+        var view = Assert.IsType<ViewResult>(action);
+        Assert.Equal("GroupsSelectSelfAssessment", view.ViewName);
+
+        var vm = Assert.IsType<GroupSelectAssessmentViewModel>(view.Model);
+        Assert.Equal("Test Academy Trust", vm.GroupName);
+
+        var categoryVm = Assert.Single(vm.Categories);
+        Assert.Equal("Header", categoryVm.CategoryName);
+
+        Assert.Collection(
+            categoryVm.Sections,
+            section =>
+            {
+                Assert.Equal("Sec SEC-1", section.SectionName);
+                Assert.Equal(0, section.UncompletedGroupSubmissions);
+            },
+            section =>
+            {
+                Assert.Equal("Sec SEC-2", section.SectionName);
+                Assert.Equal(1, section.UncompletedGroupSubmissions);
+            }
+        );
+
+        await est.Received(1).GetEstablishmentLinks(100);
+
+        await est.Received(1)
+            .GetEstablishmentsByReferencesAsync(
+                Arg.Is<string[]>(urns =>
+                    urns.SequenceEqual(new[] { "URN-1", "URN-2" })
+                )
+            );
+
+        await group.Received(1)
+            .GetGroupCompletedSubmissionsBySections(
+                Arg.Is<int[]>(ids =>
+                    ids.SequenceEqual(new[] { 10, 20 })
+                )
+            );
+    }
+
+    [Fact]
+    public async Task RouteToSelectASelfAssessmentViewModelAsync_Throws_When_No_Categories_Found()
+    {
+        // Arrange
+        var contentful = Substitute.For<IContentfulService>();
+
+        contentful
+            .GetAllCategoriesAsync()
+            .Returns(new List<QuestionnaireCategoryEntry>());
+
+        var sut = CreateServiceUnderTest(contentful: contentful);
+        var controller = new TestController();
+
+        // Act
+        var exception = await Assert.ThrowsAsync<NullReferenceException>(() =>
+            sut.RouteToSelectASelfAssessmentViewModelAsync(controller)
+        );
+
+        // Assert
+        Assert.Equal(
+            "No categories found on groups assessment selection page.",
+            exception.Message
+        );
+    }
+
+    [Fact]
+    public async Task RouteToSelectASelfAssessmentViewModelAsync_When_No_Establishments_Does_Not_Call_GroupService()
+    {
+        // Arrange
+        var contentful = Substitute.For<IContentfulService>();
+        var est = Substitute.For<IEstablishmentService>();
+        var group = Substitute.For<IGroupService>();
+
+        var sec1 = MakeSection("SEC-1");
+        var category = MakeCategory(sec1);
+
+        contentful
+            .GetAllCategoriesAsync()
+            .Returns(new List<QuestionnaireCategoryEntry> { category });
+
+        est.GetEstablishmentLinks(100)
+            .Returns(new List<SqlEstablishmentLinkDto>());
+
+        est.GetEstablishmentsByReferencesAsync(Arg.Any<string[]>())
+            .Returns(new List<SqlEstablishmentDto>());
+
+        var sut = CreateServiceUnderTest(contentful: contentful, est: est, group: group);
+        var controller = new TestController();
+
+        // Act
+        var action = await sut.RouteToSelectASelfAssessmentViewModelAsync(controller);
+
+        // Assert
+        var view = Assert.IsType<ViewResult>(action);
+        var vm = Assert.IsType<GroupSelectAssessmentViewModel>(view.Model);
+
+        var categoryVm = Assert.Single(vm.Categories);
+        var sectionVm = Assert.Single(categoryVm.Sections);
+
+        Assert.Equal("Sec SEC-1", sectionVm.SectionName);
+        Assert.Equal(0, sectionVm.UncompletedGroupSubmissions);
+
+        await group
+            .DidNotReceive()
+            .GetGroupCompletedSubmissionsBySections(Arg.Any<int[]>());
+    }
 }


### PR DESCRIPTION
## Overview

View for MAT's for selecting a self assessment. A list of the different categories/sections and how many have been completed in there MAT.

Example link to route to page: https://localhost:8080/groups/select-a-self-assessment

Addresses ticket [#311761](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/311761)

<img width="2106" height="1169" alt="image" src="https://github.com/user-attachments/assets/52b0e4c7-8435-4085-8583-f41837923916" />

The design for the ticket is based on:
https://lucid.app/lucidspark/cd0a1087-ab75-4968-9ef4-6f93a68f0945/edit?viewport_loc=-2327%2C-3766%2C1354%2C758%2C0_0&invitationId=inv_a27860a7-7c2d-4a6e-99d7-9bf64a715393

## How to review the PR

Run the solution, select a school (for now as that will change once other parts of the system are built), navigate to the example url above.

## Additional notes

Link to each self assessment is currently blank as that view is being built.
ValidateMatSelected attribute is still on the system which is why you need to select a MAT before going to the page. That will be removed once we begin to do more of the tickets.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated

