### PR TITLE
feat(313905): MAT recommendations school/trust name

### DIFF
--- a/src/Dfe.PlanTech.Application/Services/EstablishmentService.cs
+++ b/src/Dfe.PlanTech.Application/Services/EstablishmentService.cs
@@ -52,7 +52,13 @@ public class EstablishmentService(
     public async Task<SqlEstablishmentDto> GetEstablishmentByIdAsync(int id)
     {
         var establishmentEntity = await _establishmentRepository.GetEstablishmentByIdAsync(id);
-        return establishmentEntity?.AsDto()!;
+
+        if (establishmentEntity is null)
+        {
+            throw new KeyNotFoundException($"Establishment with id {id} not found");
+        }
+
+        return establishmentEntity.AsDto();
     }
 
     public async Task<List<SqlEstablishmentLinkDto>> GetEstablishmentLinksWithRecommendationCounts(

--- a/src/Dfe.PlanTech.Application/Services/EstablishmentService.cs
+++ b/src/Dfe.PlanTech.Application/Services/EstablishmentService.cs
@@ -3,11 +3,13 @@ using Dfe.PlanTech.Application.Workflows.Interfaces;
 using Dfe.PlanTech.Core.DataTransferObjects.Sql;
 using Dfe.PlanTech.Core.Enums;
 using Dfe.PlanTech.Core.Models;
+using Dfe.PlanTech.Data.Sql.Interfaces;
 
 namespace Dfe.PlanTech.Application.Services;
 
 public class EstablishmentService(
     IEstablishmentWorkflow establishmentWorkflow,
+    IEstablishmentRepository establishmentRepository,
     IRecommendationWorkflow recommendationWorkflow,
     IUserWorkflow userWorkflow
 ) : IEstablishmentService
@@ -18,6 +20,8 @@ public class EstablishmentService(
         recommendationWorkflow ?? throw new ArgumentNullException(nameof(recommendationWorkflow));
     private readonly IUserWorkflow _userWorkflow =
         userWorkflow ?? throw new ArgumentNullException(nameof(userWorkflow));
+    private readonly IEstablishmentRepository _establishmentRepository =
+        establishmentRepository ?? throw new ArgumentNullException(nameof(establishmentRepository));
 
     public Task<SqlEstablishmentDto> GetOrCreateEstablishmentAsync(
         EstablishmentModel establishmentModel
@@ -43,6 +47,12 @@ public class EstablishmentService(
         return await _establishmentWorkflow.GetEstablishmentByReferenceAsync(
             establishmentReference
         );
+    }
+
+    public async Task<SqlEstablishmentDto> GetEstablishmentByIdAsync(int id)
+    {
+        var establishmentEntity = await _establishmentRepository.GetEstablishmentByIdAsync(id);
+        return establishmentEntity?.AsDto()!;
     }
 
     public async Task<List<SqlEstablishmentLinkDto>> GetEstablishmentLinksWithRecommendationCounts(

--- a/src/Dfe.PlanTech.Application/Services/Interfaces/IEstablishmentService.cs
+++ b/src/Dfe.PlanTech.Application/Services/Interfaces/IEstablishmentService.cs
@@ -16,6 +16,9 @@ public interface IEstablishmentService
     );
 
     Task<SqlEstablishmentDto?> GetEstablishmentByReferenceAsync(string establishmentReference);
+
+    Task<SqlEstablishmentDto> GetEstablishmentByIdAsync(int id);
+    
     Task RecordGroupSelection(
         string userDsiReference,
         int? userEstablishmentId,

--- a/src/Dfe.PlanTech.Core/Constants/ContentfulMicrocopyConstants.cs
+++ b/src/Dfe.PlanTech.Core/Constants/ContentfulMicrocopyConstants.cs
@@ -175,6 +175,7 @@ public static class ContentfulMicrocopyConstants
         public const string Count = "count";
         public const string Total = "total";
         public const string ContactLink = "contactLink";
+        public const string EstablishmentName = "establishmentName";
     }
 
     public static readonly IReadOnlyDictionary<string, List<string>> Variables = new Dictionary<
@@ -186,9 +187,9 @@ public static class ContentfulMicrocopyConstants
         { LandingPageInsetIntroNotStarted, [VariableNames.Standard] },
         { LandingPageInsetIntroContinue, [VariableNames.Standard] },
         { LandingPageTopicLinkNotStarted, [VariableNames.Topic] },
-        { LandingPageTopicIntroContinue, [VariableNames.DateUpdated] },
+        { LandingPageTopicIntroContinue, [VariableNames.DateUpdated, VariableNames.EstablishmentName] },
         { LandingPageTopicLinkContinue, [VariableNames.Topic] },
-        { LandingPageTopicIntroCompleted, [VariableNames.Topic, VariableNames.DateCompleted] },
+        { LandingPageTopicIntroCompleted, [VariableNames.Topic, VariableNames.DateCompleted, VariableNames.EstablishmentName] },
         { LandingPageTopicLinkCompleted, [VariableNames.Topic] },
         { LandingPageSuccessPanelHeader, [VariableNames.Topic] },
         { SingleRecommendationPrintAllLink, [VariableNames.Topic] },

--- a/src/Dfe.PlanTech.Core/DataTransferObjects/Sql/SqlSectionStatusDto.cs
+++ b/src/Dfe.PlanTech.Core/DataTransferObjects/Sql/SqlSectionStatusDto.cs
@@ -11,5 +11,10 @@ public class SqlSectionStatusDto : ISqlDto
     public DateTime? LastCompletionDate { get; set; }
     public DateTime DateCreated { get; set; }
     public DateTime DateUpdated { get; set; }
+    public Guid? CreatedUserActionId { get; set; }
+
+    public Guid? LastUpdatedUserActionId { get; set; }
+
+    public Guid? CompletedUserActionId { get; set; }
     public SubmissionStatus Status { get; set; }
 }

--- a/src/Dfe.PlanTech.Core/DataTransferObjects/Sql/SqlUserActionDto.cs
+++ b/src/Dfe.PlanTech.Core/DataTransferObjects/Sql/SqlUserActionDto.cs
@@ -1,0 +1,18 @@
+namespace Dfe.PlanTech.Core.DataTransferObjects.Sql;
+
+public class SqlUserActionDto
+{
+    public Guid Id { get; set; }
+
+    public Guid? SessionId { get; set; }
+
+    public int UserId { get; set; }
+
+    public int? EstablishmentId { get; set; }
+
+    public int? MatEstablishmentId { get; set; }
+
+    public string RequestedUrl { get; set; } = null!;
+
+    public DateTime DateCreated { get; set; }
+}

--- a/src/Dfe.PlanTech.Data.Sql/Entities/SectionStatusEntity.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Entities/SectionStatusEntity.cs
@@ -15,6 +15,12 @@ public class SectionStatusEntity
 
     public DateTime? LastCompletionDate { get; set; }
 
+    public Guid? CreatedUserActionId { get; set; }
+
+    public Guid? LastUpdatedUserActionId { get; set; }
+
+    public Guid? CompletedUserActionId { get; set; }
+
     public SqlSectionStatusDto AsDto()
     {
         return new SqlSectionStatusDto
@@ -24,6 +30,9 @@ public class SectionStatusEntity
             DateUpdated = DateUpdated,
             Status = Status,
             LastCompletionDate = LastCompletionDate,
+            CreatedUserActionId = CreatedUserActionId,
+            LastUpdatedUserActionId = LastUpdatedUserActionId,
+            CompletedUserActionId = CompletedUserActionId,
         };
     }
 }

--- a/src/Dfe.PlanTech.Data.Sql/Interfaces/IEstablishmentRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Interfaces/IEstablishmentRepository.cs
@@ -11,6 +11,7 @@ public interface IEstablishmentRepository
     Task<List<EstablishmentEntity>> GetEstablishmentsByAsync(
         Expression<Func<EstablishmentEntity, bool>> predicate
     );
+    Task<EstablishmentEntity?> GetEstablishmentByIdAsync(int establishmentId);
     Task<List<EstablishmentEntity>> GetEstablishmentsByReferencesAsync(
         IEnumerable<string> establishmentReferences
     );

--- a/src/Dfe.PlanTech.Data.Sql/Interfaces/IUserActionRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Interfaces/IUserActionRepository.cs
@@ -5,4 +5,5 @@ namespace Dfe.PlanTech.Data.Sql.Interfaces;
 public interface IUserActionRepository
 {
     Task CreateAsync(UserActionEntity userAction);
+    Task<UserActionEntity?> GetUserActionAsync(Guid id);
 }

--- a/src/Dfe.PlanTech.Data.Sql/Repositories/EstablishmentRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Repositories/EstablishmentRepository.cs
@@ -45,6 +45,11 @@ public class EstablishmentRepository : IEstablishmentRepository
         return establishments.FirstOrDefault();
     }
 
