### PR TITLE
fix: update microcopy in E2E tests and adjust selectors for accuracy

### DIFF
--- a/tests/Dfe.PlanTech.Web.E2ETests.Beta/step_definitions/regression/multi-category-landing-page.steps.ts
+++ b/tests/Dfe.PlanTech.Web.E2ETests.Beta/step_definitions/regression/multi-category-landing-page.steps.ts
@@ -36,7 +36,7 @@ Then(
       // Paragraph with the "started on" text
       const inProgressPara = headingEl
         .locator(
-          'xpath=following-sibling::p[contains(normalize-space(.), "The self-assessment was started by")]',
+          'xpath=following-sibling::p[contains(normalize-space(.), "A self-assessment was started by")]',
         )
         .first();
 
@@ -44,7 +44,7 @@ Then(
 
       const text = (await inProgressPara.innerText()).trim();
       const normalisedText = normaliseShortDateTimeText(text);
-      const expectedText = `The self-assessment was started by DSI TEST Establishment (001) Miscellaneous (27) on ${currentDate}.`;
+      const expectedText = `A self-assessment was started by DSI TEST Establishment (001) Miscellaneous (27) on ${currentDate}.`;
       expect(normalisedText).toMatch(expectedText);
 
       // Next paragraph that actually contains the link

--- a/tests/Dfe.PlanTech.Web.E2ETests.Beta/step_definitions/regression/recommendation-page.steps.ts
+++ b/tests/Dfe.PlanTech.Web.E2ETests.Beta/step_definitions/regression/recommendation-page.steps.ts
@@ -119,12 +119,15 @@ Then(
 Then(
   'I click the print all recommendations link in the related actions for {string}',
   async function (topic: string) {
-    const container = this.page.locator(
-      '.govuk-grid-column-one-third-from-desktop.govuk-float-right',
-    );
-    const printLink = container.locator('a', {
-      hasText: `Print your school's ${topic.toLowerCase()} recommendations`,
+    const relatedActions = this.page
+      .getByRole('heading', { name: 'Related actions' })
+      .locator('..');
+
+    const printLink = relatedActions.getByRole('link', {
+      name: `Print your school's ${topic.toLowerCase()} recommendations`,
+      exact: true,
     });
+
     await expect(printLink).toBeVisible();
     await printLink.click();
   },

--- a/tests/Dfe.PlanTech.Web.E2ETests.Beta/step_definitions/smoke-tests/self-assessment.steps.ts
+++ b/tests/Dfe.PlanTech.Web.E2ETests.Beta/step_definitions/smoke-tests/self-assessment.steps.ts
@@ -36,7 +36,7 @@ Then(
       // Paragraph with the "started on" text
       const inProgressPara = headingEl
         .locator(
-          'xpath=following-sibling::p[contains(normalize-space(.), "The self-assessment was started by")]',
+          'xpath=following-sibling::p[contains(normalize-space(.), "A self-assessment was started by")]',
         )
         .first();
 
@@ -44,7 +44,7 @@ Then(
 
       const text = (await inProgressPara.innerText()).trim();
       const normalisedText = normaliseShortDateTimeText(text);
-      const expectedText = `The self-assessment was started by DSI TEST Establishment (001) Miscellaneous (27) on ${currentDate}.`;
+      const expectedText = `A self-assessment was started by DSI TEST Establishment (001) Miscellaneous (27) on ${currentDate}.`;
       expect(normalisedText).toMatch(expectedText);
 
       // Next paragraph that actually contains the link


### PR DESCRIPTION
- Corrected "Self-assessment" text in multiple E2E test scenarios.
- Updated selector logic on the recommendation page to improve readability and ensure reliability.

