### PR TITLE
feat: add fallbacks for missing establishment data on landing page

### DIFF
--- a/src/Dfe.PlanTech.Core/Constants/ContentfulMicrocopyConstants.cs
+++ b/src/Dfe.PlanTech.Core/Constants/ContentfulMicrocopyConstants.cs
@@ -19,8 +19,10 @@ public static class ContentfulMicrocopyConstants
     public const string LandingPageInsetIntroContinue = "insetIntroContinue";
     public const string LandingPageTopicLinkNotStarted = "topicLinkNotStarted";
     public const string LandingPageTopicIntroContinue = "topicIntroContinue";
+    public const string LandingPageTopicIntroContinueNoEstablishment = "topicIntroContinueNoEstablishment";
     public const string LandingPageTopicLinkContinue = "topicLinkContinue";
     public const string LandingPageTopicIntroCompleted = "topicIntroCompleted";
+    public const string LandingPageTopicIntroCompletedNoEstablishment = "topicIntroCompletedNoEstablishment";
     public const string LandingPageTopicLinkCompleted = "topicLinkCompleted";
     public const string LandingPageSuccessPanelHeader = "successHeader";
     public const string LandingPageSuccessPanelBody = "successBody";
@@ -169,8 +171,10 @@ public static class ContentfulMicrocopyConstants
         { LandingPageInsetIntroContinue, EmptyFallback },
         { LandingPageTopicLinkNotStarted, TopicLinksFallback },
         { LandingPageTopicIntroContinue, EmptyFallback },
+        { LandingPageTopicIntroContinueNoEstablishment, EmptyFallback },
         { LandingPageTopicLinkContinue, TopicLinksFallback },
         { LandingPageTopicIntroCompleted, EmptyFallback },
+        { LandingPageTopicIntroCompletedNoEstablishment, EmptyFallback },
         { LandingPageTopicLinkCompleted, TopicLinksFallback },
         { LandingPageSuccessPanelHeader, SuccessHeaderFallback },
         { LandingPageSuccessPanelBody, EmptyFallback },
@@ -261,8 +265,10 @@ public static class ContentfulMicrocopyConstants
         { LandingPageInsetIntroContinue, [VariableNames.Standard] },
         { LandingPageTopicLinkNotStarted, [VariableNames.Topic] },
         { LandingPageTopicIntroContinue, [VariableNames.DateUpdated, VariableNames.EstablishmentName] },
+        { LandingPageTopicIntroContinueNoEstablishment, [VariableNames.DateUpdated] },
         { LandingPageTopicLinkContinue, [VariableNames.Topic] },
         { LandingPageTopicIntroCompleted, [VariableNames.Topic, VariableNames.DateCompleted, VariableNames.EstablishmentName] },
+        { LandingPageTopicIntroCompletedNoEstablishment, [VariableNames.Topic, VariableNames.DateCompleted] },
         { LandingPageTopicLinkCompleted, [VariableNames.Topic] },
         { LandingPageSuccessPanelHeader, [VariableNames.Topic] },
         { SingleRecommendationPrintAllLink, [VariableNames.Topic] },

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
@@ -27,13 +27,13 @@
         case SubmissionStatus.InProgress:
         case SubmissionStatus.Inaccessible:
         case SubmissionStatus.Obsolete:
-            statusTextKey = ContentfulMicrocopyConstants.LandingPageTopicIntroContinue;
+            statusTextKey = !string.IsNullOrWhiteSpace(topic.EstablishmentName) ? ContentfulMicrocopyConstants.LandingPageTopicIntroContinue : ContentfulMicrocopyConstants.LandingPageTopicIntroCompletedNoEstablishment;
             linkTextKey = ContentfulMicrocopyConstants.LandingPageTopicLinkContinue;
             controller = nameof(QuestionsController);
             action = nameof(QuestionsController.GetContinueSelfAssessment);
             break;
         case SubmissionStatus.CompleteReviewed:
-            statusTextKey = ContentfulMicrocopyConstants.LandingPageTopicIntroCompleted;
+            statusTextKey = !string.IsNullOrWhiteSpace(topic.EstablishmentName) ? ContentfulMicrocopyConstants.LandingPageTopicIntroCompleted : ContentfulMicrocopyConstants.LandingPageTopicIntroCompletedNoEstablishment;
             linkTextKey = ContentfulMicrocopyConstants.LandingPageTopicLinkCompleted;
             controller = nameof(ReviewAnswersController);
             action = nameof(ReviewAnswersController.ViewAnswers);
@@ -66,6 +66,9 @@
         topicStatus == SubmissionStatus.Obsolete ||
         topicStatus == SubmissionStatus.InProgress;
 
+    if (Model.Section.EstablishmentName is null)
+    {
+    }
     var linkText = await Microcopy.GetTextByKeyAsync(linkTextKey, dynamicValues);
 
     if (Model.Context == "Sections")

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
@@ -66,9 +66,6 @@
         topicStatus == SubmissionStatus.Obsolete ||
         topicStatus == SubmissionStatus.InProgress;
 
-    if (Model.Section.EstablishmentName is null)
-    {
-    }
     var linkText = await Microcopy.GetTextByKeyAsync(linkTextKey, dynamicValues);
 
     if (Model.Context == "Sections")


### PR DESCRIPTION
Added fallbacks if missing establishment data on completed/continue intro text on category landing page.