+    public async Task<EstablishmentEntity?> GetEstablishmentByIdAsync(int establishmentId)
+    {
+        return await _db.Establishments.FindAsync(establishmentId);
+    }
+
     public Task<List<EstablishmentEntity>> GetEstablishmentsByReferencesAsync(
         IEnumerable<string> establishmentReferences
     )

--- a/src/Dfe.PlanTech.Data.Sql/Repositories/EstablishmentRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Repositories/EstablishmentRepository.cs
@@ -45,10 +45,7 @@ public class EstablishmentRepository : IEstablishmentRepository
         return establishments.FirstOrDefault();
     }
 
-    public async Task<EstablishmentEntity?> GetEstablishmentByIdAsync(int establishmentId)
-    {
-        return await _db.Establishments.FindAsync(establishmentId);
-    }
+    public async Task<EstablishmentEntity?> GetEstablishmentByIdAsync(int establishmentId) => await _db.Establishments.FindAsync(establishmentId);
 
     public Task<List<EstablishmentEntity>> GetEstablishmentsByReferencesAsync(
         IEnumerable<string> establishmentReferences

--- a/src/Dfe.PlanTech.Data.Sql/Repositories/SubmissionRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Repositories/SubmissionRepository.cs
@@ -529,6 +529,9 @@ public class SubmissionRepository(
                         ?? currentSubmission?.DateCreated
                         ?? DateTime.UtcNow,
                     LastCompletionDate = lastCompleteSubmission?.DateCompleted,
+                    LastUpdatedUserActionId = currentSubmission?.LastUpdatedUserActionId,
+                    CreatedUserActionId = currentSubmission?.CreatedUserActionId,
+                    CompletedUserActionId = lastCompleteSubmission?.CompletedUserActionId,
                 };
             })
             .ToList();

--- a/src/Dfe.PlanTech.Data.Sql/Repositories/UserActionRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Repositories/UserActionRepository.cs
@@ -12,6 +12,6 @@ public class UserActionRepository(PlanTechDbContext dbContext) : IUserActionRepo
         await dbContext.SaveChangesAsync();
     }
 
-    public async Task<UserActionEntity?> GetUserActionAsync(Guid id) => await dbContext.UserActions.FindAsync(id);
+    public async Task<UserActionEntity?> GetUserActionAsync(Guid id) => await  dbContext.UserActions.FindAsync(id);
 
 }

--- a/src/Dfe.PlanTech.Data.Sql/Repositories/UserActionRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Repositories/UserActionRepository.cs
@@ -11,4 +11,7 @@ public class UserActionRepository(PlanTechDbContext dbContext) : IUserActionRepo
         dbContext.UserActions.Add(userAction);
         await dbContext.SaveChangesAsync();
     }
