### PR TITLE
fix: correct microcopy and improve category ordering logic

### DIFF
--- a/src/Dfe.PlanTech.Web/ViewBuilders/GroupsViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/GroupsViewBuilder.cs
@@ -152,7 +152,19 @@ public class GroupsViewBuilder(
         var establishmentId = GetUserOrganisationIdOrThrowException();
         var groupName = CurrentUser.UserOrganisationName ?? "Your organisation";
 
-        var categories = (await ContentfulService.GetAllCategoriesAsync() ?? []).ToList();
+        //Get all categories so e2e testing categories appear when enabled
+        var allCategories = await ContentfulService.GetAllCategoriesAsync() ?? [];
+
+        //Get ordered categories from home page
+        var orderedCategories = ((await ContentfulService.GetPageBySlugAsync("home")).Content ?? [])
+            .OfType<QuestionnaireCategoryEntry>()
+            .ToList();
+
+        var categories = orderedCategories
+            .Concat(allCategories.ExceptBy(
+                orderedCategories.Select(x => x.Sys?.Id),
+                x => x.Sys?.Id))
+            .ToList();
 
         if (categories.Count == 0)
         {
@@ -264,7 +276,7 @@ public class GroupsViewBuilder(
         if (eligibleSchools.Count == 0)
         {
             return controller.RedirectToRoute(GroupsController.GetSelectASelfAssessmentAction);
-        }    
+        }
 
         viewModel ??= new GroupsSelectSchoolsToAssessViewModel();
         viewModel.CategorySlug = categorySlug;

--- a/src/Dfe.PlanTech.Web/ViewBuilders/GroupsViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/GroupsViewBuilder.cs
@@ -156,7 +156,7 @@ public class GroupsViewBuilder(
         var allCategories = await ContentfulService.GetAllCategoriesAsync() ?? [];
 
         //Get ordered categories from home page
-        var orderedCategories = ((await ContentfulService.GetPageBySlugAsync("home")).Content ?? [])
+        var orderedCategories = ((await ContentfulService.GetPageBySlugAsync("home"))?.Content ?? [])
             .OfType<QuestionnaireCategoryEntry>()
             .ToList();
 

--- a/src/Dfe.PlanTech.Web/Views/Groups/GroupsSelectSelfAssessment.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Groups/GroupsSelectSelfAssessment.cshtml
@@ -35,7 +35,7 @@ ViewData[StatePassingMechanismConstants.Title] = "Select a self-assessment";
                     var schoolPluralisation = s.UncompletedGroupSubmissions == 1 ? "school" : "schools";
 
                     <span>
-                        Self assessment required for @s.UncompletedGroupSubmissions @schoolPluralisation.
+                        Self-assessment required for @s.UncompletedGroupSubmissions @schoolPluralisation.
                     </span>
                 }
             </div>


### PR DESCRIPTION
- Ordered the categories based on the /home contentful page.
- Added dash in self-assessment.

All the categories from contentful are grabbed and then ordered by the home page. Reason being is that if only the home categories were retrieved it means we can't write any e2e tests against bulk assessment. This way we just use the home for ordering and the automatedTestingFlag will still hide/show the extra categories.