+
+    public async Task<UserActionEntity?> GetUserActionAsync(Guid id) => await dbContext.UserActions.FindAsync(id);
+
 }

--- a/src/Dfe.PlanTech.Web/Context/Interfaces/IUserActionTrackingService.cs
+++ b/src/Dfe.PlanTech.Web/Context/Interfaces/IUserActionTrackingService.cs
@@ -1,6 +1,10 @@
+using Dfe.PlanTech.Core.DataTransferObjects.Sql;
+
 namespace Dfe.PlanTech.Web.Context.Interfaces;
 
 public interface IUserActionTrackingService
 {
     Task RecordAsync();
+    Task<SqlUserActionDto?> GetAsync(Guid id);
+
 }

--- a/src/Dfe.PlanTech.Web/Context/UserActionTrackingService.cs
+++ b/src/Dfe.PlanTech.Web/Context/UserActionTrackingService.cs
@@ -1,4 +1,5 @@
 using Dfe.PlanTech.Core.Constants;
+using Dfe.PlanTech.Core.DataTransferObjects.Sql;
 using Dfe.PlanTech.Data.Sql.Entities;
 using Dfe.PlanTech.Data.Sql.Interfaces;
 using Dfe.PlanTech.Web.Context.Interfaces;
@@ -47,5 +48,25 @@ public class UserActionTrackingService(
         httpContext.Items[UserActionIdConstants.HttpContextItemKey] = userActionId;
 
         await userActionRepository.CreateAsync(userAction);
+    }
+
+    public async Task<SqlUserActionDto?> GetAsync(Guid id)
+    {
+        var userActionEntity = await userActionRepository.GetUserActionAsync(id);
+
+        if (userActionEntity is null)
+        {
+            return null;
+        }
+
+        return new SqlUserActionDto
+        {
+            Id = userActionEntity.Id,
+            SessionId = userActionEntity.SessionId,
+            UserId = userActionEntity.UserId,
+            EstablishmentId = userActionEntity.EstablishmentId,
+            MatEstablishmentId = userActionEntity.MatEstablishmentId,
+            RequestedUrl = userActionEntity.RequestedUrl,
+        };
     }
 }

--- a/src/Dfe.PlanTech.Web/ViewBuilders/CategoryLandingViewComponentViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/CategoryLandingViewComponentViewBuilder.cs
@@ -148,7 +148,7 @@ public class CategoryLandingViewComponentViewBuilder(
             {
                 var userAction = await _userActionTrackingService.GetAsync(id);
 
-                if ((userAction.MatEstablishmentId ?? userAction.EstablishmentId) is { } userActionEstablishmentId)
+                if ((userAction?.MatEstablishmentId ?? userAction?.EstablishmentId) is { } userActionEstablishmentId)
                 {
                     var userActionEstablishment = await _establishmentService.GetEstablishmentByIdAsync(userActionEstablishmentId);
                     establishmentName = userActionEstablishment.OrgName;

--- a/src/Dfe.PlanTech.Web/ViewBuilders/CategoryLandingViewComponentViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/CategoryLandingViewComponentViewBuilder.cs
@@ -16,6 +16,8 @@ public class CategoryLandingViewComponentViewBuilder(
     IContentfulService contentfulService,
     ICurrentUser currentUser,
     ISubmissionService submissionService,
+    IUserActionTrackingService userActionTrackingService,
+    IEstablishmentService establishmentService,
     IUserService userService
 )
     : BaseViewBuilder(logger, contentfulService, currentUser),
@@ -25,6 +27,10 @@ public class CategoryLandingViewComponentViewBuilder(
         submissionService ?? throw new ArgumentNullException(nameof(submissionService));
     private readonly IUserService _userService =
         userService ?? throw new ArgumentNullException(nameof(userService));
+    private readonly IUserActionTrackingService _userActionTrackingService =
+        userActionTrackingService ?? throw new ArgumentNullException(nameof(userActionTrackingService));
+    private readonly IEstablishmentService _establishmentService =
+        establishmentService ?? throw new ArgumentNullException(nameof(establishmentService));
 
     private const string CategoryLandingSectionAssessmentLink =
         "Components/CategoryLanding/SectionAssessmentLink";
@@ -121,6 +127,34 @@ public class CategoryLandingViewComponentViewBuilder(
                 sectionStatus.SectionId.Equals(section.Id)
             );
 
+            var userActionId = sectionStatus switch
+            {
+                {
+                    Status: SubmissionStatus.InProgress or SubmissionStatus.CompleteNotReviewed,
+                    CreatedUserActionId: { } createdUserActionId
+                } => createdUserActionId,
+
+                {
+                    Status: SubmissionStatus.CompleteReviewed,
+                    CompletedUserActionId: { } completedUserActionId
+                } => completedUserActionId,
+
+                _ => (Guid?)null
+            };
+
+            string? establishmentName = null;
+
+            if (userActionId is { } id)
+            {
+                var userAction = await _userActionTrackingService.GetAsync(id);
+
+                if ((userAction.MatEstablishmentId ?? userAction.EstablishmentId) is { } userActionEstablishmentId)
+                {
+                    var userActionEstablishment = await _establishmentService.GetEstablishmentByIdAsync(userActionEstablishmentId);
+                    establishmentName = userActionEstablishment.OrgName;
+                }
+            }
+
             var recommendations = sectionStatus?.Status == SubmissionStatus.CompleteReviewed
                 ? await GetCategoryLandingSectionRecommendations(
                     establishmentId,
@@ -133,7 +167,8 @@ public class CategoryLandingViewComponentViewBuilder(
                 section,
                 recommendations,
                 sectionStatus,
-                hadRetrievalError
+                hadRetrievalError,
+                establishmentName
             );
         }
     }

--- a/src/Dfe.PlanTech.Web/ViewBuilders/CategoryLandingViewComponentViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/CategoryLandingViewComponentViewBuilder.cs
@@ -131,8 +131,8 @@ public class CategoryLandingViewComponentViewBuilder(
             {
                 {
                     Status: SubmissionStatus.InProgress or SubmissionStatus.CompleteNotReviewed,
-                    CreatedUserActionId: { } createdUserActionId
-                } => createdUserActionId,
+                    LastUpdatedUserActionId: { } lastUpdatedUserActionId
+                } => lastUpdatedUserActionId,
 
                 {
                     Status: SubmissionStatus.CompleteReviewed,

--- a/src/Dfe.PlanTech.Web/ViewModels/CategoryLandingSectionViewModel.cs
+++ b/src/Dfe.PlanTech.Web/ViewModels/CategoryLandingSectionViewModel.cs
@@ -16,17 +16,21 @@ public class CategoryLandingSectionViewModel
     public string ShortDescription { get; init; }
     public string? Slug { get; init; }
 
+    public string? EstablishmentName { get; set; }
+
     public CategoryLandingSectionViewModel(
         QuestionnaireSectionEntry section,
         CategoryLandingSectionRecommendationsViewModel? recommendations,
         SqlSectionStatusDto? sectionStatus,
-        bool hadRetrievalError
+        bool hadRetrievalError,
+        string? establishmentName
     )
     {
         Slug = section.InterstitialPage?.Slug;
         Name = section.Name;
         ShortDescription = section.ShortDescription;
         Recommendations = recommendations;
+        EstablishmentName = establishmentName;
 
         if (sectionStatus is not null)
         {

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
@@ -18,7 +18,8 @@
     {
         ["dateUpdated"] = topic.DateUpdated ?? "",
         ["topic"] = topic.Name.ToLower().Trim(),
-        ["dateCompleted"] = topic.LastCompletionDate ?? ""
+        ["dateCompleted"] = topic.LastCompletionDate ?? "",
+        ["establishmentName"] = topic.EstablishmentName ?? "",
     };
 
     switch (topicStatus)

--- a/tests/Dfe.PlanTech.Application.UnitTests/Services/EstablishmentServiceTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Services/EstablishmentServiceTests.cs
@@ -4,6 +4,7 @@ using Dfe.PlanTech.Core.Contentful.Models;
 using Dfe.PlanTech.Core.DataTransferObjects.Sql;
 using Dfe.PlanTech.Core.Enums;
 using Dfe.PlanTech.Core.Models;
+using Dfe.PlanTech.Data.Sql.Interfaces;
 using NSubstitute;
 
 namespace Dfe.PlanTech.Application.UnitTests.Services;
@@ -12,6 +13,8 @@ public class EstablishmentServiceTests
 {
     private readonly IEstablishmentWorkflow _establishmentWorkflow =
         Substitute.For<IEstablishmentWorkflow>();
+    private readonly IEstablishmentRepository _establishmentRepository =
+        Substitute.For<IEstablishmentRepository>();
     private readonly IRecommendationWorkflow _recommendationWorkflow =
         Substitute.For<IRecommendationWorkflow>();
     private readonly IUserWorkflow _userWorkflow = Substitute.For<IUserWorkflow>();
@@ -19,7 +22,7 @@ public class EstablishmentServiceTests
     private static readonly string[] urnAandBandC = ["URN-A", "URN-B", "URN-C"];
 
     private EstablishmentService CreateServiceUnderTest() =>
-        new EstablishmentService(_establishmentWorkflow, _recommendationWorkflow, _userWorkflow);
+        new EstablishmentService(_establishmentWorkflow, _establishmentRepository, _recommendationWorkflow, _userWorkflow);
 
     [Fact]
     public async Task GetOrCreateEstablishmentAsync_Delegates_To_Workflow()

--- a/tests/Dfe.PlanTech.Data.Sql.UnitTests/Entities/SectionStatusEntityTests.cs
+++ b/tests/Dfe.PlanTech.Data.Sql.UnitTests/Entities/SectionStatusEntityTests.cs
@@ -15,6 +15,9 @@ public class SectionStatusEntityTests
         var expectedDateUpdated = new DateTime(2024, 02, 01, 10, 00, 00, DateTimeKind.Utc);
         var expectedLastCompletionDate = new DateTime(2024, 03, 01, 10, 00, 00, DateTimeKind.Utc);
         var expectedStatus = SubmissionStatus.None; // default value
+        var expectedCreatedActionUserId = Guid.Parse("48b46712-5f9f-46b4-b1ae-95906c591a4a");
+        var expectedUpdatedActionUserId = Guid.Parse("b9e2513a-0dab-4f8b-af9a-6752a387bf83");
+        var expectedCompletedActionUserId = Guid.Parse("26502f1d-543b-47da-a62a-9f1a09e8548f");
 
         var entity = new SectionStatusEntity
         {
@@ -22,6 +25,9 @@ public class SectionStatusEntityTests
             DateCreated = expectedDateCreated,
             DateUpdated = expectedDateUpdated,
             LastCompletionDate = expectedLastCompletionDate,
+            CreatedUserActionId = expectedCreatedActionUserId,
+            LastUpdatedUserActionId = expectedUpdatedActionUserId,
+            CompletedUserActionId = expectedCompletedActionUserId,
         };
 
         // Act
@@ -32,6 +38,9 @@ public class SectionStatusEntityTests
         Assert.Equal(expectedDateCreated, dto.DateCreated);
         Assert.Equal(expectedDateUpdated, dto.DateUpdated);
         Assert.Equal(expectedLastCompletionDate, dto.LastCompletionDate);
+        Assert.Equal(expectedCompletedActionUserId, dto.CompletedUserActionId);
+        Assert.Equal(expectedCreatedActionUserId, dto.CreatedUserActionId);
+        Assert.Equal(expectedUpdatedActionUserId, dto.LastUpdatedUserActionId);
 
         // Assert - properties not explicitly set by AsDto():
         Assert.Equal(expectedStatus, dto.Status);
@@ -44,6 +53,9 @@ public class SectionStatusEntityTests
                 nameof(SqlSectionStatusDto.DateCreated),
                 nameof(SqlSectionStatusDto.DateUpdated),
                 nameof(SqlSectionStatusDto.LastCompletionDate),
+                nameof(SqlSectionStatusDto.CompletedUserActionId),
+                nameof(SqlSectionStatusDto.CreatedUserActionId),
+                nameof(SqlSectionStatusDto.LastUpdatedUserActionId),
             },
             new[]
             {

--- a/tests/Dfe.PlanTech.Web.E2ETests.Beta/step_definitions/smoke-tests/self-assessment.steps.ts
+++ b/tests/Dfe.PlanTech.Web.E2ETests.Beta/step_definitions/smoke-tests/self-assessment.steps.ts
@@ -58,7 +58,7 @@ Then(
 
     if (state === 'completed') {
       const completionPara = headingEl
-        .locator('xpath=following-sibling::p[contains(normalize-space(.), "was completed on")]')
+        .locator('xpath=following-sibling::p[contains(normalize-space(.), "was submitted on")]')
         .first();
 
       await expect(completionPara).toBeVisible();

--- a/tests/Dfe.PlanTech.Web.E2ETests.Beta/step_definitions/smoke-tests/self-assessment.steps.ts
+++ b/tests/Dfe.PlanTech.Web.E2ETests.Beta/step_definitions/smoke-tests/self-assessment.steps.ts
@@ -65,7 +65,7 @@ Then(
 
       const completionText = (await completionPara.innerText()).trim();
       const normalisedText = normaliseShortDateTimeText(completionText);
-      const expectedText = `The self-assessment for ${sectionLower} was completed on ${currentDate}.`;
+      const expectedText = `The self-assessment for ${sectionLower} was submitted on ${currentDate} by DSI TEST Establishment (001) Miscellaneous (27).`;
       expect(normalisedText).toMatch(expectedText);
 
       const viewLink = headingEl.locator(

--- a/tests/Dfe.PlanTech.Web.UnitTests/Context/UserActionTrackingServiceTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Context/UserActionTrackingServiceTests.cs
@@ -109,4 +109,62 @@ public class UserActionTrackingServiceTests
 
         Assert.Equal("No active HttpContext found.", exception.Message);
     }
+
+    [Fact]
+    public async Task GetAsync_Returns_Null_If_UserAction_Not_Found()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        _userActionRepository
+            .GetUserActionAsync(id)
+            .Returns(Task.FromResult<UserActionEntity?>(null));
+
+        var sut = BuildService();
+
+        // Act
+        var result = await sut.GetAsync(id);
+
+        // Assert
+        Assert.Null(result);
+
+        await _userActionRepository.Received(1).GetUserActionAsync(id);
+    }
+
+    [Fact]
+    public async Task GetAsync_Maps_UserActionEntity_To_Dto()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        var userActionEntity = new UserActionEntity
+        {
+            Id = id,
+            SessionId = Guid.NewGuid(),
+            UserId = 123,
+            EstablishmentId = 456,
+            MatEstablishmentId = 789,
+            RequestedUrl = "/test-path?section=network",
+        };
+
+        _userActionRepository
+            .GetUserActionAsync(id)
+            .Returns(Task.FromResult<UserActionEntity?>(userActionEntity));
+
+        var sut = BuildService();
+
+        // Act
+        var result = await sut.GetAsync(id);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(userActionEntity.Id, result.Id);
+        Assert.Equal(userActionEntity.SessionId, result.SessionId);
+        Assert.Equal(userActionEntity.UserId, result.UserId);
+        Assert.Equal(userActionEntity.EstablishmentId, result.EstablishmentId);
+        Assert.Equal(userActionEntity.MatEstablishmentId, result.MatEstablishmentId);
+        Assert.Equal(userActionEntity.RequestedUrl, result.RequestedUrl);
+
+        await _userActionRepository.Received(1).GetUserActionAsync(id);
+    }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/CategoryLandingViewComponentViewBuilderTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/CategoryLandingViewComponentViewBuilderTests.cs
@@ -721,7 +721,272 @@ public class CategoryLandingViewComponentViewBuilderTests
         Assert.NotEmpty(chunks);
         Assert.True(
             chunks[0].LastUpdated > chunks[1].LastUpdated
-                && chunks[1].LastUpdated > chunks[2].LastUpdated
+            && chunks[1].LastUpdated > chunks[2].LastUpdated
         );
+    }
+
+    [Theory]
+    [InlineData(SubmissionStatus.InProgress)]
+    [InlineData(SubmissionStatus.CompleteNotReviewed)]
+    public async Task
+        BuildViewModelAsync_When_Section_InProgress_Or_CompleteNotReviewed_Uses_CreatedUserActionId_To_Set_EstablishmentName(
+            SubmissionStatus status
+        )
+    {
+        // Arrange
+        var section = MakeSection("S1", "Networking", "networking");
+        var category = MakeCategory(section);
+
+        var createdUserActionId = Guid.NewGuid();
+
+        var statuses = new List<SqlSectionStatusDto>
+        {
+            new SqlSectionStatusDto
+            {
+                SectionId = "S1",
+                Status = status,
+                CreatedUserActionId = createdUserActionId,
+            },
+        };
+
+        var submission = Substitute.For<ISubmissionService>();
+        submission
+            .GetSectionStatusesForSchoolAsync(Arg.Any<int>(), Arg.Any<IEnumerable<string>>())
+            .Returns(statuses);
+
+        var userActionTracking = Substitute.For<IUserActionTrackingService>();
+        userActionTracking
+            .GetAsync(createdUserActionId)
+            .Returns(
+                new SqlUserActionDto
+                {
+                    Id = createdUserActionId,
+                    EstablishmentId = 2001,
+                    MatEstablishmentId = null,
+                }
+            );
+
+        var establishment = Substitute.For<IEstablishmentService>();
+        establishment
+            .GetEstablishmentByIdAsync(2001)
+            .Returns(
+                new SqlEstablishmentDto
+                {
+                    Id = 2001,
+                    OrgName = "Test School",
+                }
+            );
+
+        var sut = CreateSut(
+            submission: submission,
+            userActionTracking: userActionTracking,
+            establishment: establishment
+        );
+
+        // Act
+        var vm = await sut.BuildViewModelAsync(
+            category,
+            "cat",
+            null,
+            RecommendationConstants.DefaultSortOrder
+        );
+
+        // Assert
+        var secVm = Assert.Single(vm.CategoryLandingSections);
+        Assert.Equal("Test School", secVm.EstablishmentName);
+
+        await userActionTracking.Received(1).GetAsync(createdUserActionId);
+        await establishment.Received(1).GetEstablishmentByIdAsync(2001);
+    }
+
+    [Fact]
+    public async Task
+        BuildViewModelAsync_When_Section_CompleteReviewed_Uses_CompletedUserActionId_To_Set_EstablishmentName()
+    {
+        // Arrange
+        var section = MakeSection("S1", "Cyber security", "cyber-security");
+        var category = MakeCategory(section);
+
+        var createdUserActionId = Guid.NewGuid();
+        var completedUserActionId = Guid.NewGuid();
+
+        var statuses = new List<SqlSectionStatusDto>
+        {
+            new SqlSectionStatusDto
+            {
+                SectionId = "S1",
+                Status = SubmissionStatus.CompleteReviewed,
+                CreatedUserActionId = createdUserActionId,
+                CompletedUserActionId = completedUserActionId,
+            },
+        };
+
+        var submission = Substitute.For<ISubmissionService>();
+        submission
+            .GetSectionStatusesForSchoolAsync(Arg.Any<int>(), Arg.Any<IEnumerable<string>>())
+            .Returns(statuses);
+
+        var userActionTracking = Substitute.For<IUserActionTrackingService>();
+        userActionTracking
+            .GetAsync(completedUserActionId)
+            .Returns(
+                new SqlUserActionDto
+                {
+                    Id = completedUserActionId,
+                    EstablishmentId = 2002,
+                    MatEstablishmentId = null,
+                }
+            );
+
+        var establishment = Substitute.For<IEstablishmentService>();
+        establishment
+            .GetEstablishmentByIdAsync(2002)
+            .Returns(
+                new SqlEstablishmentDto
+                {
+                    Id = 2002,
+                    OrgName = "Completed School",
+                }
+            );
+
+        var sut = CreateSut(
+            submission: submission,
+            userActionTracking: userActionTracking,
+            establishment: establishment
+        );
+
+        // Act
+        var vm = await sut.BuildViewModelAsync(
+            category,
+            "cat",
+            null,
+            RecommendationConstants.DefaultSortOrder
+        );
+
+        // Assert
+        var secVm = Assert.Single(vm.CategoryLandingSections);
+        Assert.Equal("Completed School", secVm.EstablishmentName);
+
+        await userActionTracking.Received(1).GetAsync(completedUserActionId);
+        await userActionTracking.DidNotReceive().GetAsync(createdUserActionId);
+        await establishment.Received(1).GetEstablishmentByIdAsync(2002);
+    }
+
+    [Fact]
+    public async Task
+        BuildViewModelAsync_When_UserAction_Has_MatEstablishmentId_Uses_MatEstablishmentId_For_EstablishmentName()
+    {
+        // Arrange
+        var section = MakeSection("S1", "Devices", "devices");
+        var category = MakeCategory(section);
+
+        var createdUserActionId = Guid.NewGuid();
+
+        var statuses = new List<SqlSectionStatusDto>
+        {
+            new SqlSectionStatusDto
+            {
+                SectionId = "S1",
+                Status = SubmissionStatus.InProgress,
+                CreatedUserActionId = createdUserActionId,
+            },
+        };
+
+        var submission = Substitute.For<ISubmissionService>();
+        submission
+            .GetSectionStatusesForSchoolAsync(Arg.Any<int>(), Arg.Any<IEnumerable<string>>())
+            .Returns(statuses);
+
+        var userActionTracking = Substitute.For<IUserActionTrackingService>();
+        userActionTracking
+            .GetAsync(createdUserActionId)
+            .Returns(
+                new SqlUserActionDto
+                {
+                    Id = createdUserActionId,
+                    EstablishmentId = 2003,
+                    MatEstablishmentId = 3003,
+                }
+            );
+
+        var establishment = Substitute.For<IEstablishmentService>();
+        establishment
+            .GetEstablishmentByIdAsync(3003)
+            .Returns(
+                new SqlEstablishmentDto
+                {
+                    Id = 3003,
+                    OrgName = "Test MAT",
+                }
+            );
+
+        var sut = CreateSut(
+            submission: submission,
+            userActionTracking: userActionTracking,
+            establishment: establishment
+        );
+
+        // Act
+        var vm = await sut.BuildViewModelAsync(
+            category,
+            "cat",
+            null,
+            RecommendationConstants.DefaultSortOrder
+        );
+
+        // Assert
+        var secVm = Assert.Single(vm.CategoryLandingSections);
+        Assert.Equal("Test MAT", secVm.EstablishmentName);
+
+        await establishment.Received(1).GetEstablishmentByIdAsync(3003);
+        await establishment.DidNotReceive().GetEstablishmentByIdAsync(2003);
+    }
+
+    [Fact]
+    public async Task BuildViewModelAsync_When_No_UserActionId_Does_Not_Retrieve_EstablishmentName()
+    {
+        // Arrange
+        var section = MakeSection("S1", "Broadband", "broadband");
+        var category = MakeCategory(section);
+
+        var statuses = new List<SqlSectionStatusDto>
+        {
+            new SqlSectionStatusDto
+            {
+                SectionId = "S1",
+                Status = SubmissionStatus.InProgress,
+                CreatedUserActionId = null,
+                CompletedUserActionId = null,
+            },
+        };
+
+        var submission = Substitute.For<ISubmissionService>();
+        submission
+            .GetSectionStatusesForSchoolAsync(Arg.Any<int>(), Arg.Any<IEnumerable<string>>())
+            .Returns(statuses);
+
+        var userActionTracking = Substitute.For<IUserActionTrackingService>();
+        var establishment = Substitute.For<IEstablishmentService>();
+
+        var sut = CreateSut(
+            submission: submission,
+            userActionTracking: userActionTracking,
+            establishment: establishment
+        );
+
+        // Act
+        var vm = await sut.BuildViewModelAsync(
+            category,
+            "cat",
+            null,
+            RecommendationConstants.DefaultSortOrder
+        );
+
+        // Assert
+        var secVm = Assert.Single(vm.CategoryLandingSections);
+        Assert.Null(secVm.EstablishmentName);
+
+        await userActionTracking.DidNotReceive().GetAsync(Arg.Any<Guid>());
+        await establishment.DidNotReceive().GetEstablishmentByIdAsync(Arg.Any<int>());
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/CategoryLandingViewComponentViewBuilderTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/CategoryLandingViewComponentViewBuilderTests.cs
@@ -20,6 +20,8 @@ public class CategoryLandingViewComponentViewBuilderTests
     private static CategoryLandingViewComponentViewBuilder CreateSut(
         IContentfulService? contentful = null,
         ISubmissionService? submission = null,
+        IEstablishmentService? establishment = null,
+        IUserActionTrackingService? userActionTracking = null,
         IUserService? user = null,
         ICurrentUser? currentUser = null,
         ILogger<BaseViewBuilder>? logger = null
@@ -27,6 +29,8 @@ public class CategoryLandingViewComponentViewBuilderTests
     {
         contentful ??= Substitute.For<IContentfulService>();
         submission ??= Substitute.For<ISubmissionService>();
+        establishment ??= Substitute.For<IEstablishmentService>();
+        userActionTracking ??= Substitute.For<IUserActionTrackingService>();
         user ??= Substitute.For<IUserService>();
         currentUser ??= Substitute.For<ICurrentUser>();
 
@@ -39,6 +43,8 @@ public class CategoryLandingViewComponentViewBuilderTests
             contentful,
             currentUser,
             submission,
+            userActionTracking,
+            establishment,
             user
         );
     }

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/CategoryLandingViewComponentViewBuilderTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewBuilders/CategoryLandingViewComponentViewBuilderTests.cs
@@ -729,7 +729,7 @@ public class CategoryLandingViewComponentViewBuilderTests
     [InlineData(SubmissionStatus.InProgress)]
     [InlineData(SubmissionStatus.CompleteNotReviewed)]
     public async Task
-        BuildViewModelAsync_When_Section_InProgress_Or_CompleteNotReviewed_Uses_CreatedUserActionId_To_Set_EstablishmentName(
+        BuildViewModelAsync_When_Section_InProgress_Or_CompleteNotReviewed_Uses_LastUpdatedUserActionId_To_Set_EstablishmentName(
             SubmissionStatus status
         )
     {
@@ -737,7 +737,7 @@ public class CategoryLandingViewComponentViewBuilderTests
         var section = MakeSection("S1", "Networking", "networking");
         var category = MakeCategory(section);
 
-        var createdUserActionId = Guid.NewGuid();
+        var lastUpdatedUserActionId = Guid.NewGuid();
 
         var statuses = new List<SqlSectionStatusDto>
         {
@@ -745,7 +745,7 @@ public class CategoryLandingViewComponentViewBuilderTests
             {
                 SectionId = "S1",
                 Status = status,
-                CreatedUserActionId = createdUserActionId,
+                LastUpdatedUserActionId = lastUpdatedUserActionId,
             },
         };
 
@@ -756,11 +756,11 @@ public class CategoryLandingViewComponentViewBuilderTests
 
         var userActionTracking = Substitute.For<IUserActionTrackingService>();
         userActionTracking
-            .GetAsync(createdUserActionId)
+            .GetAsync(lastUpdatedUserActionId)
             .Returns(
                 new SqlUserActionDto
                 {
-                    Id = createdUserActionId,
+                    Id = lastUpdatedUserActionId,
                     EstablishmentId = 2001,
                     MatEstablishmentId = null,
                 }
@@ -795,7 +795,7 @@ public class CategoryLandingViewComponentViewBuilderTests
         var secVm = Assert.Single(vm.CategoryLandingSections);
         Assert.Equal("Test School", secVm.EstablishmentName);
 
-        await userActionTracking.Received(1).GetAsync(createdUserActionId);
+        await userActionTracking.Received(1).GetAsync(lastUpdatedUserActionId);
         await establishment.Received(1).GetEstablishmentByIdAsync(2001);
     }
 
@@ -880,7 +880,7 @@ public class CategoryLandingViewComponentViewBuilderTests
         var section = MakeSection("S1", "Devices", "devices");
         var category = MakeCategory(section);
 
-        var createdUserActionId = Guid.NewGuid();
+        var lastUpdatedUserActionId = Guid.NewGuid();
 
         var statuses = new List<SqlSectionStatusDto>
         {
@@ -888,7 +888,7 @@ public class CategoryLandingViewComponentViewBuilderTests
             {
                 SectionId = "S1",
                 Status = SubmissionStatus.InProgress,
-                CreatedUserActionId = createdUserActionId,
+                LastUpdatedUserActionId = lastUpdatedUserActionId,
             },
         };
 
@@ -899,11 +899,11 @@ public class CategoryLandingViewComponentViewBuilderTests
 
         var userActionTracking = Substitute.For<IUserActionTrackingService>();
         userActionTracking
-            .GetAsync(createdUserActionId)
+            .GetAsync(lastUpdatedUserActionId)
             .Returns(
                 new SqlUserActionDto
                 {
-                    Id = createdUserActionId,
+                    Id = lastUpdatedUserActionId,
                     EstablishmentId = 2003,
                     MatEstablishmentId = 3003,
                 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewModels/CategoryLandingSectionViewModelTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewModels/CategoryLandingSectionViewModelTests.cs
@@ -37,7 +37,8 @@ public class CategoryLandingSectionViewModelTests
             section,
             Recs(),
             sectionStatus: null,
-            hadRetrievalError: false
+            hadRetrievalError: false,
+            "Test establishment name"
         );
 
         Assert.Equal(SubmissionStatus.RetrievalError, vm.ProgressStatus);
@@ -47,6 +48,7 @@ public class CategoryLandingSectionViewModelTests
         Assert.Equal("Devices", vm.Name);
         Assert.Equal("desc", vm.ShortDescription);
         Assert.Equal(string.Empty, vm.Slug);
+        Assert.Equal("Test establishment name", vm.EstablishmentName);;
     }
 
     [Fact]
@@ -64,7 +66,8 @@ public class CategoryLandingSectionViewModelTests
             section,
             Recs(),
             status,
-            hadRetrievalError: true
+            hadRetrievalError: true,
+            "Test establishment name"
         );
 
         Assert.Equal(SubmissionStatus.RetrievalError, vm.ProgressStatus);
@@ -74,6 +77,8 @@ public class CategoryLandingSectionViewModelTests
         Assert.False(string.IsNullOrWhiteSpace(vm.LastCompletionDate));
         Assert.Equal("networking", vm.Slug);
         Assert.Null(vm.ErrorMessage);
+        Assert.Equal("Test establishment name", vm.EstablishmentName);;
+
     }
 
     [Fact]
@@ -92,7 +97,8 @@ public class CategoryLandingSectionViewModelTests
             section,
             Recs(),
             status,
-            hadRetrievalError: false
+            hadRetrievalError: false,
+            "Test establishment name"
         );
 
         Assert.Equal(SubmissionStatus.CompleteReviewed, vm.ProgressStatus);
@@ -101,6 +107,8 @@ public class CategoryLandingSectionViewModelTests
         Assert.NotNull(vm.LastCompletionDate);
         Assert.False(string.IsNullOrWhiteSpace(vm.LastCompletionDate));
         Assert.Null(vm.ErrorMessage);
+        Assert.Equal("Test establishment name", vm.EstablishmentName);;
+
     }
 
     [Fact]
@@ -119,7 +127,8 @@ public class CategoryLandingSectionViewModelTests
             section,
             Recs(),
             status,
-            hadRetrievalError: false
+            hadRetrievalError: false,
+            "Test establishment name"
         );
 
         Assert.Equal(SubmissionStatus.InProgress, vm.ProgressStatus);
@@ -127,6 +136,8 @@ public class CategoryLandingSectionViewModelTests
         Assert.False(string.IsNullOrWhiteSpace(vm.DateUpdated));
         Assert.Equal(string.Empty, vm.LastCompletionDate); // explicitly empty string per code path
         Assert.Null(vm.ErrorMessage);
+        Assert.Equal("Test establishment name", vm.EstablishmentName);;
+
     }
 
     [Fact]
@@ -138,7 +149,8 @@ public class CategoryLandingSectionViewModelTests
             section,
             Recs(),
             sectionStatus: null,
-            hadRetrievalError: false
+            hadRetrievalError: false,
+            "Test establishment name"
         );
 
         Assert.Equal(SubmissionStatus.NotStarted, vm.ProgressStatus);
@@ -146,6 +158,8 @@ public class CategoryLandingSectionViewModelTests
         Assert.Null(vm.LastCompletionDate);
         Assert.Equal("hosting", vm.Slug);
         Assert.Null(vm.ErrorMessage);
+        Assert.Equal("Test establishment name", vm.EstablishmentName);;
+
     }
 
     [Fact]
@@ -158,12 +172,15 @@ public class CategoryLandingSectionViewModelTests
             section,
             recs,
             sectionStatus: null,
-            hadRetrievalError: false
+            hadRetrievalError: false,
+            "Test establishment name"
         );
 
         Assert.Equal("Connectivity", vm.Name);
         Assert.Equal("Get online", vm.ShortDescription);
         Assert.Equal("connectivity", vm.Slug);
         Assert.Same(recs, vm.Recommendations);
+        Assert.Equal("Test establishment name", vm.EstablishmentName);;
+
     }
 }


### PR DESCRIPTION
## Overview

Addresses ticket [#313905](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/#313905)

Adds the data needed to the model so we can use establishmentName within the microcopy on the category landing page for the intro texts.

The design for the ticket is based on:
<img width="780" height="1275" alt="image" src="https://github.com/user-attachments/assets/b31f69b6-a556-4bf9-93fb-80854482f9f7" />

## How to review the PR

Complete a self assessment under a MAT and view the intro text on the category landing page as a MAT/school it was for.
Start a self assessment but do not complete and view the intro text on the category landing page as a MAT/school it was for.

## Release requirements

- Contentful has not been updated on WIP for the new microcopy text. Only in development yet.
- Migration will be needed to populate the created/lastupdated/completed user action id's for previous submissions otherwise no intro text will be shown to users.


## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [x] Unit tests pass

